### PR TITLE
[feat][langchain4j] HWP 문서 리더 추가 (RAG ETL)

### DIFF
--- a/README-langchain4j-ai-rag-postgre.md
+++ b/README-langchain4j-ai-rag-postgre.md
@@ -175,13 +175,16 @@ Flux<String> 스트리밍 응답
 
 ## 문서 인덱싱
 
-- 현재 인덱싱 가능한 문서의 종류는 마크다운 파일과 PDF 파일로 구성되어 있다.
-- `application.yml`의 문서 경로 관련 속성에서 확인 가능하다.
+- 현재 인덱싱 가능한 문서의 종류는 마크다운 파일, PDF 파일, HWP(한글) 파일이다.
+- `application.yml`의 문서 경로 관련 속성(`document.path`, `document.pdf-path`, `document.hwp-path`)에서 경로를 지정한다.
+- HWP 인덱싱은 경로 기반으로만 지원된다. `document.hwp-path` 속성이 설정되지 않은 경우 HWP 처리는 건너뛰며 앱 기동에는 영향이 없다.
+  - 활성화 예시: `document.hwp-path: file:C:/workspace-test/upload/data/**/*.hwp`
+- 파일 업로드(웹 UI)는 마크다운(.md) 파일만 지원한다. PDF 및 HWP는 서버 측 경로에 파일을 직접 배치한 뒤 재인덱싱으로 처리한다.
 
 ## 실행
 
 1. 애플리케이션을 실행하면 도큐먼트 생성 및 임베딩, 적재가 실행된다. 수동으로 실행하려면 메인 화면의 `문서 재인덱싱` 버튼을 클릭한다.
-2. `문서 업로드` 버튼으로 Markdown/PDF 파일을 업로드할 수 있다.
+2. `문서 업로드` 버튼으로 Markdown(.md) 파일을 업로드할 수 있다. PDF 및 HWP 파일은 서버 경로에 직접 배치 후 재인덱싱으로 처리한다.
 3. 메인 화면의 `RAG 채팅 모드`, `일반 채팅 모드` 버튼으로 RAG가 적용된 질의 답변, 일반적인 질의 답변을 받을 수 있다.
 4. 기본 접속 주소: `http://localhost:8080`
 
@@ -236,7 +239,8 @@ langchain4j-ai-rag-postgre/
 │   │   └── etl/                     # 문서 ETL 파이프라인
 │   │       ├── readers/
 │   │       │   ├── EgovMarkdownReader.java   # 마크다운 문서 리더
-│   │       │   └── EgovPdfReader.java       # PDF 문서 리더
+│   │       │   ├── EgovPdfReader.java        # PDF 문서 리더
+│   │       │   └── EgovHwpReader.java        # HWP 문서 리더
 │   │       ├── transformers/
 │   │       │   ├── EgovContentFormatTransformer.java   # 콘텐츠 포맷 변환
 │   │       │   └── EgovEnhancedDocumentTransformer.java # 문서 변환

--- a/langchain4j-ai-rag-postgre/pom.xml
+++ b/langchain4j-ai-rag-postgre/pom.xml
@@ -142,6 +142,12 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
+        <!-- HWP 문서 파싱 (공공 행정문서 지원) -->
+        <dependency>
+            <groupId>kr.dogfoot</groupId>
+            <artifactId>hwplib</artifactId>
+            <version>1.1.9</version>
+        </dependency>
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
@@ -1,0 +1,104 @@
+package com.example.chat.config.etl.readers;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.Metadata;
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.reader.HWPReader;
+import kr.dogfoot.hwplib.tool.textextractor.TextExtractMethod;
+import kr.dogfoot.hwplib.tool.textextractor.TextExtractor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * HWP(한글) 문서 로더
+ * hwplib 라이브러리를 사용하여 .hwp 파일에서 텍스트를 추출하고
+ * LangChain4j Document 형태로 반환한다.
+ */
+@Slf4j
+@Component
+public class EgovHwpReader {
+
+    @Value("${document.hwp-path}")
+    private String hwpDocumentPath;
+
+    /**
+     * HWP 문서 로드
+     */
+    public List<Document> read() {
+        log.info("HWP 문서 읽기 시작 - 경로: {}", hwpDocumentPath);
+
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource[] resources = resolver.getResources(hwpDocumentPath);
+
+            if (resources.length == 0) {
+                log.warn("HWP 파일을 찾을 수 없습니다: {}", hwpDocumentPath);
+                return List.of();
+            }
+
+            log.info("{}개의 HWP 파일을 찾았습니다.", resources.length);
+
+            List<Document> allDocuments = new ArrayList<>();
+
+            for (Resource resource : resources) {
+                log.info("HWP 파일 처리 중: {}", resource.getFilename());
+                try {
+                    Document doc = parseHwpDocument(resource);
+                    if (doc != null) {
+                        allDocuments.add(doc);
+                    }
+                } catch (Exception e) {
+                    log.error("HWP 파일 '{}' 처리 중 오류 발생: {}", resource.getFilename(), e.getMessage());
+                    // 개별 파일 오류는 무시하고 계속 진행
+                }
+            }
+
+            log.info("총 {}개의 HWP 문서를 읽었습니다.", allDocuments.size());
+            return allDocuments;
+
+        } catch (Exception e) {
+            log.error("HWP 문서 읽기 중 오류 발생", e);
+            return List.of();
+        }
+    }
+
+    private Document parseHwpDocument(Resource resource) throws Exception {
+        String filename = resource.getFilename();
+        if (filename == null) {
+            filename = "unknown.hwp";
+        }
+
+        File file = resource.getFile();
+        HWPFile hwpFile = HWPReader.fromFile(file);
+
+        // 본문 + 표/각주 등 컨트롤 텍스트까지 포함하여 추출
+        String content = TextExtractor.extract(hwpFile, TextExtractMethod.AppendControlTextAfterParagraphText);
+
+        if (content == null || content.trim().isEmpty()) {
+            log.warn("HWP 파일 '{}': 추출된 텍스트가 없습니다.", filename);
+            return null;
+        }
+
+        String baseFilename = filename.replaceAll("\\.hwp$", "");
+        String safeFilename = baseFilename.replaceAll("[\\/:*?\"<>|]", "").replaceAll("\\s+", "-");
+        String customId = String.format("hwp-%s_1", safeFilename);
+
+        Metadata metadata = Metadata.from("id", customId);
+        metadata.put("file_name", filename);
+        metadata.put("source", filename);
+        metadata.put("type", "hwp");
+        metadata.put("content_length", String.valueOf(content.length()));
+        metadata.put("page_number", "1");
+
+        log.debug("HWP Document ID: {} (길이: {})", customId, content.length());
+
+        return Document.from(content, metadata);
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
@@ -25,13 +25,18 @@ import java.util.List;
 @Component
 public class EgovHwpReader {
 
-    @Value("${document.hwp-path}")
+    @Value("${document.hwp-path:#{null}}")
     private String hwpDocumentPath;
 
     /**
      * HWP 문서 로드
      */
     public List<Document> read() {
+        if (hwpDocumentPath == null || hwpDocumentPath.isBlank()) {
+            log.info("HWP 문서 경로가 설정되지 않아 건너뜁니다.");
+            return List.of();
+        }
+
         log.info("HWP 문서 읽기 시작 - 경로: {}", hwpDocumentPath);
 
         try {

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/service/impl/EgovDocumentServiceImpl.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/service/impl/EgovDocumentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.chat.service.impl;
 
+import com.example.chat.config.etl.readers.EgovHwpReader;
 import com.example.chat.config.etl.readers.EgovMarkdownReader;
 import com.example.chat.config.etl.readers.EgovPdfReader;
 import com.example.chat.config.etl.transformers.EgovContentFormatTransformer;
@@ -39,6 +40,7 @@ public class EgovDocumentServiceImpl extends EgovAbstractServiceImpl implements 
     // ETL 파이프라인 컴포넌트들
     private final EgovMarkdownReader egovMarkdownReader;
     private final EgovPdfReader egovPdfReader;
+    private final EgovHwpReader egovHwpReader;
     private final EgovContentFormatTransformer egovContentFormatTransformer;
     private final EgovEnhancedDocumentTransformer egovEnhancedDocumentTransformer;
     private final EgovVectorStoreWriter egovVectorStoreWriter;
@@ -90,17 +92,19 @@ public class EgovDocumentServiceImpl extends EgovAbstractServiceImpl implements 
 
         return CompletableFuture.supplyAsync(() -> {
             try {
-                // 1단계: 마크다운과 PDF 문서 읽기
+                // 1단계: 마크다운, PDF, HWP 문서 읽기
                 List<Document> markdownDocuments = egovMarkdownReader.read();
                 List<Document> pdfDocuments = egovPdfReader.read();
+                List<Document> hwpDocuments = egovHwpReader.read();
 
                 List<Document> allDocuments = new ArrayList<>();
                 allDocuments.addAll(markdownDocuments);
                 allDocuments.addAll(pdfDocuments);
+                allDocuments.addAll(hwpDocuments);
 
                 totalCount.set(allDocuments.size());
-                log.info("총 {}개의 문서를 로드했습니다. (마크다운: {}개, PDF: {}개)",
-                        allDocuments.size(), markdownDocuments.size(), pdfDocuments.size());
+                log.info("총 {}개의 문서를 로드했습니다. (마크다운: {}개, PDF: {}개, HWP: {}개)",
+                        allDocuments.size(), markdownDocuments.size(), pdfDocuments.size(), hwpDocuments.size());
 
                 // 2단계: 변경된 문서 필터링
                 List<Document> changedDocuments = filterChangedDocuments(allDocuments);

--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -66,6 +66,7 @@ document:
   # 문서 경로 설정
   path: file:C:/workspace-test/upload/data/**/*.md
   pdf-path: file:C:/workspace-test/upload/data/**/*.pdf
+  # hwp-path: file:C:/workspace-test/upload/data/**/*.hwp
 
   # PDF 리더 설정
   pdf:


### PR DESCRIPTION
## 변경 사유

공공 행정기관에서 작성된 문서의 상당수가 한글(.hwp) 형식이다. 기존 RAG ETL 파이프라인은 PDF·마크다운만 지원하여 행정문서를 벡터 스토어에 색인할 수 없었다. 이를 해결하기 위해 HWP 문서 리더를 추가한다.

## 변경 내용

- `langchain4j-ai-rag-postgre/pom.xml`: hwplib(kr.dogfoot:hwplib:1.1.9, Apache-2.0) 의존성 추가
- `EgovHwpReader.java` 신규 작성: hwplib의 `HWPReader.fromFile` + `TextExtractor.extract(AppendControlTextAfterParagraphText)`로 .hwp 본문 및 표·각주 텍스트 추출, `EgovPdfReader`와 동일한 `Document.from(content, metadata)` 형태로 변환

## 설정

`application.yml`(또는 `application.properties`)에 HWP 파일 경로 추가 필요:
```
document.hwp-path: classpath:documents/*.hwp
```

## 영향 범위

- 기존 PDF·마크다운 처리 흐름에 영향 없음
- HWP 경로 프로퍼티(`document.hwp-path`)가 없는 환경에서는 기동 시 오류 발생 가능 — 기존 `document.pdf-path`와 동일한 방식으로 운영 환경에 맞게 설정 필요

## 검증

- 빌드 환경 제약(JDK 26 로컬, 인프라 미구성)으로 전체 `mvn package`는 미실행
- hwplib API 시그니처(`HWPReader.fromFile`, `TextExtractor.extract`, `TextExtractMethod`)는 라이브러리 소스코드(GitHub neolord0/hwplib) 직접 확인 후 사용
- 런타임 동작 검증은 미완 — 실제 .hwp 파일로 통합 테스트 권장

## 체크리스트

- [x] 단일 주제만 다룸 (HWP 리더 추가)
- [x] 기존 PDF·마크다운 처리 흐름에 영향 없음
- [ ] 런타임 통합 테스트 필요 (인프라 제약으로 미완)
