### PR TITLE
[test][spring-ai] 컨텍스트 로드 smoke 테스트 추가

### DIFF
--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/SpringAiOllamaApplicationTests.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/SpringAiOllamaApplicationTests.java
@@ -1,0 +1,31 @@
+package com.example.chat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * 애플리케이션 컨텍스트 로드 확인용 smoke 테스트.
+ *
+ * <p>외부 의존성(Redis, Ollama, ONNX 임베딩 모델) 없이 Spring 컨텍스트가
+ * 정상적으로 초기화되는지 검증한다.</p>
+ *
+ * <ul>
+ *   <li>EmbeddingModel — ONNX 모델 파일이 classpath에 포함되지 않으므로 MockBean 으로 대체</li>
+ *   <li>Redis / Ollama — test/resources/application.yml 의 더미 설정으로 실제 연결 없이 기동</li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class SpringAiOllamaApplicationTests {
+
+    @MockBean
+    EmbeddingModel embeddingModel;
+
+    @Test
+    void contextLoads() {
+        // 컨텍스트가 예외 없이 로드되면 통과
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/SpringAiOllamaApplicationTests.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/SpringAiOllamaApplicationTests.java
@@ -3,7 +3,7 @@ package com.example.chat;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -13,7 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
  * 정상적으로 초기화되는지 검증한다.</p>
  *
  * <ul>
- *   <li>EmbeddingModel — ONNX 모델 파일이 classpath에 포함되지 않으므로 MockBean 으로 대체</li>
+ *   <li>EmbeddingModel — ONNX 모델 파일이 classpath에 포함되지 않으므로 MockitoBean 으로 대체</li>
  *   <li>Redis / Ollama — test/resources/application.yml 의 더미 설정으로 실제 연결 없이 기동</li>
  * </ul>
  */
@@ -21,7 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class SpringAiOllamaApplicationTests {
 
-    @MockBean
+    @MockitoBean
     EmbeddingModel embeddingModel;
 
     @Test

--- a/spring-ai-rag-redis-stack/src/test/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/test/resources/application.yml
@@ -1,0 +1,64 @@
+spring:
+  application:
+    name: spring-ai-rag-redis-test
+
+  ai:
+    ollama:
+      base-url: http://localhost:11434
+      chat:
+        model: test-model
+
+    # 임베딩 모델 비활성화 — ONNX 모델 파일이 test classpath에 없으므로 none 으로 설정
+    model:
+      embedding: none
+
+    vectorstore:
+      redis:
+        initialize-schema: false
+        index-name: test-document-index
+
+    document:
+      path: file:/tmp/data/**/*.md
+      pdf-path: file:/tmp/data/**/*.pdf
+      pdf:
+        page-top-margin: 0
+        pages-per-document: 1
+      enable-summary: false
+      summary-min-chunks: 2
+      enable-keywords: false
+      keyword-count: 5
+      chunk-size: 4000
+      min-chunk-size-chars: 350
+      max-num-chunks: 500
+      min-chunk-length-to-embed: 50
+      normalization:
+        enabled: false
+        remove-html-tags: false
+        remove-code-blocks: false
+        normalize-whitespace: false
+        normalize-newlines: false
+        clean-special-chars: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  main:
+    allow-bean-definition-overriding: true
+
+logging:
+  level:
+    com.example.chat: WARN
+    org.springframework.ai: WARN
+    ai.djl: WARN
+
+rag:
+  enable-query-compression: false
+  similarity:
+    threshold: 0.70
+  top-k: 3
+
+chat:
+  memory:
+    max-messages: 5


### PR DESCRIPTION
## 변경 사유

`spring-ai-rag-redis-stack` 모듈에 `src/test`가 전혀 없었습니다. 빌드 파이프라인에서 컨텍스트 로드 실패를 조기에 감지할 수 있도록 최소 안전망을 추가합니다.

## 변경 내용

- `spring-ai-rag-redis-stack/src/test/java/com/example/chat/SpringAiOllamaApplicationTests.java`
  - `@SpringBootTest` + `contextLoads()` 빈 테스트 메서드
  - `@MockBean EmbeddingModel` — ONNX 모델 파일(`.onnx`, `tokenizer.json`)이 classpath에 포함되지 않으므로 Mock으로 대체
- `spring-ai-rag-redis-stack/src/test/resources/application.yml`
  - `spring.ai.model.embedding: none` — Transformers 임베딩 자동 구성 비활성화
  - Redis host/port 더미 설정 (localhost:6379, 실제 연결 시도 안 함)
  - Ollama base-url 더미 유지
  - 문서 경로를 `file:/tmp/data/**/*.md` 더미로 override
  - `vectorstore.redis.initialize-schema: false` — 스키마 초기화 스킵

## 외부 의존성 우회 방법

| 의존성 | 우회 방식 |
|--------|-----------|
| ONNX 임베딩 모델 | `@MockBean EmbeddingModel` + `spring.ai.model.embedding=none` |
| Redis | 더미 호스트, `initialize-schema: false` (연결 lazy) |
| Ollama | 더미 base-url (컨텍스트 로드 시점엔 연결 불필요) |
| 문서 경로 | `/tmp/data/**` 더미로 override |

> `spring-boot-starter-test`는 pom.xml에 이미 `test` scope로 선언되어 있어 의존성 추가 없음.

## 영향 범위

production 코드 변경 없음. `src/test` 및 `test/resources`만 추가됩니다.

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 의존성 추가 없음 (spring-boot-starter-test 이미 존재)
- [x] 기존 동작에 영향 없음 (test scope만 추가)
- [ ] 테스트 통과 확인 — Redis/Ollama 미구동 환경에서 실행 시 컨텍스트 로드가 성공하는지 로컬 검증 필요 (외부 서비스 미구동 시 실패 가능성 있음)