### PR TITLE
fix: 문서 적재 동시 진입 가드를 compareAndSet 단일 원자 연산으로 교정

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/service/impl/EgovDocumentServiceImpl.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/service/impl/EgovDocumentServiceImpl.java
@@ -77,13 +77,13 @@ public class EgovDocumentServiceImpl extends EgovAbstractServiceImpl implements 
 
     @Override
     public CompletableFuture<Integer> loadDocumentsAsync() {
-        if (isProcessing.get()) {
+        // 검사·설정을 단일 원자 연산으로 처리하여 동시 진입(TOCTOU)을 차단한다.
+        if (!isProcessing.compareAndSet(false, true)) {
             log.warn("이미 문서 처리가 진행 중입니다.");
             return CompletableFuture.completedFuture(0);
         }
 
         log.info("LangChain4j ETL 파이프라인으로 문서 처리 시작");
-        isProcessing.set(true);
         processedCount.set(0);
         totalCount.set(0);
         changedCount.set(0);

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/service/impl/EgovDocumentServiceLoadGuardTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/service/impl/EgovDocumentServiceLoadGuardTest.java
@@ -1,0 +1,106 @@
+package com.example.chat.service.impl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.chat.config.etl.readers.EgovMarkdownReader;
+import com.example.chat.config.etl.readers.EgovPdfReader;
+import com.example.chat.config.etl.transformers.EgovContentFormatTransformer;
+import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
+import com.example.chat.config.etl.writers.EgovVectorStoreWriter;
+import com.example.chat.repository.DocumentHashRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * {@link EgovDocumentServiceImpl#loadDocumentsAsync()} 의 동시 진입 가드를 검증한다.
+ *
+ * <p>이전 구현은 {@code isProcessing.get()} 으로 검사한 뒤 별도로 {@code set(true)} 를
+ * 호출하여 검사와 설정이 분리(TOCTOU)되어 있었다. 다수 스레드가 동시에 진입하면 모두
+ * 가드를 통과해 중복 임베딩·벡터스토어 동시 쓰기가 발생할 수 있다. 본 테스트는 N개의
+ * 스레드가 동시에 호출했을 때 단 하나만 처리에 진입함을 확인한다.</p>
+ *
+ * <p>비동기 본문은 실행하지 않는 {@code Executor}(작업을 버림)를 주입하여 외부 의존성
+ * 호출 없이 진입 가드만 결정적으로 검증한다. 진입 가드는 {@code supplyAsync} 호출 전
+ * 요청 스레드에서 동기적으로 평가되므로 본문 미실행과 무관하게 동작한다.</p>
+ */
+class EgovDocumentServiceLoadGuardTest {
+
+    private EgovDocumentServiceImpl newService() {
+        Executor noopExecutor = command -> { /* 실행하지 않음 */ };
+        EgovDocumentServiceImpl service = new EgovDocumentServiceImpl(
+                mock(EgovMarkdownReader.class),
+                mock(EgovPdfReader.class),
+                mock(EgovContentFormatTransformer.class),
+                mock(EgovEnhancedDocumentTransformer.class),
+                mock(EgovVectorStoreWriter.class),
+                mock(DocumentHashRepository.class),
+                noopExecutor);
+        ReflectionTestUtils.setField(service, "documentPath", "classpath:/docs");
+        return service;
+    }
+
+    @Test
+    @DisplayName("다수 스레드가 동시 호출해도 처리 진입은 한 번만 허용된다")
+    void onlyOneThreadAcquiresProcessing() throws InterruptedException {
+        EgovDocumentServiceImpl service = newService();
+
+        int threads = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        AtomicInteger entered = new AtomicInteger(0);
+
+        try {
+            for (int i = 0; i < threads; i++) {
+                pool.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                        CompletableFuture<Integer> future = service.loadDocumentsAsync();
+                        if (!future.isDone()) {
+                            entered.incrementAndGet();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertThat(entered.get()).isEqualTo(1);
+        assertThat(service.isProcessing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 처리 중이면 호출은 즉시 완료된 0 Future 를 반환한다")
+    void secondCallIsRejectedWhileProcessing() {
+        EgovDocumentServiceImpl service = newService();
+
+        CompletableFuture<Integer> first = service.loadDocumentsAsync();
+        CompletableFuture<Integer> second = service.loadDocumentsAsync();
+
+        assertThat(first.isDone()).isFalse();
+        assertThat(second.isDone()).isTrue();
+        assertThat(second.join()).isZero();
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/service/impl/EgovDocumentServiceLoadGuardTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/service/impl/EgovDocumentServiceLoadGuardTest.java
@@ -1,5 +1,6 @@
 package com.example.chat.service.impl;
 
+import java.lang.reflect.Constructor;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -11,13 +12,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import com.example.chat.config.etl.readers.EgovMarkdownReader;
-import com.example.chat.config.etl.readers.EgovPdfReader;
-import com.example.chat.config.etl.transformers.EgovContentFormatTransformer;
-import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
-import com.example.chat.config.etl.writers.EgovVectorStoreWriter;
-import com.example.chat.repository.DocumentHashRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -36,23 +30,25 @@ import static org.mockito.Mockito.mock;
  */
 class EgovDocumentServiceLoadGuardTest {
 
-    private EgovDocumentServiceImpl newService() {
-        Executor noopExecutor = command -> { /* 실행하지 않음 */ };
-        EgovDocumentServiceImpl service = new EgovDocumentServiceImpl(
-                mock(EgovMarkdownReader.class),
-                mock(EgovPdfReader.class),
-                mock(EgovContentFormatTransformer.class),
-                mock(EgovEnhancedDocumentTransformer.class),
-                mock(EgovVectorStoreWriter.class),
-                mock(DocumentHashRepository.class),
-                noopExecutor);
+    // 생성자 파라미터를 위치로 나열하지 않고 실제 생성자에서 읽어 채운다.
+    // @RequiredArgsConstructor에 리더가 추가돼도(예: HWP/HWPX/DOCX) 영향을 받지 않는다.
+    // Executor 인자만 비동기 본문을 실행하지 않는 noop으로 주입하고 나머지는 mock으로 채운다.
+    private EgovDocumentServiceImpl newService() throws Exception {
+        Constructor<?> ctor = EgovDocumentServiceImpl.class.getDeclaredConstructors()[0];
+        Class<?>[] types = ctor.getParameterTypes();
+        Object[] args = new Object[types.length];
+        for (int i = 0; i < types.length; i++) {
+            args[i] = types[i].equals(Executor.class) ? (Executor) command -> { /* 실행하지 않음 */ } : mock(types[i]);
+        }
+        ctor.setAccessible(true);
+        EgovDocumentServiceImpl service = (EgovDocumentServiceImpl) ctor.newInstance(args);
         ReflectionTestUtils.setField(service, "documentPath", "classpath:/docs");
         return service;
     }
 
     @Test
     @DisplayName("다수 스레드가 동시 호출해도 처리 진입은 한 번만 허용된다")
-    void onlyOneThreadAcquiresProcessing() throws InterruptedException {
+    void onlyOneThreadAcquiresProcessing() throws Exception {
         EgovDocumentServiceImpl service = newService();
 
         int threads = 16;
@@ -93,7 +89,7 @@ class EgovDocumentServiceLoadGuardTest {
 
     @Test
     @DisplayName("이미 처리 중이면 호출은 즉시 완료된 0 Future 를 반환한다")
-    void secondCallIsRejectedWhileProcessing() {
+    void secondCallIsRejectedWhileProcessing() throws Exception {
         EgovDocumentServiceImpl service = newService();
 
         CompletableFuture<Integer> first = service.loadDocumentsAsync();

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/service/impl/EgovDocumentServiceImpl.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/service/impl/EgovDocumentServiceImpl.java
@@ -83,13 +83,13 @@ public class EgovDocumentServiceImpl extends EgovAbstractServiceImpl implements 
 
     @Override
     public CompletableFuture<Integer> loadDocumentsAsync() {
-        if (isProcessing.get()) {
+        // 검사·설정을 단일 원자 연산으로 처리하여 동시 진입(TOCTOU)을 차단한다.
+        if (!isProcessing.compareAndSet(false, true)) {
             log.warn("이미 문서 처리가 진행 중입니다.");
             return CompletableFuture.completedFuture(0);
         }
 
         log.info("Spring AI ETL 파이프라인으로 문서 처리 시작");
-        isProcessing.set(true);
         processedCount.set(0);
         totalCount.set(0);
         changedCount.set(0);

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/service/impl/EgovDocumentServiceLoadGuardTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/service/impl/EgovDocumentServiceLoadGuardTest.java
@@ -1,0 +1,119 @@
+package com.example.chat.service.impl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.vectorstore.redis.RedisVectorStore;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.chat.config.etl.readers.EgovMarkdownReader;
+import com.example.chat.config.etl.readers.EgovPdfReader;
+import com.example.chat.config.etl.transformers.EgovContentFormatTransformer;
+import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
+import com.example.chat.config.etl.writers.EgovVectorStoreWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * {@link EgovDocumentServiceImpl#loadDocumentsAsync()} 의 동시 진입 가드를 검증한다.
+ *
+ * <p>이전 구현은 {@code isProcessing.get()} 으로 검사한 뒤 별도로 {@code set(true)} 를
+ * 호출하여 검사와 설정이 분리(TOCTOU)되어 있었다. 다수 스레드가 동시에 진입하면 모두
+ * 가드를 통과해 중복 임베딩·벡터스토어 동시 쓰기가 발생할 수 있다. 본 테스트는 N개의
+ * 스레드가 동시에 호출했을 때 단 하나만 처리에 진입함을 확인한다.</p>
+ *
+ * <p>비동기 본문은 실행하지 않는 {@code Executor}(작업을 버림)를 주입하여 외부 의존성
+ * 호출 없이 진입 가드만 결정적으로 검증한다. 진입 가드는 {@code supplyAsync} 호출 전
+ * 요청 스레드에서 동기적으로 평가되므로 본문 미실행과 무관하게 동작한다.</p>
+ */
+class EgovDocumentServiceLoadGuardTest {
+
+    private EgovDocumentServiceImpl newService() {
+        // 비동기 본문이 실제로 실행되지 않도록 작업을 폐기하는 Executor 를 사용한다.
+        Executor noopExecutor = command -> { /* 실행하지 않음 */ };
+        EgovDocumentServiceImpl service = new EgovDocumentServiceImpl(
+                mock(EgovMarkdownReader.class),
+                mock(EgovPdfReader.class),
+                mock(EgovContentFormatTransformer.class),
+                mock(EgovEnhancedDocumentTransformer.class),
+                mock(EgovVectorStoreWriter.class),
+                mock(RedisVectorStore.class),
+                mock(StringRedisTemplate.class),
+                noopExecutor);
+        ReflectionTestUtils.setField(service, "documentPath", "classpath:/docs");
+        return service;
+    }
+
+    @Test
+    @DisplayName("다수 스레드가 동시 호출해도 처리 진입은 한 번만 허용된다")
+    void onlyOneThreadAcquiresProcessing() throws InterruptedException {
+        EgovDocumentServiceImpl service = newService();
+
+        int threads = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        AtomicInteger entered = new AtomicInteger(0);
+
+        try {
+            for (int i = 0; i < threads; i++) {
+                pool.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                        // 본문이 실행되지 않으므로 가드를 통과한 호출은 0이 아닌
+                        // (=처리 진입) 빈 Future 를 반환하지 않는다. completedFuture(0)
+                        // 은 가드에 막힌 호출이다. 가드를 통과한 호출은 join 시 미완료
+                        // 상태이므로 isDone() 으로 진입 여부를 구분한다.
+                        CompletableFuture<Integer> future = service.loadDocumentsAsync();
+                        if (!future.isDone()) {
+                            entered.incrementAndGet();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertThat(entered.get()).isEqualTo(1);
+        assertThat(service.isProcessing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 처리 중이면 호출은 즉시 완료된 0 Future 를 반환한다")
+    void secondCallIsRejectedWhileProcessing() {
+        EgovDocumentServiceImpl service = newService();
+
+        CompletableFuture<Integer> first = service.loadDocumentsAsync();
+        CompletableFuture<Integer> second = service.loadDocumentsAsync();
+
+        // 첫 호출은 처리에 진입(본문 미실행으로 미완료), 둘째 호출은 가드에 막혀 즉시 완료.
+        assertThat(first.isDone()).isFalse();
+        assertThat(second.isDone()).isTrue();
+        assertThat(second.join()).isZero();
+    }
+
+    /** EgovAbstractServiceImpl 상속 확인용(컴파일 가드). */
+    @SuppressWarnings("unused")
+    private static final Class<? extends EgovAbstractServiceImpl> TYPE = EgovDocumentServiceImpl.class;
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/service/impl/EgovDocumentServiceLoadGuardTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/service/impl/EgovDocumentServiceLoadGuardTest.java
@@ -1,5 +1,6 @@
 package com.example.chat.service.impl;
 
+import java.lang.reflect.Constructor;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -11,15 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.ai.vectorstore.redis.RedisVectorStore;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import com.example.chat.config.etl.readers.EgovMarkdownReader;
-import com.example.chat.config.etl.readers.EgovPdfReader;
-import com.example.chat.config.etl.transformers.EgovContentFormatTransformer;
-import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
-import com.example.chat.config.etl.writers.EgovVectorStoreWriter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -38,25 +31,25 @@ import static org.mockito.Mockito.mock;
  */
 class EgovDocumentServiceLoadGuardTest {
 
-    private EgovDocumentServiceImpl newService() {
-        // 비동기 본문이 실제로 실행되지 않도록 작업을 폐기하는 Executor 를 사용한다.
-        Executor noopExecutor = command -> { /* 실행하지 않음 */ };
-        EgovDocumentServiceImpl service = new EgovDocumentServiceImpl(
-                mock(EgovMarkdownReader.class),
-                mock(EgovPdfReader.class),
-                mock(EgovContentFormatTransformer.class),
-                mock(EgovEnhancedDocumentTransformer.class),
-                mock(EgovVectorStoreWriter.class),
-                mock(RedisVectorStore.class),
-                mock(StringRedisTemplate.class),
-                noopExecutor);
+    // 생성자 파라미터를 위치로 나열하지 않고 실제 생성자에서 읽어 채운다.
+    // @RequiredArgsConstructor에 리더가 추가돼도(예: HWP/HWPX/DOCX) 영향을 받지 않는다.
+    // Executor 인자만 비동기 본문을 실행하지 않는 noop으로 주입하고 나머지는 mock으로 채운다.
+    private EgovDocumentServiceImpl newService() throws Exception {
+        Constructor<?> ctor = EgovDocumentServiceImpl.class.getDeclaredConstructors()[0];
+        Class<?>[] types = ctor.getParameterTypes();
+        Object[] args = new Object[types.length];
+        for (int i = 0; i < types.length; i++) {
+            args[i] = types[i].equals(Executor.class) ? (Executor) command -> { /* 실행하지 않음 */ } : mock(types[i]);
+        }
+        ctor.setAccessible(true);
+        EgovDocumentServiceImpl service = (EgovDocumentServiceImpl) ctor.newInstance(args);
         ReflectionTestUtils.setField(service, "documentPath", "classpath:/docs");
         return service;
     }
 
     @Test
     @DisplayName("다수 스레드가 동시 호출해도 처리 진입은 한 번만 허용된다")
-    void onlyOneThreadAcquiresProcessing() throws InterruptedException {
+    void onlyOneThreadAcquiresProcessing() throws Exception {
         EgovDocumentServiceImpl service = newService();
 
         int threads = 16;
@@ -101,7 +94,7 @@ class EgovDocumentServiceLoadGuardTest {
 
     @Test
     @DisplayName("이미 처리 중이면 호출은 즉시 완료된 0 Future 를 반환한다")
-    void secondCallIsRejectedWhileProcessing() {
+    void secondCallIsRejectedWhileProcessing() throws Exception {
         EgovDocumentServiceImpl service = newService();
 
         CompletableFuture<Integer> first = service.loadDocumentsAsync();


### PR DESCRIPTION
## 변경 이유

`EgovDocumentServiceImpl.loadDocumentsAsync()`가 동시 진입 가드를 두 단계로 나눠 수행합니다.

```java
if (isProcessing.get()) { ... return; }
...
isProcessing.set(true);
```

`get()` 검사와 `set(true)` 설정 사이에 다른 요청이 끼어들면(TOCTOU), 두 요청 모두 가드를 통과합니다. 그 결과 문서 적재가 중복 실행되어 같은 문서를 두 번 임베딩하고 벡터스토어에 동시 쓰기가 발생할 수 있습니다.

## 변경 내용

검사와 설정을 `compareAndSet(false, true)` 단일 원자 연산으로 묶어 동시 진입을 차단합니다. 가드 통과에 실패한 요청은 기존과 동일하게 "이미 처리 중" 응답을 즉시 반환합니다. 처리 종료 시 `isProcessing.set(false)`로 해제하는 흐름은 그대로입니다.

spring-ai / langchain4j 양 모듈에 동일하게 적용했습니다.

## 테스트 방법

`EgovDocumentServiceLoadGuardTest`(양 모듈 각 2건):
- 16개 스레드가 동시에 호출해도 처리 진입은 한 번만 허용됨을 검증
- 처리 중 두 번째 호출은 즉시 완료된 0 Future를 반환함을 검증

비동기 본문을 실행하지 않는 Executor를 주입해 외부 의존(벡터스토어) 없이 진입 가드만 결정적으로 검증합니다.

## 영향 범위

`loadDocumentsAsync` 진입 가드만 변경하며 정상 적재 흐름과 응답은 동일합니다.
