### PR TITLE
[fix][spring-ai] 스트리밍 세션 컨텍스트(ThreadLocal) 정리가 reactor 스레드에서 실행되어 누락되는 문제 수정

### DIFF
--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/controller/EgovOllamaChatController.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/controller/EgovOllamaChatController.java
@@ -97,12 +97,13 @@ public class EgovOllamaChatController {
         String currentSessionId = SessionContext.getCurrentSessionId();
         log.debug("현재 세션 컨텍스트 설정됨: {}", currentSessionId);
 
-        return egovSessionAwareChatService.streamRagResponse(message, model)
-                .doFinally(signalType -> {
-                    // 스트리밍 완료 후 컨텍스트 정리
-                    SessionContext.clear();
-                    log.debug("SessionContext 정리 완료 - 세션: {}, 신호: {}", sessionId, signalType);
-                });
+        // 서비스가 sessionId를 동기적으로 읽어 처리하므로(advisor 파라미터로 값 전달),
+        // 스트림을 반환하기 전 요청 스레드에서 ThreadLocal 세션 컨텍스트를 정리한다.
+        // 이전에는 doFinally 안에서 정리했으나, doFinally는 reactor 스레드에서 실행되어
+        // 요청(서블릿) 스레드의 ThreadLocal이 정리되지 않고 워커 스레드에 남는 문제가 있었다.
+        Flux<ChatResponse> response = egovSessionAwareChatService.streamRagResponse(message, model);
+        SessionContext.clear();
+        return response;
     }
 
     /**
@@ -140,12 +141,12 @@ public class EgovOllamaChatController {
         }
 
         // 일반 스트리밍 응답 생성 (RAG 없이)
-        return egovSessionAwareChatService.streamSimpleResponse(message, model)
-                .doFinally(signalType -> {
-                    // 스트리밍 완료 후 컨텍스트 정리
-                    SessionContext.clear();
-                    log.debug("SessionContext 정리 완료 - 세션: {}, 신호: {}", sessionId, signalType);
-                });
+        // 서비스가 sessionId를 동기적으로 읽어 처리하므로, 스트림을 반환하기 전
+        // 요청 스레드에서 ThreadLocal 세션 컨텍스트를 정리한다.(doFinally는 reactor
+        // 스레드에서 실행되어 요청 스레드의 ThreadLocal을 정리하지 못했다.)
+        Flux<ChatResponse> response = egovSessionAwareChatService.streamSimpleResponse(message, model);
+        SessionContext.clear();
+        return response;
     }
 
     // ===== PromptEngineeringUtil 활용 테스트 엔드포인트들 =====

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/controller/EgovOllamaChatControllerSessionCleanupTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/controller/EgovOllamaChatControllerSessionCleanupTest.java
@@ -1,0 +1,77 @@
+package com.example.chat.controller;
+
+import com.example.chat.context.SessionContext;
+import com.example.chat.service.EgovChatSessionService;
+import com.example.chat.service.EgovSessionAwareChatService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.ollama.OllamaChatModel;
+import reactor.core.publisher.Flux;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * SessionContext(ThreadLocal) 정리가 요청 스레드에서 이루어지는지 검증한다.
+ *
+ * <p>스트리밍 엔드포인트는 {@code Flux}를 반환하며, 세션 ID는 서비스가 동기적으로 읽어
+ * 캡처한다. 이전 구현은 {@code Flux.doFinally(...)} 안에서 {@code SessionContext.clear()}를
+ * 호출했는데, doFinally 콜백은 스트림을 구독·종료시키는 reactor 스레드에서 실행되므로
+ * 요청(서블릿) 스레드에 설정된 ThreadLocal이 정리되지 않고 워커 스레드에 남았다.
+ * 본 테스트는 컨트롤러 메서드 반환(=서비스의 동기 캡처 완료) 직후 요청 스레드의 세션
+ * 컨텍스트가 비워지는지 확인한다. 따라서 reactor 스레드 구독 없이도 결정적으로 동작한다.
+ */
+class EgovOllamaChatControllerSessionCleanupTest {
+
+    private final OllamaChatModel chatModel = mock(OllamaChatModel.class);
+    private final EgovSessionAwareChatService chatService = mock(EgovSessionAwareChatService.class);
+    private final EgovChatSessionService sessionService = mock(EgovChatSessionService.class);
+    private final EgovOllamaChatController controller =
+            new EgovOllamaChatController(chatModel, chatService, sessionService);
+
+    @AfterEach
+    void tearDown() {
+        SessionContext.clear();
+    }
+
+    @Test
+    @DisplayName("유효 세션으로 RAG 스트림 요청 후 요청 스레드의 세션 컨텍스트가 정리된다")
+    void clearsSessionContextOnRequestThreadAfterRagStream() {
+        when(sessionService.sessionExists("s-1")).thenReturn(true);
+        when(sessionService.getSessionMessages("s-1")).thenReturn(Collections.emptyList());
+        when(sessionService.generateSessionTitle(anyString())).thenReturn("title");
+        when(chatService.streamRagResponse(anyString(), any())).thenReturn(Flux.<ChatResponse>empty());
+
+        controller.streamRagResponse("hello", null, "s-1");
+
+        // 정리되면 ThreadLocal이 비어 기본 세션 ID가 반환된다.
+        // 정리되지 않았다면(버그) "s-1"이 남아 단언이 실패한다.
+        assertThat(SessionContext.getCurrentSessionId())
+                .isEqualTo(ChatMemory.DEFAULT_CONVERSATION_ID);
+        verify(sessionService).sessionExists("s-1");
+    }
+
+    @Test
+    @DisplayName("유효 세션으로 일반 스트림 요청 후 요청 스레드의 세션 컨텍스트가 정리된다")
+    void clearsSessionContextOnRequestThreadAfterSimpleStream() {
+        when(sessionService.sessionExists("s-2")).thenReturn(true);
+        when(sessionService.getSessionMessages("s-2")).thenReturn(Collections.emptyList());
+        when(sessionService.generateSessionTitle(anyString())).thenReturn("title");
+        when(chatService.streamSimpleResponse(anyString(), any())).thenReturn(Flux.<ChatResponse>empty());
+
+        controller.streamSimpleResponse("hi", null, "s-2");
+
+        assertThat(SessionContext.getCurrentSessionId())
+                .isEqualTo(ChatMemory.DEFAULT_CONVERSATION_ID);
+        verify(sessionService).sessionExists("s-2");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

스트리밍 채팅 엔드포인트(`/ai/rag/stream`, `/ai/simple/stream`)에서 세션 컨텍스트(`SessionContext`, `ThreadLocal`) 정리가 실제로는 동작하지 않습니다.

세션 ID는 요청(서블릿) 스레드에서 `SessionContext.setCurrentSessionId(...)`로 설정합니다. 정리는 반환 `Flux`의 `doFinally(...)` 안에서 `SessionContext.clear()`로 했는데, `doFinally`는 스트림을 구독·종료하는 reactor 스레드에서 실행됩니다. 이 프로젝트는 reactor context-propagation을 켜지 않아 ThreadLocal이 reactor 스레드로 넘어가지 않습니다. 결국 `clear()`가 요청 스레드가 아닌 다른 스레드에서 불려서 요청 스레드의 ThreadLocal은 그대로 남고, 세션 ID가 톰캣 워커 스레드에 잔존합니다.

세션 ID는 서비스가 메서드 진입 시 동기적으로 읽어 advisor 파라미터로 넘기므로, 스트림을 반환하기 전에 요청 스레드에서 `SessionContext.clear()`를 호출하도록 바꿨습니다. reactor 스레드에서 돌던 `doFinally` 정리는 제거했습니다. 스트리밍 중 reactor 스레드는 어차피 ThreadLocal을 못 보기 때문에 정리 시점을 앞당겨도 동작은 그대로입니다.

변경 파일: `EgovOllamaChatController.java`.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovOllamaChatControllerSessionCleanupTest`를 추가했습니다. 스트리밍 메서드를 호출한 뒤 요청 스레드의 세션 컨텍스트가 정리됐는지 확인합니다. 이 결함은 요청 스레드의 ThreadLocal이 정리되지 않고 워커 스레드에 남는 문제라 화면 조작으로는 드러나지 않고, 단위 테스트의 스레드 단언으로 확인됩니다. 고치기 전에는 `expected "default" but was "s-1"`로 실패하고, 고친 뒤 통과합니다.

## 테스트 브라우저 Test Browser

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음.
