### PR TITLE
[chore] Add Dependabot configuration for Maven, Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directories:
+      - "/langchain4j-ai-rag-postgre"
+      - "/spring-ai-rag-redis-stack"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/langchain4j-ai-rag-postgre"
+      - "/spring-ai-rag-redis-stack"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "docker"
+    commit-message:
+      prefix: "docker"
+      include: "scope"


### PR DESCRIPTION
## 변경 사유
2개 Maven 모듈(`langchain4j-ai-rag-postgre`, `spring-ai-rag-redis-stack`)과 향후 도입될 Dockerfile/GitHub Actions에 대한 자동 의존성 업데이트가 부재합니다. Dependabot을 활성화합니다.

## 변경 내용
- `.github/dependabot.yml` 신규
  - maven (per-module): 주간, PR 5개
  - github-actions: 주간, PR 3개
  - docker (per-module): 주간, PR 3개
  - 스케줄: 매주 월요일 09:00 KST

## 영향 범위
- 기존 코드/빌드 영향 없음
- 머지 후 첫 월요일에 스캔 시작

## 체크리스트
- [x] 단일 주제(자동 의존성 관리 설정)
- [x] 5.0.x 브랜치 대상
- [x] 기존 동작 미변경