### PR TITLE
[test][ai-rag] langchain4j SessionContext·ConfigUtils 단위 테스트 추가

### DIFF
--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/context/SessionContextTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/context/SessionContextTest.java
@@ -1,0 +1,87 @@
+package com.example.chat.context;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SessionContext 단위 테스트")
+class SessionContextTest {
+
+    @AfterEach
+    void tearDown() {
+        SessionContext.clear();
+    }
+
+    @Test
+    @DisplayName("세션 ID 설정 후 조회 시 동일한 값 반환")
+    void setAndGetSessionId() {
+        SessionContext.setCurrentSessionId("session-001");
+        assertThat(SessionContext.getCurrentSessionId()).isEqualTo("session-001");
+    }
+
+    @Test
+    @DisplayName("세션 ID 미설정 시 기본값 반환")
+    void getSessionIdReturnsDefaultWhenNotSet() {
+        assertThat(SessionContext.getCurrentSessionId())
+                .isEqualTo(SessionContext.DEFAULT_CONVERSATION_ID);
+    }
+
+    @Test
+    @DisplayName("null 세션 ID 설정 시 기본값으로 대체")
+    void setNullSessionIdFallsBackToDefault() {
+        SessionContext.setCurrentSessionId(null);
+        assertThat(SessionContext.getCurrentSessionId())
+                .isEqualTo(SessionContext.DEFAULT_CONVERSATION_ID);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 세션 ID 설정 시 기본값으로 대체")
+    void setEmptySessionIdFallsBackToDefault() {
+        SessionContext.setCurrentSessionId("   ");
+        assertThat(SessionContext.getCurrentSessionId())
+                .isEqualTo(SessionContext.DEFAULT_CONVERSATION_ID);
+    }
+
+    @Test
+    @DisplayName("clear() 호출 후 기본값 반환")
+    void clearResetsToDefault() {
+        SessionContext.setCurrentSessionId("session-xyz");
+        SessionContext.clear();
+        assertThat(SessionContext.getCurrentSessionId())
+                .isEqualTo(SessionContext.DEFAULT_CONVERSATION_ID);
+    }
+
+    @Test
+    @DisplayName("기본 세션일 때 isDefaultSession()은 true 반환")
+    void isDefaultSessionReturnsTrueForDefaultId() {
+        SessionContext.setCurrentSessionId(SessionContext.DEFAULT_CONVERSATION_ID);
+        assertThat(SessionContext.isDefaultSession()).isTrue();
+    }
+
+    @Test
+    @DisplayName("커스텀 세션 ID일 때 isDefaultSession()은 false 반환")
+    void isDefaultSessionReturnsFalseForCustomId() {
+        SessionContext.setCurrentSessionId("custom-session");
+        assertThat(SessionContext.isDefaultSession()).isFalse();
+    }
+
+    @Test
+    @DisplayName("스레드별 독립적인 세션 ID 유지")
+    void threadLocalIsolation() throws InterruptedException {
+        SessionContext.setCurrentSessionId("main-thread-session");
+
+        String[] threadSessionId = new String[1];
+        Thread thread = new Thread(() -> {
+            // 별도 스레드에서는 main 스레드 값이 보이지 않아야 함
+            threadSessionId[0] = SessionContext.getCurrentSessionId();
+            SessionContext.clear();
+        });
+        thread.start();
+        thread.join();
+
+        assertThat(threadSessionId[0]).isEqualTo(SessionContext.DEFAULT_CONVERSATION_ID);
+        assertThat(SessionContext.getCurrentSessionId()).isEqualTo("main-thread-session");
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/ConfigUtilsResolvPathTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/ConfigUtilsResolvPathTest.java
@@ -1,0 +1,82 @@
+package com.example.chat.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ConfigUtils.resolvePath() 단위 테스트")
+class ConfigUtilsResolvPathTest {
+
+    private ConfigUtils configUtils;
+
+    @BeforeEach
+    void setUp() {
+        configUtils = new ConfigUtils();
+    }
+
+    @Test
+    @DisplayName("null 입력 시 null 반환")
+    void resolvePathWithNullReturnsNull() {
+        assertThat(configUtils.resolvePath(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("빈 문자열 입력 시 빈 문자열 반환")
+    void resolvePathWithEmptyStringReturnsEmpty() {
+        assertThat(configUtils.resolvePath("")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("${HOME} 없는 경로는 그대로 정규화하여 반환")
+    void resolvePathWithoutHomePlaceholderNormalizesPath() {
+        String result = configUtils.resolvePath("/some/path/to/file");
+        assertThat(result).isNotNull();
+        assertThat(result).contains("some");
+        assertThat(result).contains("file");
+    }
+
+    @Test
+    @DisplayName("${HOME} 플레이스홀더를 실제 홈 디렉토리로 교체")
+    void resolvePathReplacesHomeVariable() {
+        String expectedHome = System.getenv("HOME");
+        if (expectedHome == null || expectedHome.isEmpty()) {
+            expectedHome = System.getenv("USERPROFILE");
+        }
+        if (expectedHome == null || expectedHome.isEmpty()) {
+            expectedHome = System.getProperty("user.home");
+        }
+
+        String result = configUtils.resolvePath("${HOME}/models/model.onnx");
+
+        assertThat(result).isNotNull();
+        assertThat(result).doesNotContain("${HOME}");
+        assertThat(result).contains("models");
+        assertThat(result).contains("model.onnx");
+        if (expectedHome != null) {
+            assertThat(result).startsWith(expectedHome.replace('\\', File.separatorChar));
+        }
+    }
+
+    @Test
+    @DisplayName("백슬래시를 시스템 구분자로 정규화")
+    @DisabledOnOs(OS.WINDOWS)
+    void resolvePathNormalizesBackslashes() {
+        String result = configUtils.resolvePath("/some\\path\\to\\file");
+        assertThat(result).doesNotContain("\\");
+        assertThat(result).contains("/");
+    }
+
+    @Test
+    @DisplayName("중복 구분자 경로 정규화")
+    void resolvePathNormalizesRedundantSegments() {
+        String result = configUtils.resolvePath("/some/path/../path/to/file");
+        assertThat(result).isNotNull();
+        assertThat(result).doesNotContain("..");
+    }
+}


### PR DESCRIPTION
langchain4j-ai-rag-postgre 모듈에 테스트 디렉토리 자체가 없어 신규 구성하고, 외부 인프라 의존 없이 실행 가능한 순수 단위 테스트 2종을 추가합니다.

**SessionContextTest** (`context/SessionContext`)
- ThreadLocal 기반 세션 ID 설정·조회, null/빈문자열 폴백, `clear()` 후 기본값 복원, `isDefaultSession()` 판별
- 스레드 격리 검증: 별도 스레드에서 main 스레드 세션 ID가 노출되지 않음을 확인 (ThreadLocal 독립성)
- 총 8개 케이스

**ConfigUtilsResolvPathTest** (`util/ConfigUtils.resolvePath`)
- null·빈문자열 처리, `${HOME}` 환경변수 치환, 백슬래시→슬래시 정규화(비Windows), `..` 세그먼트 제거
- `@Value` 주입 없이 `resolvePath()` 메서드만 단독 테스트
- 총 6개 케이스

빌드 환경: JUnit 5 + AssertJ, `mvn test` 14/14 통과 확인.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인 (14/14)
