### PR TITLE
fix: 마크다운 메타데이터 추출이 여러 줄 문서에서 항상 false 되던 문제 수정

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
@@ -87,10 +87,11 @@ public class EgovMarkdownReader {
         metadata.put("source", filename);
         metadata.put("type", "markdown");
         metadata.put("content_length", String.valueOf(content.length()));
-        metadata.put("has_headers", String.valueOf(content.matches(".*#{1,6}\\s.*")));
+        // (?s) DOTALL: 여러 줄 마크다운에서도 '.'이 줄바꿈을 포함해 전체 매칭되도록 한다
+        metadata.put("has_headers", String.valueOf(content.matches("(?s).*#{1,6}\\s.*")));
         metadata.put("has_code_blocks", String.valueOf(content.contains("```")));
-        metadata.put("has_links", String.valueOf(content.matches(".*\\[.*\\]\\(.*\\).*")));
-        metadata.put("has_images", String.valueOf(content.matches(".*!\\[.*\\]\\(.*\\).*")));
+        metadata.put("has_links", String.valueOf(content.matches("(?s).*\\[.*\\]\\(.*\\).*")));
+        metadata.put("has_images", String.valueOf(content.matches("(?s).*!\\[.*\\]\\(.*\\).*")));
         metadata.put("line_count", String.valueOf(content.split("\n").length));
         return metadata;
     }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovMarkdownReaderMetadataTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovMarkdownReaderMetadataTest.java
@@ -1,0 +1,51 @@
+package com.example.chat.config.etl.readers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.data.document.Metadata;
+
+/**
+ * {@link EgovMarkdownReader} 의 마크다운 메타데이터 추출을 검증한다.
+ *
+ * <p>이전 구현은 {@code content.matches(".*#{1,6}\\s.*")} 처럼 DOTALL 없이 전체 매칭을
+ * 수행해, 여러 줄로 이루어진 실제 마크다운 문서에서는 {@code .} 이 줄바꿈을 포함하지 못해
+ * has_headers/has_links/has_images 가 항상 "false" 로 기록됐다. 본 테스트는 여러 줄 문서에서
+ * 각 플래그가 올바르게 "true" 가 되는지, 해당 요소가 없으면 "false" 가 되는지 확인한다.</p>
+ */
+class EgovMarkdownReaderMetadataTest {
+
+    private Metadata metadata(String content) throws Exception {
+        Method method = EgovMarkdownReader.class.getDeclaredMethod("createEnhancedMetadata", String.class, String.class);
+        method.setAccessible(true);
+        return (Metadata) method.invoke(new EgovMarkdownReader(), "sample.md", content);
+    }
+
+    @Test
+    @DisplayName("여러 줄 마크다운에서 헤더·링크·이미지 플래그가 true 로 기록된다")
+    void multilineMarkdownFlagsAreTrue() throws Exception {
+        String content = "# 제목\n\n본문 문단입니다.\n자세한 내용은 [안내](https://example.com) 를 참고하세요.\n\n![다이어그램](https://example.com/a.png)\n";
+
+        Metadata metadata = metadata(content);
+
+        assertThat(metadata.getString("has_headers")).isEqualTo("true");
+        assertThat(metadata.getString("has_links")).isEqualTo("true");
+        assertThat(metadata.getString("has_images")).isEqualTo("true");
+    }
+
+    @Test
+    @DisplayName("해당 요소가 없는 마크다운에서는 플래그가 false 로 기록된다")
+    void plainMultilineMarkdownFlagsAreFalse() throws Exception {
+        String content = "일반 문단 첫째 줄입니다.\n특수 마크다운 요소가 없는 둘째 줄입니다.\n";
+
+        Metadata metadata = metadata(content);
+
+        assertThat(metadata.getString("has_headers")).isEqualTo("false");
+        assertThat(metadata.getString("has_links")).isEqualTo("false");
+        assertThat(metadata.getString("has_images")).isEqualTo("false");
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
@@ -84,10 +84,11 @@ public class EgovMarkdownReader implements DocumentReader {
         metadata.put("source", filename);
         metadata.put("type", "markdown");
         metadata.put("content_length", content.length());
-        metadata.put("has_headers", content.matches(".*#{1,6}\\s.*"));
+        // (?s) DOTALL: 여러 줄 마크다운에서도 '.'이 줄바꿈을 포함해 전체 매칭되도록 한다
+        metadata.put("has_headers", content.matches("(?s).*#{1,6}\\s.*"));
         metadata.put("has_code_blocks", content.contains("```"));
-        metadata.put("has_links", content.matches(".*\\[.*\\]\\(.*\\).*"));
-        metadata.put("has_images", content.matches(".*!\\[.*\\]\\(.*\\).*"));
+        metadata.put("has_links", content.matches("(?s).*\\[.*\\]\\(.*\\).*"));
+        metadata.put("has_images", content.matches("(?s).*!\\[.*\\]\\(.*\\).*"));
         metadata.put("line_count", content.split("\n").length);
         
         return metadata;

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovMarkdownReaderMetadataTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovMarkdownReaderMetadataTest.java
@@ -1,0 +1,51 @@
+package com.example.chat.config.etl.readers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovMarkdownReader} 의 마크다운 메타데이터 추출을 검증한다.
+ *
+ * <p>이전 구현은 {@code content.matches(".*#{1,6}\\s.*")} 처럼 DOTALL 없이 전체 매칭을
+ * 수행해, 여러 줄로 이루어진 실제 마크다운 문서에서는 {@code .} 이 줄바꿈을 포함하지 못해
+ * has_headers/has_links/has_images 가 항상 false 로 기록됐다. 본 테스트는 여러 줄 문서에서
+ * 각 플래그가 올바르게 true 가 되는지, 해당 요소가 없으면 false 가 되는지 확인한다.</p>
+ */
+class EgovMarkdownReaderMetadataTest {
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> metadata(String content) throws Exception {
+        Method method = EgovMarkdownReader.class.getDeclaredMethod("createEnhancedMetadata", String.class, String.class);
+        method.setAccessible(true);
+        return (Map<String, Object>) method.invoke(new EgovMarkdownReader(), "sample.md", content);
+    }
+
+    @Test
+    @DisplayName("여러 줄 마크다운에서 헤더·링크·이미지 플래그가 true 로 기록된다")
+    void multilineMarkdownFlagsAreTrue() throws Exception {
+        String content = "# 제목\n\n본문 문단입니다.\n자세한 내용은 [안내](https://example.com) 를 참고하세요.\n\n![다이어그램](https://example.com/a.png)\n";
+
+        Map<String, Object> metadata = metadata(content);
+
+        assertThat(metadata.get("has_headers")).isEqualTo(Boolean.TRUE);
+        assertThat(metadata.get("has_links")).isEqualTo(Boolean.TRUE);
+        assertThat(metadata.get("has_images")).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    @DisplayName("해당 요소가 없는 마크다운에서는 플래그가 false 로 기록된다")
+    void plainMultilineMarkdownFlagsAreFalse() throws Exception {
+        String content = "일반 문단 첫째 줄입니다.\n특수 마크다운 요소가 없는 둘째 줄입니다.\n";
+
+        Map<String, Object> metadata = metadata(content);
+
+        assertThat(metadata.get("has_headers")).isEqualTo(Boolean.FALSE);
+        assertThat(metadata.get("has_links")).isEqualTo(Boolean.FALSE);
+        assertThat(metadata.get("has_images")).isEqualTo(Boolean.FALSE);
+    }
+}


### PR DESCRIPTION
## 변경 이유

`EgovMarkdownReader.createEnhancedMetadata()`가 마크다운 특성 플래그를 정규식 전체 매칭으로 판정합니다.

```java
content.matches(".*#{1,6}\\s.*")   // has_headers
content.matches(".*\\[.*\\]\\(.*\\).*")  // has_links
content.matches(".*!\\[.*\\]\\(.*\\).*") // has_images
```

`String.matches`는 문자열 전체가 패턴과 일치해야 하고 `.`은 줄바꿈을 포함하지 않습니다. 따라서 여러 줄로 이루어진 실제 마크다운 문서에서는 `.*`가 줄바꿈을 넘지 못해 위 세 플래그가 **항상 false**로 기록됩니다.

## 변경 내용

각 패턴에 `(?s)` DOTALL 플래그를 적용해 `.`이 줄바꿈을 포함하도록 합니다. 단일 행 입력 동작은 그대로이고, 여러 줄 문서에서 헤더·링크·이미지 존재 여부가 올바르게 판정됩니다.

spring-ai / langchain4j 양 모듈에 동일하게 적용했습니다.

## 테스트 방법

`EgovMarkdownReaderMetadataTest`(양 모듈 각 2건):
- 여러 줄 마크다운에서 has_headers/has_links/has_images가 true로 기록됨을 검증
- 해당 요소가 없는 여러 줄 문서에서 false로 기록됨을 검증

## 영향 범위

메타데이터 플래그 판정만 정정하며 문서 본문·청킹·임베딩에는 영향이 없습니다.
