### PR TITLE
[test][ai-rag] spring-ai 유틸리티 단위 테스트 추가

### DIFF
--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovDocumentHashUtilTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovDocumentHashUtilTest.java
@@ -1,0 +1,61 @@
+package com.example.chat.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("EgovDocumentHashUtil 단위 테스트")
+class EgovDocumentHashUtilTest {
+
+    @Test
+    @DisplayName("일반 문자열의 MD5 해시를 반환한다")
+    void calculateHash_withNormalContent_returnsMd5Hash() {
+        String content = "eGovFrame RAG 문서 내용";
+
+        String hash = EgovDocumentHashUtil.calculateHash(content);
+
+        assertThat(hash).isNotNull();
+        assertThat(hash).hasSize(32);
+        assertThat(hash).matches("[0-9a-f]{32}");
+    }
+
+    @Test
+    @DisplayName("동일한 내용은 동일한 해시를 반환한다")
+    void calculateHash_withSameContent_returnsSameHash() {
+        String content = "동일한 문서 내용";
+
+        String hash1 = EgovDocumentHashUtil.calculateHash(content);
+        String hash2 = EgovDocumentHashUtil.calculateHash(content);
+
+        assertThat(hash1).isEqualTo(hash2);
+    }
+
+    @Test
+    @DisplayName("서로 다른 내용은 서로 다른 해시를 반환한다")
+    void calculateHash_withDifferentContent_returnsDifferentHashes() {
+        String content1 = "첫 번째 문서";
+        String content2 = "두 번째 문서";
+
+        String hash1 = EgovDocumentHashUtil.calculateHash(content1);
+        String hash2 = EgovDocumentHashUtil.calculateHash(content2);
+
+        assertThat(hash1).isNotEqualTo(hash2);
+    }
+
+    @Test
+    @DisplayName("null 입력 시 빈 문자열을 반환한다")
+    void calculateHash_withNullContent_returnsEmptyString() {
+        String hash = EgovDocumentHashUtil.calculateHash(null);
+
+        assertThat(hash).isEmpty();
+    }
+
+    @Test
+    @DisplayName("빈 문자열 입력 시 빈 문자열을 반환한다")
+    void calculateHash_withEmptyContent_returnsEmptyString() {
+        String hash = EgovDocumentHashUtil.calculateHash("");
+
+        assertThat(hash).isEmpty();
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovResponseCleanerUtilTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovResponseCleanerUtilTest.java
@@ -1,0 +1,67 @@
+package com.example.chat.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("EgovResponseCleanerUtil 단위 테스트")
+class EgovResponseCleanerUtilTest {
+
+    @Test
+    @DisplayName("think 태그와 내용을 제거하고 JSON만 반환한다")
+    void cleanResponse_withThinkTag_removesThinkTagAndExtractsJson() {
+        String response = "<think>내부 추론 과정</think>{\"name\": \"Spring Boot\"}";
+
+        String cleaned = EgovResponseCleanerUtil.cleanResponse(response);
+
+        assertThat(cleaned).isEqualTo("{\"name\": \"Spring Boot\"}");
+        assertThat(cleaned).doesNotContain("<think>");
+    }
+
+    @Test
+    @DisplayName("think 태그 없이 JSON만 있으면 그대로 반환한다")
+    void cleanResponse_withoutThinkTag_returnsJsonAsIs() {
+        String response = "{\"name\": \"eGovFrame\", \"category\": \"프레임워크\"}";
+
+        String cleaned = EgovResponseCleanerUtil.cleanResponse(response);
+
+        assertThat(cleaned).isEqualTo("{\"name\": \"eGovFrame\", \"category\": \"프레임워크\"}");
+    }
+
+    @Test
+    @DisplayName("여러 줄에 걸친 think 태그도 제거한다")
+    void cleanResponse_withMultilineThinkTag_removesThinkTag() {
+        String response = "<think>\n1단계 분석\n2단계 검토\n</think>{\"answer\": \"결과\"}";
+
+        String cleaned = EgovResponseCleanerUtil.cleanResponse(response);
+
+        assertThat(cleaned).isEqualTo("{\"answer\": \"결과\"}");
+    }
+
+    @Test
+    @DisplayName("null 입력 시 null을 반환한다")
+    void cleanResponse_withNullInput_returnsNull() {
+        String cleaned = EgovResponseCleanerUtil.cleanResponse(null);
+
+        assertThat(cleaned).isNull();
+    }
+
+    @Test
+    @DisplayName("빈 문자열 입력 시 빈 문자열을 반환한다")
+    void cleanResponse_withEmptyInput_returnsEmptyString() {
+        String cleaned = EgovResponseCleanerUtil.cleanResponse("");
+
+        assertThat(cleaned).isEmpty();
+    }
+
+    @Test
+    @DisplayName("JSON 앞뒤 공백을 제거한다")
+    void cleanResponse_withSurroundingWhitespace_trimmed() {
+        String response = "  {\"key\": \"value\"}  ";
+
+        String cleaned = EgovResponseCleanerUtil.cleanResponse(response);
+
+        assertThat(cleaned).isEqualTo("{\"key\": \"value\"}");
+    }
+}


### PR DESCRIPTION
spring-ai-rag-redis-stack 모듈의 유틸리티 클래스에 대한 단위 테스트를 추가한다.

## 변경 내용

**EgovDocumentHashUtilTest** (5건)
- MD5 해시가 32자리 16진수 문자열로 반환되는지 검증
- 동일 입력에 대해 항상 동일 해시를 반환하는지 확인
- 서로 다른 입력에 대해 서로 다른 해시를 반환하는지 확인
- null 및 빈 문자열 입력 시 빈 문자열 반환 처리 검증

**EgovResponseCleanerUtilTest** (6건)
- `<think>` 태그와 그 내용을 제거하고 JSON 부분만 추출하는지 검증
- 여러 줄에 걸친 `<think>` 태그 제거 처리 확인
- `<think>` 태그 없이 JSON만 있는 경우 그대로 반환하는지 확인
- null, 빈 문자열 입력 처리 검증
- 앞뒤 공백 제거 확인

## 테스트 환경

- JUnit 5 + AssertJ (spring-boot-starter-test 포함)
- 외부 의존성(LLM API, Redis 등) 없는 순수 단위 테스트
- 전체 11건 통과

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (신규 테스트 파일만 추가)
- [x] 테스트 통과 확인 (11/11)
