### PR TITLE
[test][ai-rag] spring-ai SessionContext·DTO·Response 단위 테스트 추가

### DIFF
--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/context/SessionContextTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/context/SessionContextTest.java
@@ -1,0 +1,90 @@
+package com.example.chat.context;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("spring-ai SessionContext 단위 테스트")
+class SessionContextTest {
+
+    private static final String DEFAULT_SESSION_ID = "default";
+
+    @AfterEach
+    void tearDown() {
+        SessionContext.clear();
+    }
+
+    @Test
+    @DisplayName("세션 ID 설정 후 조회 시 동일한 값 반환")
+    void setAndGetSessionId() {
+        SessionContext.setCurrentSessionId("session-abc");
+        assertThat(SessionContext.getCurrentSessionId()).isEqualTo("session-abc");
+    }
+
+    @Test
+    @DisplayName("세션 ID 미설정 시 기본값 반환")
+    void getSessionIdReturnsDefaultWhenNotSet() {
+        assertThat(SessionContext.getCurrentSessionId()).isEqualTo(DEFAULT_SESSION_ID);
+    }
+
+    @Test
+    @DisplayName("null 세션 ID 설정 시 기본값으로 대체")
+    void setNullSessionIdFallsBackToDefault() {
+        SessionContext.setCurrentSessionId(null);
+        assertThat(SessionContext.getCurrentSessionId()).isEqualTo(DEFAULT_SESSION_ID);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 세션 ID 설정 시 기본값으로 대체")
+    void setBlankSessionIdFallsBackToDefault() {
+        SessionContext.setCurrentSessionId("   ");
+        assertThat(SessionContext.getCurrentSessionId()).isEqualTo(DEFAULT_SESSION_ID);
+    }
+
+    @Test
+    @DisplayName("clear() 호출 후 기본값 반환")
+    void clearResetsToDefault() {
+        SessionContext.setCurrentSessionId("session-xyz");
+        SessionContext.clear();
+        assertThat(SessionContext.getCurrentSessionId()).isEqualTo(DEFAULT_SESSION_ID);
+    }
+
+    @Test
+    @DisplayName("기본 세션일 때 isDefaultSession()은 true 반환")
+    void isDefaultSessionReturnsTrueForDefaultId() {
+        SessionContext.setCurrentSessionId(DEFAULT_SESSION_ID);
+        assertThat(SessionContext.isDefaultSession()).isTrue();
+    }
+
+    @Test
+    @DisplayName("커스텀 세션 ID일 때 isDefaultSession()은 false 반환")
+    void isDefaultSessionReturnsFalseForCustomId() {
+        SessionContext.setCurrentSessionId("custom-session");
+        assertThat(SessionContext.isDefaultSession()).isFalse();
+    }
+
+    @Test
+    @DisplayName("세션 ID 미설정 상태는 기본 세션으로 판정")
+    void uninitializedSessionIsDefault() {
+        assertThat(SessionContext.isDefaultSession()).isTrue();
+    }
+
+    @Test
+    @DisplayName("스레드별 독립적인 세션 ID 유지")
+    void threadLocalIsolation() throws InterruptedException {
+        SessionContext.setCurrentSessionId("main-session");
+
+        String[] threadResult = new String[1];
+        Thread worker = new Thread(() -> {
+            threadResult[0] = SessionContext.getCurrentSessionId();
+            SessionContext.clear();
+        });
+        worker.start();
+        worker.join();
+
+        assertThat(threadResult[0]).isEqualTo(DEFAULT_SESSION_ID);
+        assertThat(SessionContext.getCurrentSessionId()).isEqualTo("main-session");
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/dto/ChatMessageDtoTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/dto/ChatMessageDtoTest.java
@@ -1,0 +1,81 @@
+package com.example.chat.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import java.time.temporal.ChronoUnit;
+
+@DisplayName("ChatMessageDto 단위 테스트")
+class ChatMessageDtoTest {
+
+    @Test
+    @DisplayName("2인자 생성자는 timestamp를 현재 시각으로 자동 설정")
+    void twoArgConstructorSetsTimestampToNow() {
+        LocalDateTime before = LocalDateTime.now();
+        ChatMessageDto dto = new ChatMessageDto("USER", "안녕하세요");
+        LocalDateTime after = LocalDateTime.now();
+
+        assertThat(dto.getMessageType()).isEqualTo("USER");
+        assertThat(dto.getContent()).isEqualTo("안녕하세요");
+        assertThat(dto.getTimestamp())
+                .isAfterOrEqualTo(before)
+                .isBeforeOrEqualTo(after);
+    }
+
+    @Test
+    @DisplayName("전체 생성자로 timestamp 직접 지정")
+    void allArgsConstructorSetsExplicitTimestamp() {
+        LocalDateTime ts = LocalDateTime.of(2025, 1, 15, 10, 30, 0);
+        ChatMessageDto dto = new ChatMessageDto("ASSISTANT", "응답 내용", ts);
+
+        assertThat(dto.getMessageType()).isEqualTo("ASSISTANT");
+        assertThat(dto.getContent()).isEqualTo("응답 내용");
+        assertThat(dto.getTimestamp()).isEqualTo(ts);
+    }
+
+    @Test
+    @DisplayName("기본 생성자 후 setter로 필드 설정")
+    void noArgConstructorWithSetters() {
+        ChatMessageDto dto = new ChatMessageDto();
+        dto.setMessageType("SYSTEM");
+        dto.setContent("시스템 메시지");
+
+        assertThat(dto.getMessageType()).isEqualTo("SYSTEM");
+        assertThat(dto.getContent()).isEqualTo("시스템 메시지");
+    }
+
+    @Test
+    @DisplayName("Lombok @Data — 동일 값이면 equals는 true")
+    void equalsForSameValues() {
+        LocalDateTime ts = LocalDateTime.of(2025, 6, 1, 12, 0, 0);
+        ChatMessageDto d1 = new ChatMessageDto("USER", "내용", ts);
+        ChatMessageDto d2 = new ChatMessageDto("USER", "내용", ts);
+
+        assertThat(d1).isEqualTo(d2);
+        assertThat(d1.hashCode()).isEqualTo(d2.hashCode());
+    }
+
+    @Test
+    @DisplayName("messageType이 다르면 equals는 false")
+    void differentMessageTypeNotEqual() {
+        LocalDateTime ts = LocalDateTime.now();
+        ChatMessageDto d1 = new ChatMessageDto("USER", "내용", ts);
+        ChatMessageDto d2 = new ChatMessageDto("ASSISTANT", "내용", ts);
+
+        assertThat(d1).isNotEqualTo(d2);
+    }
+
+    @Test
+    @DisplayName("content가 다르면 equals는 false")
+    void differentContentNotEqual() {
+        LocalDateTime ts = LocalDateTime.now();
+        ChatMessageDto d1 = new ChatMessageDto("USER", "질문1", ts);
+        ChatMessageDto d2 = new ChatMessageDto("USER", "질문2", ts);
+
+        assertThat(d1).isNotEqualTo(d2);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/dto/ChatSessionTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/dto/ChatSessionTest.java
@@ -1,0 +1,82 @@
+package com.example.chat.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatSession 단위 테스트")
+class ChatSessionTest {
+
+    @Test
+    @DisplayName("3인자 생성자는 lastMessageAt을 createdAt과 동일하게 설정")
+    void threeArgConstructorSetsLastMessageAtToCreatedAt() {
+        LocalDateTime ts = LocalDateTime.of(2025, 3, 10, 9, 0, 0);
+        ChatSession session = new ChatSession("sess-001", "첫 번째 세션", ts);
+
+        assertThat(session.getSessionId()).isEqualTo("sess-001");
+        assertThat(session.getTitle()).isEqualTo("첫 번째 세션");
+        assertThat(session.getCreatedAt()).isEqualTo(ts);
+        assertThat(session.getLastMessageAt()).isEqualTo(ts);
+    }
+
+    @Test
+    @DisplayName("전체 생성자로 lastMessageAt을 별도 지정")
+    void allArgsConstructorAllowsDifferentLastMessageAt() {
+        LocalDateTime created = LocalDateTime.of(2025, 1, 1, 8, 0, 0);
+        LocalDateTime last = LocalDateTime.of(2025, 1, 2, 18, 30, 0);
+
+        ChatSession session = new ChatSession("sess-002", "두 번째 세션", created, last);
+
+        assertThat(session.getCreatedAt()).isEqualTo(created);
+        assertThat(session.getLastMessageAt()).isEqualTo(last);
+        assertThat(session.getLastMessageAt()).isAfter(session.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("기본 생성자 후 setter로 필드 설정")
+    void noArgConstructorWithSetters() {
+        ChatSession session = new ChatSession();
+        session.setSessionId("sess-003");
+        session.setTitle("제목 없음");
+
+        assertThat(session.getSessionId()).isEqualTo("sess-003");
+        assertThat(session.getTitle()).isEqualTo("제목 없음");
+    }
+
+    @Test
+    @DisplayName("Lombok @Data — 동일 값이면 equals는 true")
+    void equalsForSameValues() {
+        LocalDateTime ts = LocalDateTime.of(2025, 6, 1, 0, 0, 0);
+        ChatSession s1 = new ChatSession("s1", "제목", ts, ts);
+        ChatSession s2 = new ChatSession("s1", "제목", ts, ts);
+
+        assertThat(s1).isEqualTo(s2);
+        assertThat(s1.hashCode()).isEqualTo(s2.hashCode());
+    }
+
+    @Test
+    @DisplayName("sessionId가 다르면 equals는 false")
+    void differentSessionIdNotEqual() {
+        LocalDateTime ts = LocalDateTime.now();
+        ChatSession s1 = new ChatSession("id-A", "제목", ts, ts);
+        ChatSession s2 = new ChatSession("id-B", "제목", ts, ts);
+
+        assertThat(s1).isNotEqualTo(s2);
+    }
+
+    @Test
+    @DisplayName("lastMessageAt setter로 업데이트 가능")
+    void updateLastMessageAt() {
+        LocalDateTime created = LocalDateTime.of(2025, 4, 1, 10, 0, 0);
+        LocalDateTime updated = LocalDateTime.of(2025, 4, 1, 15, 0, 0);
+
+        ChatSession session = new ChatSession("sess-004", "업데이트 세션", created);
+        session.setLastMessageAt(updated);
+
+        assertThat(session.getLastMessageAt()).isEqualTo(updated);
+        assertThat(session.getCreatedAt()).isEqualTo(created);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/response/DocumentStatusResponseTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/response/DocumentStatusResponseTest.java
@@ -1,0 +1,85 @@
+package com.example.chat.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DocumentStatusResponse 단위 테스트")
+class DocumentStatusResponseTest {
+
+    @Test
+    @DisplayName("전체 생성자로 모든 필드 설정")
+    void fullConstructorSetsAllFields() {
+        DocumentStatusResponse response = new DocumentStatusResponse(true, 5, 10, 3, true);
+
+        assertThat(response.processing()).isTrue();
+        assertThat(response.processedCount()).isEqualTo(5);
+        assertThat(response.totalCount()).isEqualTo(10);
+        assertThat(response.changedCount()).isEqualTo(3);
+        assertThat(response.hasDocuments()).isTrue();
+    }
+
+    @Test
+    @DisplayName("3인자 생성자는 changedCount=0, hasDocuments=totalCount>0으로 초기화")
+    void threeArgConstructorDefaults() {
+        DocumentStatusResponse response = new DocumentStatusResponse(false, 3, 8);
+
+        assertThat(response.processing()).isFalse();
+        assertThat(response.processedCount()).isEqualTo(3);
+        assertThat(response.totalCount()).isEqualTo(8);
+        assertThat(response.changedCount()).isEqualTo(0);
+        assertThat(response.hasDocuments()).isTrue();
+    }
+
+    @Test
+    @DisplayName("3인자 생성자에서 totalCount=0이면 hasDocuments=false")
+    void threeArgConstructorNoDocuments() {
+        DocumentStatusResponse response = new DocumentStatusResponse(false, 0, 0);
+
+        assertThat(response.hasDocuments()).isFalse();
+    }
+
+    @Test
+    @DisplayName("4인자 생성자는 hasDocuments=totalCount>0으로 초기화")
+    void fourArgConstructorSetsHasDocuments() {
+        DocumentStatusResponse withDocs = new DocumentStatusResponse(true, 2, 5, 1);
+        assertThat(withDocs.hasDocuments()).isTrue();
+
+        DocumentStatusResponse withoutDocs = new DocumentStatusResponse(false, 0, 0, 0);
+        assertThat(withoutDocs.hasDocuments()).isFalse();
+    }
+
+    @Test
+    @DisplayName("처리 중 상태와 완료 상태 구분")
+    void processingFlagDistinction() {
+        DocumentStatusResponse inProgress = new DocumentStatusResponse(true, 2, 10, 2, true);
+        DocumentStatusResponse done = new DocumentStatusResponse(false, 10, 10, 0, true);
+
+        assertThat(inProgress.processing()).isTrue();
+        assertThat(done.processing()).isFalse();
+    }
+
+    @Test
+    @DisplayName("record equals — 동일한 값이면 같은 객체")
+    void recordEquality() {
+        DocumentStatusResponse r1 = new DocumentStatusResponse(false, 3, 3, 0, true);
+        DocumentStatusResponse r2 = new DocumentStatusResponse(false, 3, 3, 0, true);
+
+        assertThat(r1).isEqualTo(r2);
+        assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+    }
+
+    @Test
+    @DisplayName("record toString은 모든 필드를 포함")
+    void recordToStringContainsFields() {
+        DocumentStatusResponse response = new DocumentStatusResponse(true, 1, 5, 2, true);
+        String str = response.toString();
+
+        assertThat(str).contains("processing=true")
+                .contains("processedCount=1")
+                .contains("totalCount=5")
+                .contains("changedCount=2")
+                .contains("hasDocuments=true");
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/response/TechnologyResponseTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/response/TechnologyResponseTest.java
@@ -1,0 +1,85 @@
+package com.example.chat.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TechnologyResponse 단위 테스트")
+class TechnologyResponseTest {
+
+    @Test
+    @DisplayName("기본 생성자 후 setter로 필드 설정")
+    void noArgConstructorAndSetters() {
+        TechnologyResponse response = new TechnologyResponse();
+        response.setName("Spring Boot");
+        response.setCategory("Framework");
+        response.setDescription("Java 기반 웹 프레임워크");
+        response.setFeatures(List.of("자동 구성", "내장 서버"));
+        response.setUseCases(List.of("REST API", "마이크로서비스"));
+
+        assertThat(response.getName()).isEqualTo("Spring Boot");
+        assertThat(response.getCategory()).isEqualTo("Framework");
+        assertThat(response.getDescription()).isEqualTo("Java 기반 웹 프레임워크");
+        assertThat(response.getFeatures()).containsExactly("자동 구성", "내장 서버");
+        assertThat(response.getUseCases()).containsExactly("REST API", "마이크로서비스");
+    }
+
+    @Test
+    @DisplayName("전체 생성자로 모든 필드 초기화")
+    void allArgsConstructorInitializesAllFields() {
+        List<String> features = List.of("컨테이너 오케스트레이션", "자동 스케일링");
+        List<String> useCases = List.of("클라우드 배포", "무중단 운영");
+
+        TechnologyResponse response = new TechnologyResponse(
+                "Kubernetes", "Infra", "컨테이너 오케스트레이션 플랫폼", features, useCases);
+
+        assertThat(response.getName()).isEqualTo("Kubernetes");
+        assertThat(response.getCategory()).isEqualTo("Infra");
+        assertThat(response.getFeatures()).hasSize(2);
+        assertThat(response.getUseCases()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Lombok @Data — equals/hashCode는 모든 필드 기준")
+    void equalsBasedOnAllFields() {
+        List<String> features = List.of("기능1");
+        List<String> useCases = List.of("활용1");
+
+        TechnologyResponse r1 = new TechnologyResponse("Redis", "DB", "인메모리 저장소", features, useCases);
+        TechnologyResponse r2 = new TechnologyResponse("Redis", "DB", "인메모리 저장소", features, useCases);
+
+        assertThat(r1).isEqualTo(r2);
+        assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+    }
+
+    @Test
+    @DisplayName("name이 다르면 equals는 false")
+    void differentNameProducesNotEqual() {
+        TechnologyResponse r1 = new TechnologyResponse("Redis", "DB", "설명", null, null);
+        TechnologyResponse r2 = new TechnologyResponse("Kafka", "DB", "설명", null, null);
+
+        assertThat(r1).isNotEqualTo(r2);
+    }
+
+    @Test
+    @DisplayName("features와 useCases가 null이어도 객체 생성 가능")
+    void nullListsAllowed() {
+        TechnologyResponse response = new TechnologyResponse("Test", "Cat", "Desc", null, null);
+
+        assertThat(response.getFeatures()).isNull();
+        assertThat(response.getUseCases()).isNull();
+    }
+
+    @Test
+    @DisplayName("Lombok @Data — toString은 클래스명과 필드를 포함")
+    void toStringContainsFieldValues() {
+        TechnologyResponse response = new TechnologyResponse(
+                "Docker", "Infra", "컨테이너 플랫폼", List.of("경량화"), List.of("CI/CD"));
+        String str = response.toString();
+
+        assertThat(str).contains("Docker").contains("Infra");
+    }
+}


### PR DESCRIPTION
spring-ai 모듈에서 외부 의존성(DB, Redis, Ollama) 없이 순수하게 테스트 가능한 클래스들의 단위 테스트를 추가합니다.

**대상 클래스**

- `SessionContext` — ThreadLocal 기반 세션 ID 관리, null/빈값 처리, 스레드 격리
- `DocumentStatusResponse` — record 3·4·5인자 생성자 및 필드 기본값 검증
- `TechnologyResponse` — Lombok @Data 기반 equals/hashCode/setter 검증
- `ChatMessageDto` — 2인자 생성자의 timestamp 자동 설정, @Data 동등성
- `ChatSession` — 3인자 생성자의 lastMessageAt 초기화, setter 업데이트

**테스트 현황**

- 총 34개 케이스, 외부 서버 의존 없음
- JUnit 5 + AssertJ, `mvn test` 로컬 통과 확인

---

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (테스트 추가만)
- [x] 테스트 통과 확인 (34/34)
