### PR TITLE
[test][ai-rag] langchain4j PromptEngineeringUtil 단위 테스트 추가

### DIFF
--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/PromptEngineeringUtilTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/PromptEngineeringUtilTest.java
@@ -1,0 +1,84 @@
+package com.example.chat.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("PromptEngineeringUtil 단위 테스트")
+class PromptEngineeringUtilTest {
+
+    @Test
+    @DisplayName("Zero-shot 프롬프트는 한국어 응답 지시를 포함한다")
+    void createZeroShotPrompt_containsKoreanResponseInstruction() {
+        String prompt = PromptEngineeringUtil.createZeroShotPrompt();
+
+        assertThat(prompt).isNotBlank();
+        assertThat(prompt).contains("Respond in Korean");
+    }
+
+    @Test
+    @DisplayName("컨텍스트 기반 프롬프트에 컨텍스트 내용이 포함된다")
+    void createContextBasedPrompt_withContext_includesContextInPrompt() {
+        String context = "eGovFrame은 공공기관 웹 서비스 개발을 위한 표준 프레임워크이다.";
+
+        String prompt = PromptEngineeringUtil.createContextBasedPrompt(context);
+
+        assertThat(prompt).contains(context);
+        assertThat(prompt).contains("Respond in Korean");
+    }
+
+    @Test
+    @DisplayName("Few-shot 프롬프트에 컨텍스트와 예시가 포함된다")
+    void createFewShotLearningPrompt_withContext_includesContextAndExamples() {
+        String context = "Spring Boot 관련 문서 내용";
+
+        String prompt = PromptEngineeringUtil.createFewShotLearningPrompt(context);
+
+        assertThat(prompt).contains(context);
+        assertThat(prompt).contains("Example 1");
+        assertThat(prompt).contains("Example 2");
+    }
+
+    @Test
+    @DisplayName("코드 생성 프롬프트에 언어와 요구사항이 포함된다")
+    void createCodeGenerationPrompt_withLanguageAndRequirement_includesBoth() {
+        String language = "Java";
+        String requirement = "파일을 읽어 MD5 해시를 계산하는 유틸리티";
+
+        String prompt = PromptEngineeringUtil.createCodeGenerationPrompt(language, requirement);
+
+        assertThat(prompt).contains(language);
+        assertThat(prompt).contains(requirement);
+    }
+
+    @Test
+    @DisplayName("역할 기반 프롬프트에 역할과 작업이 포함된다")
+    void createRoleBasedPrompt_withRoleAndTask_includesBoth() {
+        String role = "보안 전문가";
+        String task = "의존성 취약점 분석";
+
+        String prompt = PromptEngineeringUtil.createRoleBasedPrompt(role, task);
+
+        assertThat(prompt).contains(role);
+        assertThat(prompt).contains(task);
+    }
+
+    @Test
+    @DisplayName("동적 Few-shot 프롬프트에 예시 질문과 답변이 포함된다")
+    void createDynamicFewShotPrompt_withExamples_includesQuestionsAndAnswers() {
+        String context = "기술 문서 컨텍스트";
+        List<Map.Entry<String, String>> examples = List.of(
+            Map.entry("Spring Boot란?", "Spring Boot는 자동 구성을 지원하는 프레임워크입니다.")
+        );
+
+        String prompt = PromptEngineeringUtil.createDynamicFewShotPrompt(context, examples);
+
+        assertThat(prompt).contains(context);
+        assertThat(prompt).contains("Spring Boot란?");
+        assertThat(prompt).contains("Spring Boot는 자동 구성을 지원하는 프레임워크입니다.");
+    }
+}


### PR DESCRIPTION
langchain4j-ai-rag-postgre 모듈의 PromptEngineeringUtil 클래스에 대한 단위 테스트를 추가한다.

## 변경 내용

**PromptEngineeringUtilTest** (6건)
- Zero-shot 프롬프트에 한국어 응답 지시(`Respond in Korean`)가 포함되는지 확인
- 컨텍스트 기반 프롬프트에 전달된 컨텍스트 문자열이 그대로 포함되는지 확인
- Few-shot 프롬프트에 컨텍스트와 예시(Example 1, Example 2)가 포함되는지 확인
- 코드 생성 프롬프트에 언어명 및 요구사항이 포함되는지 확인
- 역할 기반 프롬프트에 역할과 작업 내용이 포함되는지 확인
- 동적 Few-shot 프롬프트에 전달된 예시 질문/답변이 포함되는지 확인

## 테스트 환경

- JUnit 5 + AssertJ (spring-boot-starter-test 포함)
- 외부 의존성(PostgreSQL, Ollama 등) 없는 순수 단위 테스트
- 전체 6건 통과

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (신규 테스트 파일만 추가)
- [x] 테스트 통과 확인 (6/6)
