### PR TITLE
[test][ai-rag] spring-ai EgovJsonPromptTemplates 단위 테스트 추가

### DIFF
--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovJsonPromptTemplatesTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovJsonPromptTemplatesTest.java
@@ -1,0 +1,59 @@
+package com.example.chat.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EgovJsonPromptTemplatesTest {
+
+    @Test
+    @DisplayName("createTechnologyInfoPrompt: 질의 문자열이 프롬프트에 포함된다")
+    void createTechnologyInfoPrompt_containsQuery() {
+        String query = "Spring Boot란 무엇인가?";
+        String prompt = EgovJsonPromptTemplates.createTechnologyInfoPrompt(query);
+
+        assertThat(prompt).contains(query);
+    }
+
+    @Test
+    @DisplayName("createTechnologyInfoPrompt: JSON 응답 형식 키가 모두 포함된다")
+    void createTechnologyInfoPrompt_containsJsonFields() {
+        String prompt = EgovJsonPromptTemplates.createTechnologyInfoPrompt("any");
+
+        assertThat(prompt)
+                .contains("\"name\"")
+                .contains("\"category\"")
+                .contains("\"description\"")
+                .contains("\"features\"")
+                .contains("\"useCases\"")
+                .contains("\"complexity\"");
+    }
+
+    @Test
+    @DisplayName("createTechnologyInfoPrompt: 빈 문자열 질의도 처리된다")
+    void createTechnologyInfoPrompt_emptyQuery() {
+        String prompt = EgovJsonPromptTemplates.createTechnologyInfoPrompt("");
+
+        assertThat(prompt).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("createTechnologyInfoPrompt: 서로 다른 질의는 서로 다른 프롬프트를 반환한다")
+    void createTechnologyInfoPrompt_differentQueriesProduceDifferentPrompts() {
+        String prompt1 = EgovJsonPromptTemplates.createTechnologyInfoPrompt("Kubernetes");
+        String prompt2 = EgovJsonPromptTemplates.createTechnologyInfoPrompt("Docker");
+
+        assertThat(prompt1).isNotEqualTo(prompt2);
+    }
+
+    @Test
+    @DisplayName("createTechnologyInfoPrompt: 동일 질의는 동일 프롬프트를 반환한다")
+    void createTechnologyInfoPrompt_sameQueryProducesSamePrompt() {
+        String query = "eGovFrame";
+        String prompt1 = EgovJsonPromptTemplates.createTechnologyInfoPrompt(query);
+        String prompt2 = EgovJsonPromptTemplates.createTechnologyInfoPrompt(query);
+
+        assertThat(prompt1).isEqualTo(prompt2);
+    }
+}


### PR DESCRIPTION
spring-ai 모듈의 `EgovJsonPromptTemplates` 클래스에 대한 단위 테스트를 추가한다.

**변경 내용**
- `EgovJsonPromptTemplatesTest`: `createTechnologyInfoPrompt` 메서드 5건 검증
  - 질의 문자열이 프롬프트에 포함되는지 확인
  - JSON 응답 형식 키(`name`, `category`, `description`, `features`, `useCases`, `complexity`) 포함 여부 확인
  - 빈 문자열 질의 처리 확인
  - 서로 다른 질의에서 서로 다른 프롬프트 생성 확인
  - 동일 질의에서 동일 프롬프트 반환 확인

**테스트 환경**: JUnit 5 + AssertJ, 외부 의존성(LLM, Redis) 없는 순수 로직 검증

**테스트 결과**: 5/5 통과

---

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 외부 의존성 없는 순수 단위 테스트
- [ ] 기존 동작에 영향 없음
- [ ] 테스트 통과 확인
