### PR TITLE
test: 응답 정리·문서 해시 유틸 단위테스트 추가 (spring-ai)

### DIFF
--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovDocumentHashUtilTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovDocumentHashUtilTest.java
@@ -1,0 +1,51 @@
+package com.example.chat.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovDocumentHashUtil} 단위테스트.
+ * 문서 내용의 MD5 해시 계산 동작을 검증한다.
+ */
+class EgovDocumentHashUtilTest {
+
+    @Test
+    @DisplayName("null/빈 문자열은 빈 문자열을 반환한다")
+    void nullOrEmptyReturnsEmpty() {
+        assertEquals("", EgovDocumentHashUtil.calculateHash(null));
+        assertEquals("", EgovDocumentHashUtil.calculateHash(""));
+    }
+
+    @Test
+    @DisplayName("알려진 입력에 대해 알려진 MD5 해시를 반환한다")
+    void knownMd5() {
+        // MD5("test") = 098f6bcd4621d373cade4e832627b4f6
+        assertEquals("098f6bcd4621d373cade4e832627b4f6", EgovDocumentHashUtil.calculateHash("test"));
+    }
+
+    @Test
+    @DisplayName("동일 입력은 항상 동일 해시를 반환한다(결정적)")
+    void deterministic() {
+        String content = "전자정부 표준프레임워크 RAG 문서";
+        assertEquals(EgovDocumentHashUtil.calculateHash(content), EgovDocumentHashUtil.calculateHash(content));
+    }
+
+    @Test
+    @DisplayName("다른 입력은 다른 해시를 반환한다")
+    void differentInputDifferentHash() {
+        assertNotEquals(
+            EgovDocumentHashUtil.calculateHash("문서 A"),
+            EgovDocumentHashUtil.calculateHash("문서 B"));
+    }
+
+    @Test
+    @DisplayName("MD5 해시는 32자리 16진수 문자열이다")
+    void hashLengthAndFormat() {
+        String hash = EgovDocumentHashUtil.calculateHash("한글 UTF-8 콘텐츠");
+        assertEquals(32, hash.length());
+        org.junit.jupiter.api.Assertions.assertTrue(hash.matches("[0-9a-f]{32}"));
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovResponseCleanerUtilTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovResponseCleanerUtilTest.java
@@ -1,0 +1,69 @@
+package com.example.chat.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovResponseCleanerUtil} 단위테스트.
+ * AI 응답에서 think 태그 제거 및 JSON 추출 동작을 검증한다.
+ */
+class EgovResponseCleanerUtilTest {
+
+    @Test
+    @DisplayName("null 입력은 null 그대로 반환한다")
+    void nullInput() {
+        assertNull(EgovResponseCleanerUtil.cleanResponse(null));
+    }
+
+    @Test
+    @DisplayName("공백만 있는 입력은 원본 그대로 반환한다")
+    void blankInput() {
+        assertEquals("   ", EgovResponseCleanerUtil.cleanResponse("   "));
+        assertEquals("", EgovResponseCleanerUtil.cleanResponse(""));
+    }
+
+    @Test
+    @DisplayName("think 태그와 그 내용을 제거하고 JSON만 추출한다")
+    void removeThinkTagAndExtractJson() {
+        String input = "<think>모델의 추론 과정</think>{\"answer\":\"42\"}";
+        assertEquals("{\"answer\":\"42\"}", EgovResponseCleanerUtil.cleanResponse(input));
+    }
+
+    @Test
+    @DisplayName("think 태그는 대소문자를 구분하지 않고 제거한다")
+    void thinkTagCaseInsensitive() {
+        String input = "<THINK>reasoning</THINK>{\"k\":2}";
+        assertEquals("{\"k\":2}", EgovResponseCleanerUtil.cleanResponse(input));
+    }
+
+    @Test
+    @DisplayName("think 태그가 여러 줄에 걸쳐 있어도 제거한다(DOTALL)")
+    void thinkTagMultiline() {
+        String input = "<think>\n여러\n줄\n추론\n</think>\n{\"x\":1}";
+        assertEquals("{\"x\":1}", EgovResponseCleanerUtil.cleanResponse(input));
+    }
+
+    @Test
+    @DisplayName("JSON 앞뒤 텍스트가 있어도 첫 '{'부터 마지막 '}'까지 추출한다")
+    void extractJsonBetweenBraces() {
+        String input = "여기 결과입니다: {\"a\":1} 끝";
+        assertEquals("{\"a\":1}", EgovResponseCleanerUtil.cleanResponse(input));
+    }
+
+    @Test
+    @DisplayName("중첩 객체는 가장 바깥 범위를 유지한다")
+    void nestedObject() {
+        String input = "{\"a\":{\"b\":1}}";
+        assertEquals("{\"a\":{\"b\":1}}", EgovResponseCleanerUtil.cleanResponse(input));
+    }
+
+    @Test
+    @DisplayName("중괄호가 없으면 think 제거 후 트림된 텍스트를 반환한다")
+    void noBracePassthrough() {
+        String input = "<think>x</think>  순수 텍스트  ";
+        assertEquals("순수 텍스트", EgovResponseCleanerUtil.cleanResponse(input));
+    }
+}


### PR DESCRIPTION
## 개요

`spring-ai-rag-redis-stack` 모듈은 핵심 유틸 클래스에 단위테스트가 거의 없습니다. 응답 처리·문서 해시 로직은 RAG 파이프라인의 결정적 동작에 직접 영향을 주므로 회귀 방지를 위한 테스트를 추가합니다.

## 변경 내용

- **EgovResponseCleanerUtil** (8건): `<think>` 태그 제거, JSON 추출, 대소문자 무시, 멀티라인(DOTALL), null/공백, 중괄호 없음, 중첩 객체, 앞뒤 텍스트 포함
- **EgovDocumentHashUtil** (5건): null/빈 입력 → 빈 문자열, 알려진 MD5 일치, 결정성, 서로 다른 입력의 해시 충돌 없음, 32자리 16진수 형식

## 검증

`mvn -Dtest='EgovResponseCleanerUtilTest,EgovDocumentHashUtilTest' test` — 13건 전부 통과. 운영 코드 변경 없이 테스트만 추가합니다.
