### PR TITLE
[chore] Log4j2 RollingFile 운영 설정 추가

### DIFF
--- a/langchain4j-ai-rag-postgre/pom.xml
+++ b/langchain4j-ai-rag-postgre/pom.xml
@@ -47,6 +47,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- LangChain4j Core -->
@@ -101,6 +107,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -117,12 +129,24 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Spring Boot Data JPA -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- eGovFrame Runtime -->

--- a/langchain4j-ai-rag-postgre/src/main/resources/log4j2-spring.xml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="30">
+
+    <Properties>
+        <Property name="LOG_DIR">${sys:user.home}/logs/langchain4j-ai-rag-postgre</Property>
+        <Property name="LOG_FILE">application</Property>
+        <Property name="CONSOLE_PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level} [%t] %style{%logger{36}}{cyan} - %msg%n</Property>
+        <Property name="FILE_PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} - %msg%n</Property>
+    </Properties>
+
+    <Appenders>
+        <!-- Console Appender (default) -->
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="${CONSOLE_PATTERN}" />
+        </Console>
+
+        <!-- RollingFile Appender (prod) -->
+        <RollingFile name="RollingFile"
+                     fileName="${LOG_DIR}/${LOG_FILE}.log"
+                     filePattern="${LOG_DIR}/${LOG_FILE}-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="${FILE_PATTERN}" />
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true" />
+                <SizeBasedTriggeringPolicy size="50MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="30">
+                <Delete basePath="${LOG_DIR}" maxDepth="1">
+                    <IfFileName glob="${LOG_FILE}-*.log.gz" />
+                    <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <!-- Spring Profile: default / local -->
+        <SpringProfile name="default | local">
+            <Root level="INFO">
+                <AppenderRef ref="Console" />
+            </Root>
+        </SpringProfile>
+
+        <!-- Spring Profile: prod -->
+        <SpringProfile name="prod">
+            <Root level="INFO">
+                <AppenderRef ref="Console" />
+                <AppenderRef ref="RollingFile" />
+            </Root>
+        </SpringProfile>
+    </Loggers>
+
+</Configuration>

--- a/spring-ai-rag-redis-stack/pom.xml
+++ b/spring-ai-rag-redis-stack/pom.xml
@@ -47,6 +47,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -85,6 +91,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-ai-rag-redis-stack/src/main/resources/log4j2-spring.xml
+++ b/spring-ai-rag-redis-stack/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="30">
+
+    <Properties>
+        <Property name="LOG_DIR">${sys:user.home}/logs/spring-ai-rag-redis</Property>
+        <Property name="LOG_FILE">application</Property>
+        <Property name="CONSOLE_PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5level} [%t] %style{%logger{36}}{cyan} - %msg%n</Property>
+        <Property name="FILE_PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %logger{36} - %msg%n</Property>
+    </Properties>
+
+    <Appenders>
+        <!-- Console Appender (default) -->
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="${CONSOLE_PATTERN}" />
+        </Console>
+
+        <!-- RollingFile Appender (prod) -->
+        <RollingFile name="RollingFile"
+                     fileName="${LOG_DIR}/${LOG_FILE}.log"
+                     filePattern="${LOG_DIR}/${LOG_FILE}-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="${FILE_PATTERN}" />
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true" />
+                <SizeBasedTriggeringPolicy size="50MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="30">
+                <Delete basePath="${LOG_DIR}" maxDepth="1">
+                    <IfFileName glob="${LOG_FILE}-*.log.gz" />
+                    <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <!-- Spring Profile: default / local -->
+        <SpringProfile name="default | local">
+            <Root level="INFO">
+                <AppenderRef ref="Console" />
+            </Root>
+        </SpringProfile>
+
+        <!-- Spring Profile: prod -->
+        <SpringProfile name="prod">
+            <Root level="INFO">
+                <AppenderRef ref="Console" />
+                <AppenderRef ref="RollingFile" />
+            </Root>
+        </SpringProfile>
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
## 개요

두 모듈(langchain4j-ai-rag-postgre, spring-ai-rag-redis-stack)에 `log4j2-spring.xml` 운영용 로깅 설정을 추가합니다.

## 변경 내용

현재 두 모듈 모두 별도의 Log4j2 설정 파일 없이 `application.yml`의 `logging.level`만으로 콘솔 로깅을 수행하고 있습니다. 운영 환경에서 로그 파일 관리가 필요하므로 Spring Profile 기반의 `log4j2-spring.xml`을 추가합니다.

### default / local 프로파일
- 기존과 동일하게 콘솔 출력만 사용
- **기존 동작에 변경 없음**

### prod 프로파일
- RollingFileAppender 추가
- 일 단위 로테이션 + 50 MB 크기 기반 롤링
- gzip 압축 아카이브
- 30일 보관 후 자동 삭제
- `monitorInterval=30`으로 런타임 설정 리로드 지원

## 변경 파일

| 파일 | 설명 |
|------|------|
| `langchain4j-ai-rag-postgre/src/main/resources/log4j2-spring.xml` | 신규 추가 |
| `spring-ai-rag-redis-stack/src/main/resources/log4j2-spring.xml` | 신규 추가 |

## 검증

- 두 모듈 모두 `mvn -B -ntp -DskipTests compile` 빌드 성공
- production 코드 동작 변경 없음 (default 프로파일은 기존 콘솔 로깅 동작 유지)