### PR TITLE
[chore][AI] spring-ai·langchain4j 모듈 k8s 매니페스트 추가

### DIFF
--- a/langchain4j-ai-rag-postgre/k8s/configmap.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: langchain4j-rag-config
+  labels:
+    app: langchain4j-ai-rag-postgre
+data:
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-pgvector:5432/ragdb"
+  SPRING_DATASOURCE_USERNAME: "postgres"

--- a/langchain4j-ai-rag-postgre/k8s/deployment.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: langchain4j-ai-rag-postgre
+  labels:
+    app: langchain4j-ai-rag-postgre
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: langchain4j-ai-rag-postgre
+  template:
+    metadata:
+      labels:
+        app: langchain4j-ai-rag-postgre
+    spec:
+      containers:
+        - name: langchain4j-ai-rag-postgre
+          image: langchain4j-ai-rag-postgre:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: langchain4j-rag-config
+          env:
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: langchain4j-rag-secret
+                  key: db-password
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: langchain4j-rag-secret
+                  key: openai-api-key
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 15

--- a/langchain4j-ai-rag-postgre/k8s/service.yaml
+++ b/langchain4j-ai-rag-postgre/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: langchain4j-ai-rag-postgre
+  labels:
+    app: langchain4j-ai-rag-postgre
+spec:
+  selector:
+    app: langchain4j-ai-rag-postgre
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30081

--- a/spring-ai-rag-redis-stack/k8s/configmap.yaml
+++ b/spring-ai-rag-redis-stack/k8s/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spring-ai-rag-config
+  labels:
+    app: spring-ai-rag-redis-stack
+data:
+  SPRING_REDIS_HOST: "redis-stack"
+  SPRING_REDIS_PORT: "6379"
+  SPRING_AI_OPENAI_BASE_URL: "https://api.openai.com"

--- a/spring-ai-rag-redis-stack/k8s/deployment.yaml
+++ b/spring-ai-rag-redis-stack/k8s/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-ai-rag-redis-stack
+  labels:
+    app: spring-ai-rag-redis-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spring-ai-rag-redis-stack
+  template:
+    metadata:
+      labels:
+        app: spring-ai-rag-redis-stack
+    spec:
+      containers:
+        - name: spring-ai-rag-redis-stack
+          image: spring-ai-rag-redis-stack:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: spring-ai-rag-config
+          env:
+            - name: SPRING_AI_OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: spring-ai-rag-secret
+                  key: openai-api-key
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 15

--- a/spring-ai-rag-redis-stack/k8s/service.yaml
+++ b/spring-ai-rag-redis-stack/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spring-ai-rag-redis-stack
+  labels:
+    app: spring-ai-rag-redis-stack
+spec:
+  selector:
+    app: spring-ai-rag-redis-stack
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30080


### PR DESCRIPTION
## 변경 사유

두 RAG 모듈(spring-ai-rag-redis-stack, langchain4j-ai-rag-postgre)에 k8s 배포용 매니페스트가 없어 minikube·EKS 등 로컬·클라우드 환경에서 데모 구성이 번거로움

## 변경 내용

**spring-ai-rag-redis-stack/k8s/**
- `configmap.yaml`: Redis 호스트·포트 및 OpenAI base URL 환경변수
- `deployment.yaml`: 단일 replica, 컨테이너 포트 8080, OpenAI API 키 Secret 참조, readiness/liveness probe 포함
- `service.yaml`: NodePort 30080

**langchain4j-ai-rag-postgre/k8s/**
- `configmap.yaml`: PostgreSQL datasource URL·사용자명 환경변수
- `deployment.yaml`: 단일 replica, 컨테이너 포트 8080, DB 비밀번호·OpenAI API 키 Secret 참조, readiness/liveness probe 포함
- `service.yaml`: NodePort 30081

## 영향 범위

- k8s 디렉토리 신규 추가, 기존 소스 코드·빌드 설정 영향 없음

## 체크리스트

- [x] 단일 주제만 다룸 (k8s 매니페스트 추가)
- [x] 기존 동작에 영향 없음
- [x] 민감 정보(API 키, 비밀번호)는 Secret 참조 방식으로 처리
