### PR TITLE
test: 핵심 유틸 단위테스트 추가 (langchain4j)

### DIFF
--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/ConfigUtilsResolvePathTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/ConfigUtilsResolvePathTest.java
@@ -1,0 +1,46 @@
+package com.example.chat.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ConfigUtils#resolvePath(String)} 단위테스트.
+ * ${HOME} 치환 및 경로 정규화 동작을 검증한다(설정 파일/Spring 컨텍스트 불필요).
+ */
+class ConfigUtilsResolvePathTest {
+
+    private final ConfigUtils configUtils = new ConfigUtils();
+
+    @Test
+    @DisplayName("null 입력은 null 그대로 반환한다")
+    void nullInput() {
+        assertNull(configUtils.resolvePath(null));
+    }
+
+    @Test
+    @DisplayName("빈 문자열은 빈 문자열 그대로 반환한다")
+    void emptyInput() {
+        assertEquals("", configUtils.resolvePath(""));
+    }
+
+    @Test
+    @DisplayName("${HOME}이 실제 홈 경로로 치환된다")
+    void resolvesHomePlaceholder() {
+        String resolved = configUtils.resolvePath("${HOME}/models/onnx");
+        assertFalse(resolved.contains("${HOME}"), "${HOME} 플레이스홀더가 남아있으면 안 된다");
+        assertTrue(resolved.contains("models"), "치환 후에도 하위 경로는 유지되어야 한다");
+    }
+
+    @Test
+    @DisplayName("${HOME}이 없는 경로는 정규화되어 반환된다")
+    void plainPathNormalized() {
+        String resolved = configUtils.resolvePath("/tmp/data/config");
+        assertFalse(resolved.contains("${HOME}"));
+        assertTrue(resolved.contains("data"));
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/DocumentHashUtilTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/DocumentHashUtilTest.java
@@ -1,0 +1,52 @@
+package com.example.chat.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link DocumentHashUtil} 단위테스트.
+ * 문서 내용의 MD5 해시 계산 동작을 검증한다.
+ */
+class DocumentHashUtilTest {
+
+    @Test
+    @DisplayName("null/빈 문자열은 빈 문자열을 반환한다")
+    void nullOrEmptyReturnsEmpty() {
+        assertEquals("", DocumentHashUtil.calculateHash(null));
+        assertEquals("", DocumentHashUtil.calculateHash(""));
+    }
+
+    @Test
+    @DisplayName("알려진 입력에 대해 알려진 MD5 해시를 반환한다")
+    void knownMd5() {
+        // MD5("test") = 098f6bcd4621d373cade4e832627b4f6
+        assertEquals("098f6bcd4621d373cade4e832627b4f6", DocumentHashUtil.calculateHash("test"));
+    }
+
+    @Test
+    @DisplayName("동일 입력은 항상 동일 해시를 반환한다(결정적)")
+    void deterministic() {
+        String content = "전자정부 표준프레임워크 RAG 문서";
+        assertEquals(DocumentHashUtil.calculateHash(content), DocumentHashUtil.calculateHash(content));
+    }
+
+    @Test
+    @DisplayName("다른 입력은 다른 해시를 반환한다")
+    void differentInputDifferentHash() {
+        assertNotEquals(
+            DocumentHashUtil.calculateHash("문서 A"),
+            DocumentHashUtil.calculateHash("문서 B"));
+    }
+
+    @Test
+    @DisplayName("MD5 해시는 32자리 16진수 문자열이다")
+    void hashLengthAndFormat() {
+        String hash = DocumentHashUtil.calculateHash("한글 UTF-8 콘텐츠");
+        assertEquals(32, hash.length());
+        assertTrue(hash.matches("[0-9a-f]{32}"));
+    }
+}


### PR DESCRIPTION
## 개요

`langchain4j-ai-rag-postgre` 모듈의 핵심 유틸 클래스에 단위테스트를 추가합니다. spring-ai 모듈에 추가한 테스트(#41)와 프레임워크 parity를 맞춥니다.

## 변경 내용

- **DocumentHashUtil** (5건): null/빈 입력 → 빈 문자열, 알려진 MD5 일치, 결정성, 서로 다른 입력의 해시 충돌 없음, 32자리 16진수 형식
- **ConfigUtils.resolvePath** (4건): null/빈 입력 처리, `${HOME}` 치환, `${HOME}`이 없는 일반 경로 정규화

## 검증

`mvn -Dtest='DocumentHashUtilTest,ConfigUtilsResolvePathTest' test` — 9건 전부 통과. 운영 코드 변경 없이 테스트만 추가합니다.
