### PR TITLE
[feat][langchain4j] Dockerfile + Kubernetes 매니페스트 추가

### DIFF
--- a/langchain4j-ai-rag-postgre/.dockerignore
+++ b/langchain4j-ai-rag-postgre/.dockerignore
@@ -1,0 +1,13 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+postgres_data/
+k8s/
+README*.md
+*.iml

--- a/langchain4j-ai-rag-postgre/Dockerfile
+++ b/langchain4j-ai-rag-postgre/Dockerfile
@@ -18,10 +18,12 @@ RUN --mount=type=cache,target=/root/.m2 \
     cp target/*.jar /workspace/app.jar
 
 # ---------- Runtime ----------
-FROM eclipse-temurin:17-jre-alpine AS runtime
+# jammy(glibc) 베이스 사용 — DJL libtokenizers.so 등 네이티브 라이브러리가 glibc를 요구하므로
+# musl 기반 alpine 이미지에서는 실행 시 로드 오류가 발생한다.
+FROM eclipse-temurin:17-jre-jammy AS runtime
 
 # Run as a non-root user
-RUN addgroup -S app && adduser -S -G app app
+RUN groupadd -r app && useradd -r -g app app
 USER app:app
 
 WORKDIR /app

--- a/langchain4j-ai-rag-postgre/Dockerfile
+++ b/langchain4j-ai-rag-postgre/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for langchain4j-ai-rag-postgre.
+# Stage 1 builds the executable Spring Boot jar with Maven.
+# Stage 2 runs it on a minimal Temurin JRE 17 image as a non-root user.
+
+# ---------- Build ----------
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+# Resolve dependencies first for better layer caching
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+# ---------- Runtime ----------
+FROM eclipse-temurin:17-jre-alpine AS runtime
+
+# Run as a non-root user
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError" \
+    SPRING_PROFILES_ACTIVE=""
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/langchain4j-ai-rag-postgre/k8s/README.md
+++ b/langchain4j-ai-rag-postgre/k8s/README.md
@@ -1,0 +1,225 @@
+# Kubernetes 배포 운영 절차
+
+`langchain4j-ai-rag-postgre` 모듈을 Kubernetes 클러스터에 배포하는 전체 절차를 안내한다.
+
+---
+
+## 사전 요건
+
+| 항목 | 비고 |
+|------|------|
+| Docker 28+ | 이미지 빌드용 |
+| kubectl | 클러스터 접근 |
+| 실행 중인 Kubernetes 클러스터 | 로컬: minikube / kind, 운영: EKS·GKE·AKS 등 |
+| 컨테이너 레지스트리 | 이미지 push 가능한 레지스트리 |
+| PostgreSQL + PGVector | `postgres-pgvector` 서비스로 접근 가능해야 함 |
+| Ollama | 클러스터 내 또는 외부에서 `11434` 포트 접근 가능해야 함 |
+
+---
+
+## 1. 이미지 빌드
+
+```bash
+# 프로젝트 루트(pom.xml이 있는 디렉터리)에서 실행
+cd langchain4j-ai-rag-postgre
+
+docker build \
+  -t <레지스트리>/langchain4j-ai-rag-postgre:1.0.0 \
+  .
+```
+
+빌드가 완료되면 이미지를 레지스트리에 push한다.
+
+```bash
+docker push <레지스트리>/langchain4j-ai-rag-postgre:1.0.0
+```
+
+---
+
+## 2. 매니페스트 수정
+
+### deployment.yaml — 이미지 경로 교체
+
+`k8s/deployment.yaml`의 `image` 필드를 push한 이미지 경로로 변경한다.
+
+```yaml
+image: <레지스트리>/langchain4j-ai-rag-postgre:1.0.0
+```
+
+### configmap.yaml — 환경별 값 확인
+
+`k8s/configmap.yaml`에서 아래 항목이 실제 클러스터 환경과 일치하는지 확인한다.
+
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `SPRING_DATASOURCE_URL` | `jdbc:postgresql://postgres-pgvector:5432/ragdb` | PostgreSQL 서비스명·포트·DB명 |
+| `SPRING_DATASOURCE_DRIVER_CLASS_NAME` | `org.postgresql.Driver` | 드라이버 클래스 |
+| `SPRING_JPA_HIBERNATE_DDL_AUTO` | `update` | DDL 전략 (운영: `validate` 권장) |
+| `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE` | `health,info` | Actuator 노출 엔드포인트 |
+
+### Secret — DB 인증 정보 생성
+
+DB 사용자명과 비밀번호는 Secret으로 관리한다. Secret 이름은 `langchain4j-ai-rag-postgre-db`이어야 한다.
+
+```bash
+kubectl create secret generic langchain4j-ai-rag-postgre-db \
+  --from-literal=username=<DB_USERNAME> \
+  --from-literal=password=<DB_PASSWORD>
+```
+
+### Ollama 연결 주소 설정 (환경변수 추가)
+
+Ollama가 클러스터 외부에 있는 경우 `deployment.yaml`의 `env` 섹션에 아래 항목을 추가한다.
+
+```yaml
+env:
+  - name: LANGCHAIN4J_OLLAMA_BASE_URL
+    value: "http://<ollama-host>:11434"
+```
+
+클러스터 내 Ollama 서비스가 있으면 서비스 DNS 이름(예: `http://ollama:11434`)을 사용한다.
+
+### ONNX 임베딩 모델 경로 설정
+
+`app.embedding-config-path`는 파드 내 경로를 가리킨다. PersistentVolumeClaim 또는 ConfigMap/Secret을 통해 아래 환경변수로 재정의한다.
+
+```yaml
+env:
+  - name: APP_EMBEDDING_CONFIG_PATH
+    value: "/config/embeddingConfig.json"
+```
+
+---
+
+## 3. 배포
+
+```bash
+# ConfigMap 먼저 적용
+kubectl apply -f k8s/configmap.yaml
+
+# Deployment · Service 적용
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+```
+
+---
+
+## 4. 상태 확인
+
+```bash
+# 파드 상태 확인
+kubectl get pods -l app.kubernetes.io/name=langchain4j-ai-rag-postgre
+
+# 파드 로그 확인
+kubectl logs -l app.kubernetes.io/name=langchain4j-ai-rag-postgre --tail=100
+
+# Deployment 롤아웃 상태
+kubectl rollout status deployment/langchain4j-ai-rag-postgre
+
+# Actuator health 확인 (파드 내부에서)
+kubectl exec -it <pod-name> -- wget -qO- http://127.0.0.1:8080/actuator/health
+```
+
+---
+
+## 5. 접속
+
+Service 타입이 `ClusterIP`이므로 클러스터 외부에서 직접 접근할 수 없다. 아래 방법 중 하나를 선택한다.
+
+### 방법 A: kubectl port-forward (개발·디버그용)
+
+```bash
+kubectl port-forward svc/langchain4j-ai-rag-postgre 8080:8080
+# 이후 http://localhost:8080 으로 접속
+```
+
+### 방법 B: NodePort로 Service 타입 변경 (테스트 환경)
+
+`k8s/service.yaml`에서 `type: ClusterIP`를 `type: NodePort`로 변경하고 재적용한다.
+
+```yaml
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      nodePort: 30080   # 30000–32767 범위
+```
+
+```bash
+kubectl apply -f k8s/service.yaml
+# 접속: http://<NodeIP>:30080
+```
+
+### 방법 C: Ingress 사용 (운영 환경 권장)
+
+Ingress Controller(nginx 등)가 설치된 경우 Ingress 리소스를 별도로 생성한다.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: langchain4j-ai-rag-postgre
+spec:
+  rules:
+    - host: rag.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: langchain4j-ai-rag-postgre
+                port:
+                  number: 8080
+```
+
+---
+
+## 6. 주요 포트 및 환경변수 요약
+
+| 항목 | 값 | 설명 |
+|------|----|------|
+| 애플리케이션 포트 | `8080` | HTTP, EXPOSE 및 containerPort |
+| Readiness probe | `GET /actuator/health/readiness` | 트래픽 수신 준비 여부 |
+| Liveness probe | `GET /actuator/health/liveness` | 재시작 필요 여부 |
+| PostgreSQL 서비스명 | `postgres-pgvector` | 클러스터 내 DNS |
+| PostgreSQL 포트 | `5432` | |
+| DB 이름 | `ragdb` | |
+| Ollama 기본 포트 | `11434` | |
+| ONNX 임베딩 설정 파일 | `${user.home}/langchain4j-Config/Config/embeddingConfig.json` | 파드 내 마운트 경로로 재정의 가능 |
+
+---
+
+## 7. 업데이트 배포 (롤링 업데이트)
+
+새 이미지를 빌드·push한 후 이미지 태그를 갱신하여 재적용한다.
+
+```bash
+docker build -t <레지스트리>/langchain4j-ai-rag-postgre:1.0.1 .
+docker push <레지스트리>/langchain4j-ai-rag-postgre:1.0.1
+
+# deployment.yaml의 image 태그 수정 후
+kubectl apply -f k8s/deployment.yaml
+
+# 롤아웃 진행 상황 확인
+kubectl rollout status deployment/langchain4j-ai-rag-postgre
+```
+
+롤백이 필요한 경우:
+
+```bash
+kubectl rollout undo deployment/langchain4j-ai-rag-postgre
+```
+
+---
+
+## 8. 리소스 정리
+
+```bash
+kubectl delete -f k8s/service.yaml
+kubectl delete -f k8s/deployment.yaml
+kubectl delete -f k8s/configmap.yaml
+kubectl delete secret langchain4j-ai-rag-postgre-db
+```

--- a/langchain4j-ai-rag-postgre/k8s/README.md
+++ b/langchain4j-ai-rag-postgre/k8s/README.md
@@ -57,13 +57,24 @@ kubectl cp <로컬-모델-디렉토리>/. model-loader:/models/
 kubectl delete pod model-loader
 ```
 
+PVC는 사용자 홈 디렉터리 내용을 `/models`에 마운트한다. 따라서 `application.yml` 기본값
+(`${user.home}/langchain4j-Config/Config/embeddingConfig.json`)과 동일한 하위 경로를 유지해야 한다.
+
 PVC 내 디렉토리 구조 예시:
 
 ```
 /models/
-└── Config/
-    └── embeddingConfig.json   ← APP_EMBEDDINGCONFIGPATH 참조 경로
+└── langchain4j-Config/
+    ├── Config/
+    │   └── embeddingConfig.json   ← APP_EMBEDDING_CONFIG_PATH 참조 경로
+    └── model/
+        ├── model.onnx             ← embeddingConfig.json의 modelPath
+        └── tokenizer.json         ← embeddingConfig.json의 tokenizerPath
 ```
+
+> `embeddingConfig.json`의 `modelPath`/`tokenizerPath`는 `${HOME}/langchain4j-Config/model/...` 형태이며,
+> `ConfigUtils.resolvePath`가 `${HOME}`을 HOME 환경변수로 치환한다. ConfigMap에 `HOME: /models`를 두어
+> 모델 파일이 PVC 마운트 경로 기준으로 해석되도록 한다.
 
 ---
 
@@ -90,11 +101,17 @@ image: <레지스트리>/langchain4j-ai-rag-postgre:1.0.0
 | `PGVECTOR_PORT` | `5432` | `pgvector.port` |
 | `PGVECTOR_DATABASE` | `ragdb` | `pgvector.database` |
 | `PGVECTOR_USERNAME` | `postgres` | `pgvector.username` |
-| `LANGCHAIN4J_OLLAMA_BASEURL` | `http://ollama:11434` | `langchain4j.ollama.base-url` |
-| `APP_EMBEDDINGCONFIGPATH` | `/models/Config/embeddingConfig.json` | `app.embedding-config-path` |
-| `MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED` | `true` | `management.endpoint.health.probes.enabled` |
+| `LANGCHAIN4J_OLLAMA_BASE_URL` | `http://ollama:11434` | `langchain4j.ollama.base-url` |
+| `APP_EMBEDDING_CONFIG_PATH` | `/models/langchain4j-Config/Config/embeddingConfig.json` | `app.embedding-config-path` |
+| `HOME` | `/models` | `embeddingConfig.json`의 `${HOME}` 치환 기준 경로 |
+| `MANAGEMENT_HEALTH_PROBES_ENABLED` | `true` | `management.health.probes.enabled` |
 
 > `SPRING_DATASOURCE_*`와 `PGVECTOR_*`는 각각 독립적인 연결 설정이며 둘 다 `postgres-pgvector`를 가리킨다.
+
+> **user.home 분리** — DJL은 네이티브 라이브러리를 `user.home/.djl.ai/`에 캐시한다.
+> `readOnlyRootFilesystem: true` 환경에서 쓰기 실패를 막기 위해 `deployment.yaml`의
+> `JAVA_TOOL_OPTIONS: -Duser.home=/tmp`로 JVM `user.home`을 쓰기 가능한 `/tmp`(emptyDir)로 지정한다.
+> `${HOME}` 치환용 `HOME`(=/models)과 DJL 캐시용 `user.home`(=/tmp)은 서로 다른 용도로 분리되어 있다.
 
 ### Secret — DB 인증 정보 생성
 
@@ -219,7 +236,7 @@ spec:
 | PostgreSQL 포트 | `5432` | |
 | DB 이름 | `ragdb` | |
 | Ollama 서비스 | `http://ollama:11434` | 클러스터 내 DNS 기본값 |
-| 임베딩 설정 파일 경로 | `/models/Config/embeddingConfig.json` | PVC 마운트 경로 |
+| 임베딩 설정 파일 경로 | `/models/langchain4j-Config/Config/embeddingConfig.json` | PVC 마운트 경로 |
 | 모델 PVC | `langchain4j-ai-rag-postgre-models` (5Gi) | 사전 적재 필요 |
 
 ---

--- a/langchain4j-ai-rag-postgre/k8s/README.md
+++ b/langchain4j-ai-rag-postgre/k8s/README.md
@@ -13,7 +13,8 @@
 | 실행 중인 Kubernetes 클러스터 | 로컬: minikube / kind, 운영: EKS·GKE·AKS 등 |
 | 컨테이너 레지스트리 | 이미지 push 가능한 레지스트리 |
 | PostgreSQL + PGVector | `postgres-pgvector` 서비스로 접근 가능해야 함 |
-| Ollama | 클러스터 내 또는 외부에서 `11434` 포트 접근 가능해야 함 |
+| Ollama | 클러스터 내 `ollama` 서비스(11434 포트) 또는 외부 주소 |
+| ONNX 임베딩 모델 | 사용자가 직접 준비 후 PVC에 적재 (이미지에 포함되지 않음) |
 
 ---
 
@@ -34,9 +35,39 @@ docker build \
 docker push <레지스트리>/langchain4j-ai-rag-postgre:1.0.0
 ```
 
+> **참고** — 런타임 베이스 이미지로 `eclipse-temurin:17-jre-jammy`(glibc)를 사용한다.
+> DJL `libtokenizers.so` 등 네이티브 라이브러리가 glibc를 요구하므로 musl 기반 alpine 이미지는 사용하지 않는다.
+
 ---
 
-## 2. 매니페스트 수정
+## 2. 임베딩 모델 PVC 준비
+
+ONNX 임베딩 모델과 `embeddingConfig.json`은 이미지에 포함되지 않는다.
+배포 전 아래 순서로 PVC를 생성하고 모델 파일을 적재한다.
+
+```bash
+# PVC 생성
+kubectl apply -f k8s/models-pvc.yaml
+
+# 임시 파드로 파일 복사 (minikube 예시)
+kubectl run model-loader --image=busybox --restart=Never \
+  --overrides='{"spec":{"volumes":[{"name":"m","persistentVolumeClaim":{"claimName":"langchain4j-ai-rag-postgre-models"}}],"containers":[{"name":"c","image":"busybox","command":["sleep","3600"],"volumeMounts":[{"name":"m","mountPath":"/models"}]}]}}'
+
+kubectl cp <로컬-모델-디렉토리>/. model-loader:/models/
+kubectl delete pod model-loader
+```
+
+PVC 내 디렉토리 구조 예시:
+
+```
+/models/
+└── Config/
+    └── embeddingConfig.json   ← APP_EMBEDDINGCONFIGPATH 참조 경로
+```
+
+---
+
+## 3. 매니페스트 수정
 
 ### deployment.yaml — 이미지 경로 교체
 
@@ -46,20 +77,30 @@ docker push <레지스트리>/langchain4j-ai-rag-postgre:1.0.0
 image: <레지스트리>/langchain4j-ai-rag-postgre:1.0.0
 ```
 
-### configmap.yaml — 환경별 값 확인
+### configmap.yaml — 환경변수 목록
 
-`k8s/configmap.yaml`에서 아래 항목이 실제 클러스터 환경과 일치하는지 확인한다.
+`k8s/configmap.yaml`에 설정된 환경변수가 실제 클러스터 환경과 일치하는지 확인한다.
 
-| 키 | 기본값 | 설명 |
-|----|--------|------|
-| `SPRING_DATASOURCE_URL` | `jdbc:postgresql://postgres-pgvector:5432/ragdb` | PostgreSQL 서비스명·포트·DB명 |
-| `SPRING_DATASOURCE_DRIVER_CLASS_NAME` | `org.postgresql.Driver` | 드라이버 클래스 |
-| `SPRING_JPA_HIBERNATE_DDL_AUTO` | `update` | DDL 전략 (운영: `validate` 권장) |
-| `MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE` | `health,info` | Actuator 노출 엔드포인트 |
+| 환경변수 | 기본값 | 대응 프로퍼티 |
+|---------|--------|--------------|
+| `SPRING_DATASOURCE_URL` | `jdbc:postgresql://postgres-pgvector:5432/ragdb` | `spring.datasource.url` |
+| `SPRING_DATASOURCE_DRIVER_CLASS_NAME` | `org.postgresql.Driver` | `spring.datasource.driver-class-name` |
+| `SPRING_JPA_HIBERNATE_DDL_AUTO` | `update` | `spring.jpa.hibernate.ddl-auto` |
+| `PGVECTOR_HOST` | `postgres-pgvector` | `pgvector.host` |
+| `PGVECTOR_PORT` | `5432` | `pgvector.port` |
+| `PGVECTOR_DATABASE` | `ragdb` | `pgvector.database` |
+| `PGVECTOR_USERNAME` | `postgres` | `pgvector.username` |
+| `LANGCHAIN4J_OLLAMA_BASEURL` | `http://ollama:11434` | `langchain4j.ollama.base-url` |
+| `APP_EMBEDDINGCONFIGPATH` | `/models/Config/embeddingConfig.json` | `app.embedding-config-path` |
+| `MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED` | `true` | `management.endpoint.health.probes.enabled` |
+
+> `SPRING_DATASOURCE_*`와 `PGVECTOR_*`는 각각 독립적인 연결 설정이며 둘 다 `postgres-pgvector`를 가리킨다.
 
 ### Secret — DB 인증 정보 생성
 
-DB 사용자명과 비밀번호는 Secret으로 관리한다. Secret 이름은 `langchain4j-ai-rag-postgre-db`이어야 한다.
+DB 비밀번호는 ConfigMap에 평문으로 넣지 않고 Secret으로 관리한다.
+`k8s/pgvector-secret.yaml`의 `stringData` 값을 실제 비밀번호로 수정하거나
+아래 명령으로 직접 생성한다.
 
 ```bash
 kubectl create secret generic langchain4j-ai-rag-postgre-db \
@@ -67,34 +108,20 @@ kubectl create secret generic langchain4j-ai-rag-postgre-db \
   --from-literal=password=<DB_PASSWORD>
 ```
 
-### Ollama 연결 주소 설정 (환경변수 추가)
-
-Ollama가 클러스터 외부에 있는 경우 `deployment.yaml`의 `env` 섹션에 아래 항목을 추가한다.
-
-```yaml
-env:
-  - name: LANGCHAIN4J_OLLAMA_BASE_URL
-    value: "http://<ollama-host>:11434"
-```
-
-클러스터 내 Ollama 서비스가 있으면 서비스 DNS 이름(예: `http://ollama:11434`)을 사용한다.
-
-### ONNX 임베딩 모델 경로 설정
-
-`app.embedding-config-path`는 파드 내 경로를 가리킨다. PersistentVolumeClaim 또는 ConfigMap/Secret을 통해 아래 환경변수로 재정의한다.
-
-```yaml
-env:
-  - name: APP_EMBEDDING_CONFIG_PATH
-    value: "/config/embeddingConfig.json"
-```
+Secret의 `password` 키는 `SPRING_DATASOURCE_PASSWORD`와 `PGVECTOR_PASSWORD` 양쪽에 주입된다.
 
 ---
 
-## 3. 배포
+## 4. 배포
 
 ```bash
-# ConfigMap 먼저 적용
+# PVC 먼저 생성 (임베딩 모델 적재 포함 — 위 2번 참고)
+kubectl apply -f k8s/models-pvc.yaml
+
+# Secret 적용
+kubectl apply -f k8s/pgvector-secret.yaml
+
+# ConfigMap 적용
 kubectl apply -f k8s/configmap.yaml
 
 # Deployment · Service 적용
@@ -104,7 +131,7 @@ kubectl apply -f k8s/service.yaml
 
 ---
 
-## 4. 상태 확인
+## 5. 상태 확인
 
 ```bash
 # 파드 상태 확인
@@ -120,9 +147,11 @@ kubectl rollout status deployment/langchain4j-ai-rag-postgre
 kubectl exec -it <pod-name> -- wget -qO- http://127.0.0.1:8080/actuator/health
 ```
 
+> **참고** — ONNX 모델 로딩에 시간이 걸리므로 `readinessProbe.initialDelaySeconds`는 60초로 설정되어 있다.
+
 ---
 
-## 5. 접속
+## 6. 접속
 
 Service 타입이 `ClusterIP`이므로 클러스터 외부에서 직접 접근할 수 없다. 아래 방법 중 하나를 선택한다.
 
@@ -177,22 +206,25 @@ spec:
 
 ---
 
-## 6. 주요 포트 및 환경변수 요약
+## 7. 주요 포트 및 리소스 설정 요약
 
 | 항목 | 값 | 설명 |
 |------|----|------|
 | 애플리케이션 포트 | `8080` | HTTP, EXPOSE 및 containerPort |
-| Readiness probe | `GET /actuator/health/readiness` | 트래픽 수신 준비 여부 |
-| Liveness probe | `GET /actuator/health/liveness` | 재시작 필요 여부 |
+| Readiness probe | `GET /actuator/health/readiness` | 트래픽 수신 준비 여부 (initialDelay: 60s) |
+| Liveness probe | `GET /actuator/health/liveness` | 재시작 필요 여부 (initialDelay: 60s) |
+| CPU requests/limits | `500m` / `2000m` | |
+| Memory requests/limits | `2Gi` / `8Gi` | ONNX 모델 로딩 고려 |
 | PostgreSQL 서비스명 | `postgres-pgvector` | 클러스터 내 DNS |
 | PostgreSQL 포트 | `5432` | |
 | DB 이름 | `ragdb` | |
-| Ollama 기본 포트 | `11434` | |
-| ONNX 임베딩 설정 파일 | `${user.home}/langchain4j-Config/Config/embeddingConfig.json` | 파드 내 마운트 경로로 재정의 가능 |
+| Ollama 서비스 | `http://ollama:11434` | 클러스터 내 DNS 기본값 |
+| 임베딩 설정 파일 경로 | `/models/Config/embeddingConfig.json` | PVC 마운트 경로 |
+| 모델 PVC | `langchain4j-ai-rag-postgre-models` (5Gi) | 사전 적재 필요 |
 
 ---
 
-## 7. 업데이트 배포 (롤링 업데이트)
+## 8. 업데이트 배포 (롤링 업데이트)
 
 새 이미지를 빌드·push한 후 이미지 태그를 갱신하여 재적용한다.
 
@@ -215,11 +247,12 @@ kubectl rollout undo deployment/langchain4j-ai-rag-postgre
 
 ---
 
-## 8. 리소스 정리
+## 9. 리소스 정리
 
 ```bash
 kubectl delete -f k8s/service.yaml
 kubectl delete -f k8s/deployment.yaml
 kubectl delete -f k8s/configmap.yaml
+kubectl delete -f k8s/models-pvc.yaml
 kubectl delete secret langchain4j-ai-rag-postgre-db
 ```

--- a/langchain4j-ai-rag-postgre/k8s/configmap.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/configmap.yaml
@@ -25,9 +25,15 @@ data:
   LANGCHAIN4J_OLLAMA_BASE_URL: "http://ollama:11434"
 
   # 임베딩 설정 파일 경로 (app.embedding-config-path → APP_EMBEDDING_CONFIG_PATH)
-  # 파드에 마운트된 PVC(/models) 내 사용자가 적재한 파일을 참조한다.
-  APP_EMBEDDING_CONFIG_PATH: "/models/Config/embeddingConfig.json"
+  # PVC가 사용자 홈 디렉터리 내용을 /models에 마운트하므로 application.yml 기본값
+  # (${user.home}/langchain4j-Config/Config/embeddingConfig.json)과 동일한 하위 경로를 유지한다.
+  APP_EMBEDDING_CONFIG_PATH: "/models/langchain4j-Config/Config/embeddingConfig.json"
+
+  # embeddingConfig.json의 modelPath/tokenizerPath에 쓰인 ${HOME} 치환 기준 경로.
+  # ConfigUtils.resolvePath가 HOME 환경변수를 우선 사용하므로 PVC 마운트 지점을 지정한다.
+  HOME: "/models"
 
   # Actuator health probe 활성화
   MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: "health,info"
-  MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED: "true"
+  # management.health.probes.enabled (Spring Boot 정식 속성명)
+  MANAGEMENT_HEALTH_PROBES_ENABLED: "true"

--- a/langchain4j-ai-rag-postgre/k8s/configmap.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/configmap.yaml
@@ -21,12 +21,12 @@ data:
   PGVECTOR_DATABASE: "ragdb"
   PGVECTOR_USERNAME: "postgres"
 
-  # LangChain4j Ollama (langchain4j.ollama.base-url, 대시 제거 env명)
-  LANGCHAIN4J_OLLAMA_BASEURL: "http://ollama:11434"
+  # LangChain4j Ollama (langchain4j.ollama.base-url → LANGCHAIN4J_OLLAMA_BASE_URL)
+  LANGCHAIN4J_OLLAMA_BASE_URL: "http://ollama:11434"
 
-  # 임베딩 설정 파일 경로 (app.embedding-config-path, 대시 제거 env명)
+  # 임베딩 설정 파일 경로 (app.embedding-config-path → APP_EMBEDDING_CONFIG_PATH)
   # 파드에 마운트된 PVC(/models) 내 사용자가 적재한 파일을 참조한다.
-  APP_EMBEDDINGCONFIGPATH: "/models/Config/embeddingConfig.json"
+  APP_EMBEDDING_CONFIG_PATH: "/models/Config/embeddingConfig.json"
 
   # Actuator health probe 활성화
   MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: "health,info"

--- a/langchain4j-ai-rag-postgre/k8s/configmap.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/configmap.yaml
@@ -8,7 +8,26 @@ metadata:
 data:
   # Override application.yml values via Spring relaxed binding.
   # Sensitive credentials should come from a Secret, not this ConfigMap.
+
+  # Spring DataSource (spring.datasource.*)
   SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-pgvector:5432/ragdb"
   SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
   SPRING_JPA_HIBERNATE_DDL_AUTO: "update"
+
+  # PGVector 전용 연결 설정 (pgvector.*)
+  # application.yml의 pgvector.* 프로퍼티를 오버라이드한다.
+  PGVECTOR_HOST: "postgres-pgvector"
+  PGVECTOR_PORT: "5432"
+  PGVECTOR_DATABASE: "ragdb"
+  PGVECTOR_USERNAME: "postgres"
+
+  # LangChain4j Ollama (langchain4j.ollama.base-url, 대시 제거 env명)
+  LANGCHAIN4J_OLLAMA_BASEURL: "http://ollama:11434"
+
+  # 임베딩 설정 파일 경로 (app.embedding-config-path, 대시 제거 env명)
+  # 파드에 마운트된 PVC(/models) 내 사용자가 적재한 파일을 참조한다.
+  APP_EMBEDDINGCONFIGPATH: "/models/Config/embeddingConfig.json"
+
+  # Actuator health probe 활성화
   MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: "health,info"
+  MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED: "true"

--- a/langchain4j-ai-rag-postgre/k8s/configmap.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: langchain4j-ai-rag-postgre
+  labels:
+    app.kubernetes.io/name: langchain4j-ai-rag-postgre
+    app.kubernetes.io/part-of: egovframe-ai-rag
+data:
+  # Override application.yml values via Spring relaxed binding.
+  # Sensitive credentials should come from a Secret, not this ConfigMap.
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-pgvector:5432/ragdb"
+  SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
+  SPRING_JPA_HIBERNATE_DDL_AUTO: "update"
+  MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: "health,info"

--- a/langchain4j-ai-rag-postgre/k8s/deployment.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/deployment.yaml
@@ -38,6 +38,10 @@ spec:
             - configMapRef:
                 name: langchain4j-ai-rag-postgre
           env:
+            # DJL이 네이티브 라이브러리를 user.home/.djl.ai/에 캐시하므로 쓰기 가능한 /tmp로 지정한다.
+            # HOME(=/models, ${HOME} 치환용)과 분리해 readOnlyRootFilesystem 환경에서도 동작하게 한다.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Duser.home=/tmp"
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/langchain4j-ai-rag-postgre/k8s/deployment.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: langchain4j-ai-rag-postgre
+  labels:
+    app.kubernetes.io/name: langchain4j-ai-rag-postgre
+    app.kubernetes.io/part-of: egovframe-ai-rag
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: langchain4j-ai-rag-postgre
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: langchain4j-ai-rag-postgre
+        app.kubernetes.io/part-of: egovframe-ai-rag
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          # Replace with your registry/tag, e.g. ghcr.io/<org>/langchain4j-ai-rag-postgre:1.0.0
+          image: langchain4j-ai-rag-postgre:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: langchain4j-ai-rag-postgre
+          env:
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: langchain4j-ai-rag-postgre-db
+                  key: username
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: langchain4j-ai-rag-postgre-db
+                  key: password
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/langchain4j-ai-rag-postgre/k8s/deployment.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/deployment.yaml
@@ -48,18 +48,25 @@ spec:
                 secretKeyRef:
                   name: langchain4j-ai-rag-postgre-db
                   key: password
+            # pgvector.password는 Spring datasource와 별개의 연결 설정이므로 별도 주입
+            - name: PGVECTOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: langchain4j-ai-rag-postgre-db
+                  key: password
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
+              cpu: "500m"
+              memory: "2Gi"
             limits:
-              cpu: "1000m"
-              memory: "1Gi"
+              cpu: "2000m"
+              # ONNX 임베딩 모델 로딩 시 대용량 메모리가 필요하므로 8Gi로 설정
+              memory: "8Gi"
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: http
-            initialDelaySeconds: 20
+            initialDelaySeconds: 60
             periodSeconds: 10
             failureThreshold: 6
           livenessProbe:
@@ -78,6 +85,14 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            # ONNX 임베딩 모델 및 embeddingConfig.json을 PVC에서 마운트
+            # PVC에 사전 적재 필요: kubectl cp <local-model-dir> <pod>:/models/
+            - name: models
+              mountPath: /models
+              readOnly: true
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: models
+          persistentVolumeClaim:
+            claimName: langchain4j-ai-rag-postgre-models

--- a/langchain4j-ai-rag-postgre/k8s/models-pvc.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/models-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: langchain4j-ai-rag-postgre-models
+  labels:
+    app.kubernetes.io/name: langchain4j-ai-rag-postgre
+    app.kubernetes.io/part-of: egovframe-ai-rag
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  # storageClassName: standard  # 클러스터 환경에 맞게 수정 (미지정 시 기본 StorageClass 사용)

--- a/langchain4j-ai-rag-postgre/k8s/pgvector-secret.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/pgvector-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: langchain4j-ai-rag-postgre-db
+  labels:
+    app.kubernetes.io/name: langchain4j-ai-rag-postgre
+    app.kubernetes.io/part-of: egovframe-ai-rag
+type: Opaque
+# 실제 배포 시에는 아래 stringData 블록을 삭제하고
+# kubectl create secret generic 명령으로 생성하거나 Sealed Secrets / Vault를 사용한다.
+# kubectl create secret generic langchain4j-ai-rag-postgre-db \
+#   --from-literal=username=<DB_USERNAME> \
+#   --from-literal=password=<DB_PASSWORD>
+#
+# PGVECTOR_PASSWORD도 동일 Secret에서 주입된다 (deployment.yaml 참고).
+stringData:
+  username: "postgres"
+  password: "changeme"

--- a/langchain4j-ai-rag-postgre/k8s/service.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: langchain4j-ai-rag-postgre
+  labels:
+    app.kubernetes.io/name: langchain4j-ai-rag-postgre
+    app.kubernetes.io/part-of: egovframe-ai-rag
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: langchain4j-ai-rag-postgre
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http


### PR DESCRIPTION
## 변경 사유
`langchain4j-ai-rag-postgre` 모듈은 PostgreSQL/pgvector를 띄우는 `docker-compose.yml`만 갖고 있어 애플리케이션 자체를 컨테이너로 빌드하거나 Kubernetes에 배포할 수 있는 매니페스트가 없습니다. 운영 배포 경로를 만들기 위한 최소 산출물을 추가합니다.

## 변경 내용
- `langchain4j-ai-rag-postgre/Dockerfile`
  - multi-stage 빌드 (`maven:3.9-eclipse-temurin-17` → `eclipse-temurin:17-jre-alpine`)
  - 비루트 사용자(`app:app`) 실행
  - `JAVA_OPTS=-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError`
  - `HEALTHCHECK`로 Actuator `/actuator/health` 확인
  - `EXPOSE 8080`
- `langchain4j-ai-rag-postgre/.dockerignore`
  - `target/`, `k8s/`, IDE 파일, `postgres_data/` 등 제외해 빌드 컨텍스트 축소
- `langchain4j-ai-rag-postgre/k8s/configmap.yaml`
  - 비밀이 아닌 Spring 환경변수(datasource URL, JPA `ddl-auto`, Actuator 노출 범위) 외부화
- `langchain4j-ai-rag-postgre/k8s/deployment.yaml`
  - 1 replica + RollingUpdate(maxSurge 1, maxUnavailable 0)
  - `runAsNonRoot`, `readOnlyRootFilesystem`, `drop: ALL` capability, `tmp` emptyDir
  - resource `requests/limits` 명시 (CPU 250m–1000m, Memory 512Mi–1Gi)
  - `livenessProbe`/`readinessProbe`를 Actuator `liveness`/`readiness`로 분리
  - DB 자격증명은 `langchain4j-ai-rag-postgre-db` Secret에서 주입 (Secret 자체는 본 PR에 포함되지 않음 — 클러스터 운영자가 직접 생성)
- `langchain4j-ai-rag-postgre/k8s/service.yaml`
  - ClusterIP, 포트 8080

## 영향 범위
- 기존 `application.yml`, 소스 코드, `docker-compose.yml` 변경 없음
- 환경변수(ConfigMap/Secret) 바인딩은 Spring relaxed binding을 통해 자동 적용
- `image:` 태그(`langchain4j-ai-rag-postgre:1.0.0`)는 예시 — 운영 환경 레지스트리로 교체 필요

## 체크리스트
- [x] 단일 주제 (langchain4j 모듈 컨테이너화 + k8s 매니페스트)
- [x] 5.0.x 브랜치 대상
- [x] 기존 코드/설정 미변경
- [x] 비밀 정보(시크릿/비밀번호) 커밋 없음