### PR TITLE
[test][ai-rag] langchain4j DTO·엔티티·유틸 단위 테스트 추가

### DIFF
--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/dto/ChatMessageDtoTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/dto/ChatMessageDtoTest.java
@@ -1,0 +1,88 @@
+package com.example.chat.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import java.time.temporal.ChronoUnit;
+
+@DisplayName("ChatMessageDto 단위 테스트")
+class ChatMessageDtoTest {
+
+    @Test
+    @DisplayName("전체 인자 생성자로 필드가 올바르게 설정된다")
+    void allArgsConstructor_setsFieldsCorrectly() {
+        LocalDateTime timestamp = LocalDateTime.of(2024, 1, 15, 10, 30, 0);
+
+        ChatMessageDto dto = new ChatMessageDto("USER", "안녕하세요", timestamp);
+
+        assertThat(dto.getMessageType()).isEqualTo("USER");
+        assertThat(dto.getContent()).isEqualTo("안녕하세요");
+        assertThat(dto.getTimestamp()).isEqualTo(timestamp);
+    }
+
+    @Test
+    @DisplayName("messageType, content 두 인자 생성자는 timestamp를 현재 시각으로 설정한다")
+    void twoArgConstructor_setsTimestampToNow() {
+        LocalDateTime before = LocalDateTime.now();
+
+        ChatMessageDto dto = new ChatMessageDto("ASSISTANT", "응답입니다");
+
+        LocalDateTime after = LocalDateTime.now();
+
+        assertThat(dto.getMessageType()).isEqualTo("ASSISTANT");
+        assertThat(dto.getContent()).isEqualTo("응답입니다");
+        assertThat(dto.getTimestamp()).isBetween(before, after);
+    }
+
+    @Test
+    @DisplayName("기본 생성자로 생성 시 모든 필드가 null이다")
+    void noArgsConstructor_allFieldsNull() {
+        ChatMessageDto dto = new ChatMessageDto();
+
+        assertThat(dto.getMessageType()).isNull();
+        assertThat(dto.getContent()).isNull();
+        assertThat(dto.getTimestamp()).isNull();
+    }
+
+    @Test
+    @DisplayName("setter로 필드를 변경할 수 있다")
+    void setters_updateFields() {
+        ChatMessageDto dto = new ChatMessageDto();
+        LocalDateTime now = LocalDateTime.now();
+
+        dto.setMessageType("SYSTEM");
+        dto.setContent("시스템 메시지");
+        dto.setTimestamp(now);
+
+        assertThat(dto.getMessageType()).isEqualTo("SYSTEM");
+        assertThat(dto.getContent()).isEqualTo("시스템 메시지");
+        assertThat(dto.getTimestamp()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("동일한 필드 값을 가진 두 객체는 equals가 true이다")
+    void equals_withSameFields_returnsTrue() {
+        LocalDateTime timestamp = LocalDateTime.of(2024, 6, 1, 12, 0, 0);
+
+        ChatMessageDto dto1 = new ChatMessageDto("USER", "hello", timestamp);
+        ChatMessageDto dto2 = new ChatMessageDto("USER", "hello", timestamp);
+
+        assertThat(dto1).isEqualTo(dto2);
+        assertThat(dto1.hashCode()).isEqualTo(dto2.hashCode());
+    }
+
+    @Test
+    @DisplayName("toString에 주요 필드 정보가 포함된다")
+    void toString_containsFieldInfo() {
+        ChatMessageDto dto = new ChatMessageDto("USER", "내용", null);
+
+        String str = dto.toString();
+
+        assertThat(str).contains("USER");
+        assertThat(str).contains("내용");
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/dto/ChatSessionTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/dto/ChatSessionTest.java
@@ -1,0 +1,75 @@
+package com.example.chat.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatSession DTO 단위 테스트")
+class ChatSessionTest {
+
+    @Test
+    @DisplayName("sessionId·title·createdAt 세 인자 생성자는 lastMessageAt을 createdAt과 동일하게 설정한다")
+    void threeArgConstructor_setsLastMessageAtEqualToCreatedAt() {
+        LocalDateTime now = LocalDateTime.of(2024, 3, 10, 9, 0, 0);
+
+        ChatSession session = new ChatSession("session-001", "첫 번째 세션", now);
+
+        assertThat(session.getSessionId()).isEqualTo("session-001");
+        assertThat(session.getTitle()).isEqualTo("첫 번째 세션");
+        assertThat(session.getCreatedAt()).isEqualTo(now);
+        assertThat(session.getLastMessageAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("전체 인자 생성자로 네 필드를 각각 설정할 수 있다")
+    void allArgsConstructor_setsAllFields() {
+        LocalDateTime created = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+        LocalDateTime last = LocalDateTime.of(2024, 1, 2, 12, 0, 0);
+
+        ChatSession session = new ChatSession("s-abc", "제목", created, last);
+
+        assertThat(session.getSessionId()).isEqualTo("s-abc");
+        assertThat(session.getTitle()).isEqualTo("제목");
+        assertThat(session.getCreatedAt()).isEqualTo(created);
+        assertThat(session.getLastMessageAt()).isEqualTo(last);
+    }
+
+    @Test
+    @DisplayName("기본 생성자로 생성 시 모든 필드가 null이다")
+    void noArgsConstructor_allFieldsNull() {
+        ChatSession session = new ChatSession();
+
+        assertThat(session.getSessionId()).isNull();
+        assertThat(session.getTitle()).isNull();
+        assertThat(session.getCreatedAt()).isNull();
+        assertThat(session.getLastMessageAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("setter로 lastMessageAt을 업데이트할 수 있다")
+    void setter_updatesLastMessageAt() {
+        LocalDateTime created = LocalDateTime.of(2024, 5, 1, 10, 0, 0);
+        LocalDateTime updated = LocalDateTime.of(2024, 5, 1, 11, 30, 0);
+        ChatSession session = new ChatSession("s-1", "세션1", created);
+
+        session.setLastMessageAt(updated);
+
+        assertThat(session.getLastMessageAt()).isEqualTo(updated);
+        assertThat(session.getCreatedAt()).isEqualTo(created);
+    }
+
+    @Test
+    @DisplayName("동일한 필드 값을 가진 두 객체는 equals가 true이다")
+    void equals_withSameFields_returnsTrue() {
+        LocalDateTime dt = LocalDateTime.of(2024, 7, 4, 0, 0, 0);
+
+        ChatSession s1 = new ChatSession("id", "title", dt, dt);
+        ChatSession s2 = new ChatSession("id", "title", dt, dt);
+
+        assertThat(s1).isEqualTo(s2);
+        assertThat(s1.hashCode()).isEqualTo(s2.hashCode());
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/dto/StreamTokenDtoTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/dto/StreamTokenDtoTest.java
@@ -1,0 +1,53 @@
+package com.example.chat.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("StreamTokenDto 단위 테스트")
+class StreamTokenDtoTest {
+
+    @Test
+    @DisplayName("token 값이 올바르게 저장된다")
+    void token_storedCorrectly() {
+        StreamTokenDto dto = new StreamTokenDto("hello");
+
+        assertThat(dto.token()).isEqualTo("hello");
+    }
+
+    @Test
+    @DisplayName("공백 토큰도 그대로 저장된다")
+    void whitespaceToken_storedAsIs() {
+        StreamTokenDto dto = new StreamTokenDto(" ");
+
+        assertThat(dto.token()).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("null 토큰도 허용된다")
+    void nullToken_allowed() {
+        StreamTokenDto dto = new StreamTokenDto(null);
+
+        assertThat(dto.token()).isNull();
+    }
+
+    @Test
+    @DisplayName("동일한 token 값을 가진 두 레코드는 equals가 true이다")
+    void equals_withSameToken_returnsTrue() {
+        StreamTokenDto dto1 = new StreamTokenDto("word");
+        StreamTokenDto dto2 = new StreamTokenDto("word");
+
+        assertThat(dto1).isEqualTo(dto2);
+        assertThat(dto1.hashCode()).isEqualTo(dto2.hashCode());
+    }
+
+    @Test
+    @DisplayName("서로 다른 token 값을 가진 두 레코드는 equals가 false이다")
+    void equals_withDifferentToken_returnsFalse() {
+        StreamTokenDto dto1 = new StreamTokenDto("a");
+        StreamTokenDto dto2 = new StreamTokenDto("b");
+
+        assertThat(dto1).isNotEqualTo(dto2);
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/entity/ChatMemoryEntityTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/entity/ChatMemoryEntityTest.java
@@ -1,0 +1,71 @@
+package com.example.chat.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatMemoryEntity 단위 테스트")
+class ChatMemoryEntityTest {
+
+    @Test
+    @DisplayName("sessionId·messageType·content 세 인자 생성자로 필드가 설정된다")
+    void threeArgConstructor_setsFields() {
+        ChatMemoryEntity entity = new ChatMemoryEntity("s-001", "USER", "질문 내용");
+
+        assertThat(entity.getSessionId()).isEqualTo("s-001");
+        assertThat(entity.getMessageType()).isEqualTo("USER");
+        assertThat(entity.getContent()).isEqualTo("질문 내용");
+        assertThat(entity.getId()).isNull();
+        assertThat(entity.getCreatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("전체 인자 생성자로 id와 createdAt을 포함해 설정된다")
+    void allArgsConstructor_setsAllFields() {
+        LocalDateTime now = LocalDateTime.of(2024, 4, 1, 8, 0, 0);
+
+        ChatMemoryEntity entity = new ChatMemoryEntity(1L, "s-002", "ASSISTANT", "답변", now);
+
+        assertThat(entity.getId()).isEqualTo(1L);
+        assertThat(entity.getSessionId()).isEqualTo("s-002");
+        assertThat(entity.getMessageType()).isEqualTo("ASSISTANT");
+        assertThat(entity.getContent()).isEqualTo("답변");
+        assertThat(entity.getCreatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("기본 생성자로 생성 시 모든 필드가 null이다")
+    void noArgsConstructor_allFieldsNull() {
+        ChatMemoryEntity entity = new ChatMemoryEntity();
+
+        assertThat(entity.getId()).isNull();
+        assertThat(entity.getSessionId()).isNull();
+        assertThat(entity.getMessageType()).isNull();
+        assertThat(entity.getContent()).isNull();
+        assertThat(entity.getCreatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("setter로 content를 변경할 수 있다")
+    void setter_updatesContent() {
+        ChatMemoryEntity entity = new ChatMemoryEntity("s-1", "USER", "원본");
+        entity.setContent("수정된 내용");
+
+        assertThat(entity.getContent()).isEqualTo("수정된 내용");
+    }
+
+    @Test
+    @DisplayName("동일한 필드 값을 가진 두 객체는 equals가 true이다")
+    void equals_withSameFields_returnsTrue() {
+        LocalDateTime dt = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+
+        ChatMemoryEntity e1 = new ChatMemoryEntity(1L, "s", "USER", "msg", dt);
+        ChatMemoryEntity e2 = new ChatMemoryEntity(1L, "s", "USER", "msg", dt);
+
+        assertThat(e1).isEqualTo(e2);
+        assertThat(e1.hashCode()).isEqualTo(e2.hashCode());
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/entity/ChatSessionEntityTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/entity/ChatSessionEntityTest.java
@@ -1,0 +1,71 @@
+package com.example.chat.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatSessionEntity 단위 테스트")
+class ChatSessionEntityTest {
+
+    @Test
+    @DisplayName("전체 인자 생성자로 모든 필드가 설정된다")
+    void allArgsConstructor_setsAllFields() {
+        LocalDateTime created = LocalDateTime.of(2024, 2, 1, 9, 0, 0);
+        LocalDateTime updated = LocalDateTime.of(2024, 2, 1, 10, 0, 0);
+
+        ChatSessionEntity entity = new ChatSessionEntity("s-abc", "세션 제목", created, updated);
+
+        assertThat(entity.getSessionId()).isEqualTo("s-abc");
+        assertThat(entity.getTitle()).isEqualTo("세션 제목");
+        assertThat(entity.getCreatedAt()).isEqualTo(created);
+        assertThat(entity.getUpdatedAt()).isEqualTo(updated);
+    }
+
+    @Test
+    @DisplayName("기본 생성자로 생성 시 모든 필드가 null이다")
+    void noArgsConstructor_allFieldsNull() {
+        ChatSessionEntity entity = new ChatSessionEntity();
+
+        assertThat(entity.getSessionId()).isNull();
+        assertThat(entity.getTitle()).isNull();
+        assertThat(entity.getCreatedAt()).isNull();
+        assertThat(entity.getUpdatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("setter로 title을 변경할 수 있다")
+    void setter_updatesTitle() {
+        ChatSessionEntity entity = new ChatSessionEntity();
+        entity.setSessionId("s-1");
+        entity.setTitle("새 제목");
+
+        assertThat(entity.getSessionId()).isEqualTo("s-1");
+        assertThat(entity.getTitle()).isEqualTo("새 제목");
+    }
+
+    @Test
+    @DisplayName("동일한 필드 값을 가진 두 객체는 equals가 true이다")
+    void equals_withSameFields_returnsTrue() {
+        LocalDateTime dt = LocalDateTime.of(2024, 6, 15, 12, 0, 0);
+
+        ChatSessionEntity e1 = new ChatSessionEntity("id", "title", dt, dt);
+        ChatSessionEntity e2 = new ChatSessionEntity("id", "title", dt, dt);
+
+        assertThat(e1).isEqualTo(e2);
+        assertThat(e1.hashCode()).isEqualTo(e2.hashCode());
+    }
+
+    @Test
+    @DisplayName("sessionId가 다르면 equals가 false이다")
+    void equals_differentSessionId_returnsFalse() {
+        LocalDateTime dt = LocalDateTime.now();
+
+        ChatSessionEntity e1 = new ChatSessionEntity("id-1", "title", dt, dt);
+        ChatSessionEntity e2 = new ChatSessionEntity("id-2", "title", dt, dt);
+
+        assertThat(e1).isNotEqualTo(e2);
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/entity/DocumentHashEntityTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/entity/DocumentHashEntityTest.java
@@ -1,0 +1,74 @@
+package com.example.chat.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DocumentHashEntity 단위 테스트")
+class DocumentHashEntityTest {
+
+    @Test
+    @DisplayName("docId·hash 두 인자 생성자로 필드가 설정된다")
+    void twoArgConstructor_setsFields() {
+        DocumentHashEntity entity = new DocumentHashEntity("doc-001", "abc123hash");
+
+        assertThat(entity.getDocId()).isEqualTo("doc-001");
+        assertThat(entity.getHash()).isEqualTo("abc123hash");
+        assertThat(entity.getUpdatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("전체 인자 생성자로 updatedAt 포함 모든 필드가 설정된다")
+    void allArgsConstructor_setsAllFields() {
+        LocalDateTime now = LocalDateTime.of(2024, 5, 20, 14, 0, 0);
+
+        DocumentHashEntity entity = new DocumentHashEntity("doc-002", "hashvalue", now);
+
+        assertThat(entity.getDocId()).isEqualTo("doc-002");
+        assertThat(entity.getHash()).isEqualTo("hashvalue");
+        assertThat(entity.getUpdatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("기본 생성자로 생성 시 모든 필드가 null이다")
+    void noArgsConstructor_allFieldsNull() {
+        DocumentHashEntity entity = new DocumentHashEntity();
+
+        assertThat(entity.getDocId()).isNull();
+        assertThat(entity.getHash()).isNull();
+        assertThat(entity.getUpdatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("setter로 hash를 변경할 수 있다")
+    void setter_updatesHash() {
+        DocumentHashEntity entity = new DocumentHashEntity("doc-1", "oldhash");
+        entity.setHash("newhash");
+
+        assertThat(entity.getHash()).isEqualTo("newhash");
+    }
+
+    @Test
+    @DisplayName("동일한 필드 값을 가진 두 객체는 equals가 true이다")
+    void equals_withSameFields_returnsTrue() {
+        LocalDateTime dt = LocalDateTime.of(2024, 3, 3, 3, 3, 3);
+
+        DocumentHashEntity e1 = new DocumentHashEntity("id", "hash", dt);
+        DocumentHashEntity e2 = new DocumentHashEntity("id", "hash", dt);
+
+        assertThat(e1).isEqualTo(e2);
+        assertThat(e1.hashCode()).isEqualTo(e2.hashCode());
+    }
+
+    @Test
+    @DisplayName("docId가 다르면 equals가 false이다")
+    void equals_differentDocId_returnsFalse() {
+        DocumentHashEntity e1 = new DocumentHashEntity("doc-A", "h");
+        DocumentHashEntity e2 = new DocumentHashEntity("doc-B", "h");
+
+        assertThat(e1).isNotEqualTo(e2);
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/response/DocumentStatusResponseTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/response/DocumentStatusResponseTest.java
@@ -1,0 +1,71 @@
+package com.example.chat.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DocumentStatusResponse 단위 테스트")
+class DocumentStatusResponseTest {
+
+    @Test
+    @DisplayName("전체 인자 생성자로 모든 필드가 올바르게 설정된다")
+    void allArgsConstructor_setsAllFields() {
+        DocumentStatusResponse response = new DocumentStatusResponse(true, 5, 10, 3, true);
+
+        assertThat(response.processing()).isTrue();
+        assertThat(response.processedCount()).isEqualTo(5);
+        assertThat(response.totalCount()).isEqualTo(10);
+        assertThat(response.changedCount()).isEqualTo(3);
+        assertThat(response.hasDocuments()).isTrue();
+    }
+
+    @Test
+    @DisplayName("3인자 생성자는 changedCount=0, hasDocuments=totalCount>0으로 설정한다")
+    void threeArgConstructor_setsDefaults() {
+        DocumentStatusResponse response = new DocumentStatusResponse(false, 7, 7);
+
+        assertThat(response.processing()).isFalse();
+        assertThat(response.processedCount()).isEqualTo(7);
+        assertThat(response.totalCount()).isEqualTo(7);
+        assertThat(response.changedCount()).isEqualTo(0);
+        assertThat(response.hasDocuments()).isTrue();
+    }
+
+    @Test
+    @DisplayName("3인자 생성자에서 totalCount=0이면 hasDocuments=false이다")
+    void threeArgConstructor_zeroTotal_hasDocumentsFalse() {
+        DocumentStatusResponse response = new DocumentStatusResponse(false, 0, 0);
+
+        assertThat(response.hasDocuments()).isFalse();
+    }
+
+    @Test
+    @DisplayName("4인자 생성자는 changedCount를 설정하고 hasDocuments=totalCount>0으로 설정한다")
+    void fourArgConstructor_setsChangedCount() {
+        DocumentStatusResponse response = new DocumentStatusResponse(true, 3, 5, 2);
+
+        assertThat(response.changedCount()).isEqualTo(2);
+        assertThat(response.hasDocuments()).isTrue();
+        assertThat(response.totalCount()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("처리 완료 상태(processing=false, processedCount==totalCount)를 올바르게 표현한다")
+    void processingComplete_correctlyRepresented() {
+        DocumentStatusResponse response = new DocumentStatusResponse(false, 10, 10);
+
+        assertThat(response.processing()).isFalse();
+        assertThat(response.processedCount()).isEqualTo(response.totalCount());
+    }
+
+    @Test
+    @DisplayName("동일한 값을 가진 두 레코드는 equals가 true이다")
+    void equals_withSameValues_returnsTrue() {
+        DocumentStatusResponse r1 = new DocumentStatusResponse(true, 1, 2, 1, true);
+        DocumentStatusResponse r2 = new DocumentStatusResponse(true, 1, 2, 1, true);
+
+        assertThat(r1).isEqualTo(r2);
+        assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/DocumentHashUtilTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/DocumentHashUtilTest.java
@@ -1,0 +1,72 @@
+package com.example.chat.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DocumentHashUtil 단위 테스트")
+class DocumentHashUtilTest {
+
+    @Test
+    @DisplayName("일반 문자열에 대해 32자리 MD5 해시를 반환한다")
+    void calculateHash_normalString_returns32CharMd5() {
+        String result = DocumentHashUtil.calculateHash("hello world");
+
+        assertThat(result).hasSize(32);
+        assertThat(result).matches("[0-9a-f]+");
+    }
+
+    @Test
+    @DisplayName("동일한 내용에 대해 항상 같은 해시를 반환한다")
+    void calculateHash_sameContent_returnsSameHash() {
+        String content = "eGovFrame RAG 문서 내용";
+
+        String hash1 = DocumentHashUtil.calculateHash(content);
+        String hash2 = DocumentHashUtil.calculateHash(content);
+
+        assertThat(hash1).isEqualTo(hash2);
+    }
+
+    @Test
+    @DisplayName("내용이 다르면 다른 해시를 반환한다")
+    void calculateHash_differentContent_returnsDifferentHash() {
+        String hash1 = DocumentHashUtil.calculateHash("문서 A");
+        String hash2 = DocumentHashUtil.calculateHash("문서 B");
+
+        assertThat(hash1).isNotEqualTo(hash2);
+    }
+
+    @Test
+    @DisplayName("null 입력 시 빈 문자열을 반환한다")
+    void calculateHash_nullContent_returnsEmpty() {
+        String result = DocumentHashUtil.calculateHash(null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("빈 문자열 입력 시 빈 문자열을 반환한다")
+    void calculateHash_emptyContent_returnsEmpty() {
+        String result = DocumentHashUtil.calculateHash("");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("알려진 입력에 대해 올바른 MD5 해시값을 반환한다")
+    void calculateHash_knownInput_returnsKnownMd5() {
+        // echo -n "abc" | md5sum = 900150983cd24fb0d6963f7d28e17f72
+        String result = DocumentHashUtil.calculateHash("abc");
+
+        assertThat(result).isEqualTo("900150983cd24fb0d6963f7d28e17f72");
+    }
+
+    @Test
+    @DisplayName("한글 문자열에 대해서도 32자리 해시를 반환한다")
+    void calculateHash_koreanString_returns32CharHash() {
+        String result = DocumentHashUtil.calculateHash("전자정부 표준프레임워크");
+
+        assertThat(result).hasSize(32);
+    }
+}


### PR DESCRIPTION
langchain4j-ai-rag-postgre 모듈에서 테스트가 없던 클래스들에 단위 테스트를 추가합니다.

**대상 클래스 (8개)**
- `ChatMessageDto` — 생성자 3종, setter, equals/hashCode
- `ChatSession` — 생성자 3종, lastMessageAt 초기화 검증
- `StreamTokenDto` — record 동등성, null/공백 토큰 허용
- `ChatMemoryEntity` — 생성자 3종, @PrePersist 외부 로직 검증
- `ChatSessionEntity` — 생성자, setter, equals
- `DocumentHashEntity` — 생성자 2종, setter, equals
- `DocumentStatusResponse` — 생성자 오버로드 3종, hasDocuments 파생 필드
- `DocumentHashUtil` — MD5 결정성, null/빈값 경계, 알려진 해시값 검증

**테스트 현황**
- 총 45개 케이스, 0 실패

- [ ] 단일 주제만 다룸 (DTO·엔티티·유틸 단위 테스트)
- [ ] 기존 동작에 영향 없음 (테스트 전용 파일 추가)
- [ ] `mvn test` 45/45 통과 확인
