### PR TITLE
feat: 표준프레임워크 RAG를 MCP 서버로 노출 (Spring AI MCP Server)

### DIFF
--- a/README-spring-ai-rag-redis-stack.md
+++ b/README-spring-ai-rag-redis-stack.md
@@ -423,12 +423,59 @@ redis-cli ping
 java -Xmx4g -jar target/spring-ai-rag-redis-stack-1.0.0.jar
 ```
 
+## MCP(Model Context Protocol) 서버
+
+이 애플리케이션은 표준프레임워크 RAG 기능을 **MCP 도구**로 노출한다. Claude Desktop, IDE 에이전트, `egovframe-vscode-initializr` 등 MCP 클라이언트가 표준프레임워크 지식베이스를 표준 도구 호출로 사용할 수 있다.
+
+Spring AI의 MCP Server(WebMVC SSE)를 사용하며, 별도 프로세스 없이 기존 RAG/문서/모델 서비스를 그대로 재사용한다.
+
+### 제공 도구
+
+| 도구 | 설명 |
+| --- | --- |
+| `egov_rag_ask` | 지식베이스를 근거로 질문에 답변(RAG 증강 질의) |
+| `egov_doc_search` | 질문과 유사한 문서 청크를 검색(검색 전용, 답변 생성 없음) |
+| `egov_index_status` | 지식베이스 인덱싱 현황 조회 |
+| `egov_models` | 사용 가능한 LLM(Ollama) 모델 목록 조회 |
+
+### 설정
+
+`application.yml`:
+
+```yaml
+spring:
+  ai:
+    mcp:
+      server:
+        name: egov-rag-mcp-server
+        version: 1.0.0
+        type: SYNC
+```
+
+애플리케이션 기동 시 WebMVC 기반 SSE 엔드포인트(`/sse`)로 MCP 서버가 노출된다.
+
+### MCP 클라이언트 연결 예시
+
+```json
+{
+  "mcpServers": {
+    "egov-rag": {
+      "url": "http://localhost:8080/sse"
+    }
+  }
+}
+```
+
+> 도구가 LLM 답변을 생성하려면 Ollama, 검색을 수행하려면 Redis Stack과 인덱싱된 문서가 필요하다(본문 실행 절차 참조).
+
 ## 참고 자료
 
 - [Spring AI 공식 문서](https://docs.spring.io/spring-ai/reference/)
 - [Spring AI Ollama](https://docs.spring.io/spring-ai/reference/api/chat/ollama-chat.html)
 - [Spring AI RAG](https://docs.spring.io/spring-ai/reference/api/retrieval-augmented-generation.html)
 - [Spring AI Vector Store - Redis](https://docs.spring.io/spring-ai/reference/api/vectordbs/redis.html)
+- [Spring AI MCP Server](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
 - [Redis Stack 문서](https://redis.io/docs/stack/)
 - [Ollama 문서](https://github.com/ollama/ollama)
 - [ONNX Runtime 문서](https://onnxruntime.ai/)

--- a/spring-ai-rag-redis-stack/pom.xml
+++ b/spring-ai-rag-redis-stack/pom.xml
@@ -107,6 +107,13 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+        <!-- MCP(Model Context Protocol) 서버 - 표준프레임워크 RAG를 MCP 도구로 노출 (WebMVC SSE) -->
+        <!-- 버전은 부모(egovframe-boot-starter-parent)가 관리하는 spring.ai.version과 동일하게 명시 -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
+            <version>${spring.ai.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovMcpServerConfig.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovMcpServerConfig.java
@@ -1,0 +1,30 @@
+package com.example.chat.config;
+
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.example.chat.tool.EgovRagToolService;
+
+/**
+ * MCP(Model Context Protocol) 서버 설정.
+ *
+ * <p>{@link EgovRagToolService}의 {@code @Tool} 메서드들을 MCP 도구로 등록한다.
+ * Spring AI MCP Server 스타터가 이 {@link ToolCallbackProvider}를 감지하여 MCP 클라이언트에
+ * 도구 목록(egov_rag_ask, egov_doc_search, egov_index_status, egov_models)을 노출한다.</p>
+ *
+ * <p>전송 방식은 {@code application.yml}의 {@code spring.ai.mcp.server} 설정을 따른다
+ * (기본: WebMVC 기반 SSE).</p>
+ */
+@Configuration
+public class EgovMcpServerConfig {
+
+    @Bean
+    public ToolCallbackProvider egovRagTools(EgovRagToolService egovRagToolService) {
+        return MethodToolCallbackProvider.builder()
+                .toolObjects(egovRagToolService)
+                .build();
+    }
+
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/tool/EgovRagToolService.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/tool/EgovRagToolService.java
@@ -1,0 +1,114 @@
+package com.example.chat.tool;
+
+import java.util.List;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+import org.springframework.ai.rag.retrieval.search.VectorStoreDocumentRetriever;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Service;
+
+import com.example.chat.config.EgovRagConfig;
+import com.example.chat.response.DocumentStatusResponse;
+import com.example.chat.service.EgovDocumentService;
+import com.example.chat.service.EgovOllamaModelService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 표준프레임워크 RAG 기능을 MCP(Model Context Protocol) 도구로 노출하는 서비스.
+ *
+ * <p>외부 AI 클라이언트(Claude Desktop, IDE 에이전트, egovframe-vscode-initializr 등)가
+ * 표준프레임워크 지식베이스를 표준 도구 호출로 사용할 수 있도록, 기존 RAG/문서/모델 서비스를
+ * {@link Tool} 메서드로 래핑한다. 각 메서드는 동기 응답(String)을 반환하여 MCP 도구 규약에 맞춘다.</p>
+ *
+ * <p>이 클래스는 기존 빈({@link ChatClient}, {@link VectorStoreDocumentRetriever},
+ * {@link EgovDocumentService}, {@link EgovOllamaModelService})을 재사용하며 별도 상태를 두지 않는다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EgovRagToolService {
+
+    private final ChatClient chatClient;
+    private final VectorStoreDocumentRetriever documentRetriever;
+    private final EgovDocumentService documentService;
+    private final EgovOllamaModelService modelService;
+
+    /**
+     * 표준프레임워크 지식베이스를 근거로 질문에 답한다(RAG 증강 질의).
+     */
+    @Tool(name = "egov_rag_ask",
+            description = "전자정부 표준프레임워크(eGovFrame) 지식베이스(인덱싱된 문서)를 검색해 근거로 삼아 질문에 한국어로 답한다. "
+                    + "표준프레임워크 실행환경/공통컴포넌트/사용법 등 프레임워크 관련 질문에 사용한다.")
+    public String egovRagAsk(
+            @ToolParam(description = "표준프레임워크에 대한 자연어 질문") String question) {
+        log.info("[MCP] egov_rag_ask: {}", question);
+        Advisor ragAdvisor = EgovRagConfig.createRagAdvisor(documentRetriever);
+        String answer = chatClient.prompt()
+                .user(question)
+                .advisors(ragAdvisor)
+                .call()
+                .content();
+        return answer != null ? answer : "(빈 응답)";
+    }
+
+    /**
+     * 질문과 의미적으로 유사한 표준프레임워크 문서 청크를 검색해 반환한다(검색 전용, 답변 생성 없음).
+     */
+    @Tool(name = "egov_doc_search",
+            description = "전자정부 표준프레임워크 지식베이스에서 질문과 의미적으로 가장 유사한 문서 청크를 검색해 원문을 반환한다. "
+                    + "LLM 답변 없이 근거 원문만 필요할 때(에이전트 grounding, 인용) 사용한다.")
+    public String egovDocSearch(
+            @ToolParam(description = "검색할 질의문") String query) {
+        log.info("[MCP] egov_doc_search: {}", query);
+        List<Document> documents = documentRetriever.retrieve(new Query(query));
+        if (documents.isEmpty()) {
+            return "검색 결과 없음(유사도 임계값 미달 또는 관련 문서 없음).";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("검색된 문서 청크 ").append(documents.size()).append("건:\n\n");
+        for (int i = 0; i < documents.size(); i++) {
+            Document doc = documents.get(i);
+            Object source = doc.getMetadata().get("source");
+            sb.append("## #").append(i + 1);
+            if (source != null) {
+                sb.append(" (").append(source).append(")");
+            }
+            sb.append("\n").append(doc.getText()).append("\n\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 지식베이스 인덱싱 현황(처리/문서 수 등)을 반환한다.
+     */
+    @Tool(name = "egov_index_status",
+            description = "표준프레임워크 지식베이스의 인덱싱 현황(처리 중 여부, 처리된 청크 수, 총 문서 수, 변경 문서 수, 문서 보유 여부)을 반환한다.")
+    public String egovIndexStatus() {
+        log.info("[MCP] egov_index_status");
+        DocumentStatusResponse s = documentService.getStatusResponse();
+        return String.format(
+                "처리중=%b, 처리된청크=%d, 총문서=%d, 변경문서=%d, 문서보유=%b",
+                s.processing(), s.processedCount(), s.totalCount(), s.changedCount(), s.hasDocuments());
+    }
+
+    /**
+     * 사용 가능한 LLM(Ollama) 모델 목록을 반환한다.
+     */
+    @Tool(name = "egov_models",
+            description = "현재 사용 가능한 LLM(Ollama) 모델 목록과 가용 여부를 반환한다. egov_rag_ask 호출 시 어떤 모델을 쓸 수 있는지 확인할 때 사용한다.")
+    public String egovModels() {
+        log.info("[MCP] egov_models");
+        if (!modelService.isOllamaAvailable()) {
+            return "Ollama 사용 불가(서비스 미기동 또는 연결 실패).";
+        }
+        List<String> models = modelService.getInstalledModels();
+        return models.isEmpty() ? "설치된 모델 없음." : "사용 가능 모델: " + String.join(", ", models);
+    }
+
+}

--- a/spring-ai-rag-redis-stack/src/main/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/main/resources/application.yml
@@ -11,6 +11,14 @@ spring:
         options:
           temperature: 0.4
 
+    # MCP(Model Context Protocol) 서버 - 표준프레임워크 RAG를 MCP 도구로 노출
+    # (WebMVC SSE 전송. 도구: egov_rag_ask / egov_doc_search / egov_index_status / egov_models)
+    mcp:
+      server:
+        name: egov-rag-mcp-server
+        version: 1.0.0
+        type: SYNC
+
     # 로컬 ONNX 모델 사용 설정
     model:
       embedding: transformers


### PR DESCRIPTION
## 개요

`spring-ai-rag-redis-stack`의 RAG 기능을 **MCP(Model Context Protocol) 도구**로 노출합니다. Claude Desktop, IDE 에이전트, `egovframe-vscode-initializr` 등 MCP 클라이언트가 표준프레임워크 지식베이스를 표준 도구 호출로 사용할 수 있습니다.

제안 이슈 #34 의 PoC입니다.

## 변경 내용

| 파일 | 내용 |
| --- | --- |
| `tool/EgovRagToolService.java` | `@Tool` 4종(`egov_rag_ask`/`egov_doc_search`/`egov_index_status`/`egov_models`). 기존 빈 재사용, 상태 없음 |
| `config/EgovMcpServerConfig.java` | `ToolCallbackProvider`(`MethodToolCallbackProvider`) 빈 등록 |
| `pom.xml` | `spring-ai-starter-mcp-server-webmvc` 의존성(버전은 부모가 관리하는 `spring.ai.version`과 동일하게 명시) |
| `application.yml` | `spring.ai.mcp.server` 설정(WebMVC SSE) |
| `README-spring-ai-rag-redis-stack.md` | MCP 섹션(도구 목록/설정/클라이언트 연결 예시) |

## 제공 도구

| 도구 | 매핑 | 용도 |
| --- | --- | --- |
| `egov_rag_ask` | `ChatClient` + RAG Advisor | 지식베이스 근거 답변 |
| `egov_doc_search` | `VectorStoreDocumentRetriever` | 검색 전용 문서 청크 반환 |
| `egov_index_status` | `EgovDocumentService` | 인덱싱 현황 |
| `egov_models` | `EgovOllamaModelService` | 가용 LLM 모델 목록 |

## 설계

- 기존 RAG/문서/모델 서비스를 그대로 재사용하며, 기존 코드는 변경하지 않는 추가 구성입니다.
- `@Tool` 메서드는 동기 응답(String)을 반환하여 MCP 도구 규약에 맞춥니다.

## 검증

- `mvn compile` 통과 — MCP 스타터 의존성 해석 및 `@Tool`/`ToolCallbackProvider`/`ChatClient`/`DocumentRetriever` API 정합성 확인.
- 기존 코드 무변경(추가 파일 + 설정)으로 회귀 위험이 낮습니다.
- 전체 런타임(도구의 실제 응답 생성/검색)은 Ollama 및 Redis Stack + 인덱싱된 문서가 필요합니다(README의 실행 절차 참조).

## 참고

- [Spring AI MCP Server](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html)
- [Model Context Protocol](https://modelcontextprotocol.io/)