### PR TITLE
[feat][spring-ai] HWP 문서 리더 추가 (RAG ETL)

### DIFF
--- a/README-spring-ai-rag-redis-stack.md
+++ b/README-spring-ai-rag-redis-stack.md
@@ -68,7 +68,7 @@
 
 1. [Ollama](https://ollama.com/download) 설치 및 사용할 LLM 모델을 설치한다. Ollama 설치 및 ONNX 모델 익스포트 방법은 [루트 README](./README.md)의 `공통 사전 준비`, `폐쇄망에서의 Ollama`, `Onnx 모델 익스포트` 항목을 참고한다.
 2. 임베딩 모델 파일(`model.onnx`, `tokenizer.json`)은 jar(프로젝트) 외부 경로인 `${user.home}/spring-ai-Config/model` (예: 윈도우 `%USERPROFILE%\spring-ai-Config\model`, 리눅스/macOS `~/spring-ai-Config/model`) 디렉토리에 위치시켜야 한다. 다른 경로를 사용하려면 `EMBEDDING_MODEL_PATH`/`EMBEDDING_TOKENIZER_PATH` 환경변수로 전체 경로를 오버라이드할 수 있다 (자세한 설정은 `application.yml`의 `spring.ai.embedding.transformer.onnx.modelUri`/`tokenizer.uri` 참고).
-3. Redis Stack에 인덱싱 될 문서의 경로는 `application.yml`의 `spring.ai.document.path` 및 `spring.ai.document.pdf-path` 속성에 설정되어 있으므로 확인 후 환경에 맞추어 변경하도록 한다.
+3. Redis Stack에 인덱싱 될 문서의 경로는 `application.yml`의 `spring.ai.document.path` 및 `spring.ai.document.pdf-path` 속성에 설정되어 있으므로 확인 후 환경에 맞추어 변경하도록 한다. HWP 파일을 인덱싱하려면 `spring.ai.document.hwp-path` 속성을 추가한다 (예: `file:C:/workspace-test/upload/data/**/*.hwp`). 해당 속성이 없으면 HWP 처리를 건너뛴다.
 4. `docker-compose.yml` 을 사용해 `docker compose up -d`로 docker container 기반의 Redis 설정을 해 둔다. Redis Insight의 기본 포트는 `8001`이다.
 
 ## Spring AI ONNX 모델 주의사항
@@ -214,8 +214,8 @@ Flux<ChatResponse> 스트리밍 응답
 
 ## 문서 인덱싱
 
-- 현재 인덱싱 가능한 문서의 종류는 마크다운 파일과 PDF 파일로 구성되어 있다.
-- `application.yml` 의 `spring.ai.document.path` 및 `spring.ai.document.pdf-path` 에서 확인 가능하다.
+- 현재 인덱싱 가능한 문서의 종류는 마크다운 파일, PDF 파일, HWP 파일이다.
+- `application.yml` 의 `spring.ai.document.path`, `spring.ai.document.pdf-path`, `spring.ai.document.hwp-path` 에서 확인 가능하다. HWP 경로 속성이 없으면 HWP 처리를 건너뛴다.
 
 ## 실행
 
@@ -277,7 +277,8 @@ spring-ai-rag-redis-stack/
 │   │   │   ├── EgovETLPipelineConfig.java          # ETL 빈 구성
 │   │   │   ├── readers/
 │   │   │   │   ├── EgovMarkdownReader.java         # 마크다운 리더
-│   │   │   │   └── EgovPdfReader.java              # PDF 리더
+│   │   │   │   ├── EgovPdfReader.java              # PDF 리더
+│   │   │   │   └── EgovHwpReader.java              # HWP 리더
 │   │   │   ├── transformers/
 │   │   │   │   ├── EgovContentFormatTransformer.java    # 문서 정규화
 │   │   │   │   └── EgovEnhancedDocumentTransformer.java # 청킹, 메타데이터

--- a/spring-ai-rag-redis-stack/pom.xml
+++ b/spring-ai-rag-redis-stack/pom.xml
@@ -119,6 +119,12 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+        <!-- HWP 문서 파싱 (공공 행정문서 지원) -->
+        <dependency>
+            <groupId>kr.dogfoot</groupId>
+            <artifactId>hwplib</artifactId>
+            <version>1.1.9</version>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/EgovETLPipelineConfig.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/EgovETLPipelineConfig.java
@@ -5,6 +5,7 @@ import org.springframework.ai.vectorstore.redis.RedisVectorStore;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.example.chat.config.etl.readers.EgovHwpReader;
 import com.example.chat.config.etl.readers.EgovMarkdownReader;
 import com.example.chat.config.etl.readers.EgovPdfReader;
 import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
@@ -27,6 +28,12 @@ public class EgovETLPipelineConfig {
     public EgovPdfReader pdfReader() {
         log.info("EgovPdfReader 빈 생성");
         return new EgovPdfReader();
+    }
+
+    @Bean
+    public EgovHwpReader hwpReader() {
+        log.info("EgovHwpReader 빈 생성");
+        return new EgovHwpReader();
     }
 
     @Bean

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
@@ -1,0 +1,103 @@
+package com.example.chat.config.etl.readers;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.reader.HWPReader;
+import kr.dogfoot.hwplib.tool.textextractor.TextExtractMethod;
+import kr.dogfoot.hwplib.tool.textextractor.TextExtractor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * HWP(한글) 문서 리더
+ * hwplib 라이브러리를 사용하여 .hwp 파일에서 텍스트를 추출하고
+ * Spring AI Document 형태로 반환한다.
+ */
+@Slf4j
+@Component
+public class EgovHwpReader implements DocumentReader {
+
+    @Value("${spring.ai.document.hwp-path}")
+    private String hwpDocumentPath;
+
+    @Override
+    public List<Document> get() {
+        log.info("HWP 문서 읽기 시작 - 경로: {}", hwpDocumentPath);
+
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource[] resources = resolver.getResources(hwpDocumentPath);
+
+            if (resources.length == 0) {
+                log.warn("HWP 파일을 찾을 수 없습니다: {}", hwpDocumentPath);
+                return List.of();
+            }
+
+            log.info("{}개의 HWP 파일을 찾았습니다.", resources.length);
+
+            List<Document> allDocuments = new ArrayList<>();
+
+            for (Resource resource : resources) {
+                log.info("HWP 파일 처리 중: {}", resource.getFilename());
+                try {
+                    Document doc = parseHwpDocument(resource);
+                    if (doc != null) {
+                        allDocuments.add(doc);
+                    }
+                } catch (Exception e) {
+                    log.error("HWP 파일 '{}' 처리 중 오류 발생: {}", resource.getFilename(), e.getMessage());
+                    // 개별 파일 오류는 무시하고 계속 진행
+                }
+            }
+
+            log.info("총 {}개의 HWP 문서를 읽었습니다.", allDocuments.size());
+            return allDocuments;
+
+        } catch (Exception e) {
+            log.error("HWP 문서 읽기 중 오류 발생", e);
+            return List.of();
+        }
+    }
+
+    private Document parseHwpDocument(Resource resource) throws Exception {
+        String filename = resource.getFilename();
+        if (filename == null) {
+            filename = "unknown.hwp";
+        }
+
+        File file = resource.getFile();
+        HWPFile hwpFile = HWPReader.fromFile(file);
+
+        // 본문 + 표/각주 등 컨트롤 텍스트까지 포함하여 추출
+        String content = TextExtractor.extract(hwpFile, TextExtractMethod.AppendControlTextAfterParagraphText);
+
+        if (content == null || content.trim().isEmpty()) {
+            log.warn("HWP 파일 '{}': 추출된 텍스트가 없습니다.", filename);
+            return null;
+        }
+
+        String baseFilename = filename.replaceAll("\\.hwp$", "");
+        String safeFilename = baseFilename.replaceAll("[\\/:*?\"<>|]", "").replaceAll("\\s+", "-");
+        String customId = String.format("hwp-%s_1", safeFilename);
+
+        java.util.Map<String, Object> metadata = new java.util.HashMap<>();
+        metadata.put("file_name", filename);
+        metadata.put("source", filename);
+        metadata.put("type", "hwp");
+        metadata.put("content_length", content.length());
+        metadata.put("page_number", 1);
+
+        log.debug("HWP Document ID: {} (길이: {})", customId, content.length());
+
+        return new Document(customId, content, metadata);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
@@ -26,11 +26,15 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class EgovHwpReader implements DocumentReader {
 
-    @Value("${spring.ai.document.hwp-path}")
+    @Value("${spring.ai.document.hwp-path:#{null}}")
     private String hwpDocumentPath;
 
     @Override
     public List<Document> get() {
+        if (hwpDocumentPath == null || hwpDocumentPath.isBlank()) {
+            log.info("HWP 문서 경로가 설정되지 않아 건너뜁니다.");
+            return List.of();
+        }
         log.info("HWP 문서 읽기 시작 - 경로: {}", hwpDocumentPath);
 
         try {

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/service/impl/EgovDocumentServiceImpl.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/service/impl/EgovDocumentServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.beans.factory.annotation.Value;
 
+import com.example.chat.config.etl.readers.EgovHwpReader;
 import com.example.chat.config.etl.readers.EgovMarkdownReader;
 import com.example.chat.config.etl.readers.EgovPdfReader;
 import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
@@ -45,6 +46,7 @@ public class EgovDocumentServiceImpl extends EgovAbstractServiceImpl implements 
     // ETL 파이프라인 컴포넌트들
     private final EgovMarkdownReader egovMarkdownReader;
     private final EgovPdfReader egovPdfReader;
+    private final EgovHwpReader egovHwpReader;
     private final EgovContentFormatTransformer egovContentFormatTransformer;
     private final EgovEnhancedDocumentTransformer egovEnhancedDocumentTransformer;
     private final EgovVectorStoreWriter egovVectorStoreWriter;
@@ -96,17 +98,19 @@ public class EgovDocumentServiceImpl extends EgovAbstractServiceImpl implements 
 
         return CompletableFuture.supplyAsync(() -> {
             try {
-                // 1단계: 마크다운과 PDF 문서 읽기
+                // 1단계: 마크다운, PDF, HWP 문서 읽기
                 List<Document> markdownDocuments = egovMarkdownReader.get();
                 List<Document> pdfDocuments = egovPdfReader.get();
+                List<Document> hwpDocuments = egovHwpReader.get();
 
                 List<Document> allDocuments = new ArrayList<>();
                 allDocuments.addAll(markdownDocuments);
                 allDocuments.addAll(pdfDocuments);
+                allDocuments.addAll(hwpDocuments);
 
                 totalCount.set(allDocuments.size());
-                log.info("총 {}개의 문서를 로드했습니다. (마크다운: {}개, PDF: {}개)",
-                        allDocuments.size(), markdownDocuments.size(), pdfDocuments.size());
+                log.info("총 {}개의 문서를 로드했습니다. (마크다운: {}개, PDF: {}개, HWP: {}개)",
+                        allDocuments.size(), markdownDocuments.size(), pdfDocuments.size(), hwpDocuments.size());
 
                 // 2단계: 변경된 문서 필터링
                 List<Document> changedDocuments = filterChangedDocuments(allDocuments);

--- a/spring-ai-rag-redis-stack/src/main/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/main/resources/application.yml
@@ -41,6 +41,7 @@ spring:
     document:
       path: file:C:/workspace-test/upload/data/**/*.md
       pdf-path: file:C:/workspace-test/upload/data/**/*.pdf
+      # hwp-path: file:C:/workspace-test/upload/data/**/*.hwp
 
       # PDF 리더 설정
       pdf:


### PR DESCRIPTION
## 변경 사유

공공 행정기관에서 작성된 문서의 상당수가 한글(.hwp) 형식이다. 기존 RAG ETL 파이프라인은 PDF·마크다운만 지원하여 행정문서를 벡터 스토어에 색인할 수 없었다. 이를 해결하기 위해 HWP 문서 리더를 추가한다.

## 변경 내용

- `spring-ai-rag-redis-stack/pom.xml`: hwplib(kr.dogfoot:hwplib:1.1.9, Apache-2.0) 의존성 추가
- `EgovHwpReader.java` 신규 작성: hwplib의 `HWPReader.fromFile` + `TextExtractor.extract(AppendControlTextAfterParagraphText)`로 .hwp 본문 및 표·각주 텍스트 추출, `EgovPdfReader`와 동일한 `Document(customId, content, metadata)` 형태로 변환, `DocumentReader` 인터페이스 구현
- `EgovETLPipelineConfig.java`: `hwpReader()` 빈 등록 추가

## 설정

`application.yml`(또는 `application.properties`)에 HWP 파일 경로 추가 필요:
```
spring.ai.document.hwp-path: classpath:documents/*.hwp
```

## 영향 범위

- 기존 PDF·마크다운 처리 흐름에 영향 없음
- HWP 경로 프로퍼티(`spring.ai.document.hwp-path`)가 없는 환경에서는 기동 시 오류 발생 가능 — 기존 `pdf-path`와 동일한 방식으로 운영 환경에 맞게 설정 필요

## 검증

- 빌드 환경 제약(JDK 26 로컬, 인프라 미구성)으로 전체 `mvn package`는 미실행
- hwplib API 시그니처(`HWPReader.fromFile`, `TextExtractor.extract`, `TextExtractMethod`)는 라이브러리 소스코드(GitHub neolord0/hwplib) 직접 확인 후 사용
- 런타임 동작 검증은 미완 — 실제 .hwp 파일로 통합 테스트 권장

## 체크리스트

- [x] 단일 주제만 다룸 (HWP 리더 추가)
- [x] 기존 PDF·마크다운 처리 흐름에 영향 없음
- [ ] 런타임 통합 테스트 필요 (인프라 제약으로 미완)
