### PR TITLE
[보안][main] CVE-2026-42198 postgresql JDBC 42.7.11로 업데이트

### DIFF
--- a/langchain4j-ai-rag-postgre/pom.xml
+++ b/langchain4j-ai-rag-postgre/pom.xml
@@ -17,6 +17,8 @@
 
     <properties>
         <java.version>17</java.version>
+        <!-- CVE-2026-42198: SCRAM-SHA-256 인증 시 CPU 소진 DoS 취약점 패치 (42.7.3 → 42.7.11) -->
+        <postgresql.version>42.7.11</postgresql.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## 변경 사유

CVE-2026-42198: pgjdbc(postgresql JDBC 드라이버)에서 SCRAM-SHA-256 인증 처리 중 악의적인 서버가 클라이언트에게 과도한 PBKDF2 반복 횟수를 강제할 수 있는 DoS 취약점이 발견되었다. 반복 횟수가 크면 인증 실패 전에 CPU 코어 하나를 무한정 점유하며, 동시 연결 시 커넥션 풀을 고갈시킬 수 있다. loginTimeout 설정만으로는 워커 스레드가 계속 실행되어 완전한 mitigation이 되지 않는다.

- 영향 버전: 42.2.0 ~ 42.7.10
- 패치 버전: 42.7.11
- CVSSv3 점수: 7.5 (HIGH)
- 참조: https://github.com/pgjdbc/pgjdbc/security/advisories

## 변경 내용

- `langchain4j-ai-rag-postgre/pom.xml`: `<properties>`에 `<postgresql.version>42.7.11</postgresql.version>` 추가
  - egovframe-boot-starter-parent 5.0.0 BOM이 관리하는 42.7.3을 오버라이드

## 테스트 방법

```
mvn -f langchain4j-ai-rag-postgre/pom.xml dependency:tree -Dincludes=org.postgresql
```
출력에서 `42.7.11` 버전 확인.

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.0.x 브랜치용 후속 PR 필요 (별도 생성 예정)
- [x] 기존 동작에 영향 없음 (드라이버 API 호환)
- [x] 빌드 통과 확인 (`mvn clean package -DskipTests`)
