### PR TITLE
fix: 빈 PDF 페이지가 빈 문서로 색인되지 않도록 건너뛰기

### DIFF
--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovPdfReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovPdfReader.java
@@ -104,9 +104,11 @@ public class EgovPdfReader implements DocumentReader {
             Document document = documents.get(i);
             String content = document.getText();
             
-            // 빈 페이지 체크 (로깅만)
+            // 빈(공백뿐인) 페이지는 건너뛴다. 내용 없는 페이지를 그대로 변환하면
+            // 임베딩·벡터스토어에 무의미한 빈 문서가 색인되어 검색 품질을 떨어뜨린다.
             if (content == null || content.trim().isEmpty()) {
-                log.debug("PDF 페이지 {}: 빈 내용 (길이: 0)", i + 1);
+                log.debug("PDF 페이지 {}: 빈 내용으로 건너뜀", i + 1);
+                continue;
             } else if (content.trim().length() < 10) {
                 log.debug("PDF 페이지 {}: 매우 짧은 내용 (길이: {})", i + 1, content.trim().length());
             }

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovPdfReaderEmptyPageTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovPdfReaderEmptyPageTest.java
@@ -1,0 +1,44 @@
+package com.example.chat.config.etl.readers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+/**
+ * {@link EgovPdfReader} 의 빈 페이지 처리(createDocumentsWithCustomIds)를 검증한다.
+ *
+ * <p>빈 내용 페이지는 로깅만 하고 흐름을 멈추지 않아 이후 content.length() 등에서
+ * 문제가 발생할 수 있었다. 빈 페이지는 건너뛰고 정상 페이지만 변환됨을 확인한다.</p>
+ */
+class EgovPdfReaderEmptyPageTest {
+
+    @SuppressWarnings("unchecked")
+    private List<Document> invoke(List<Document> documents) throws Exception {
+        Method method = EgovPdfReader.class.getDeclaredMethod("createDocumentsWithCustomIds", List.class, String.class);
+        method.setAccessible(true);
+        return (List<Document>) method.invoke(new EgovPdfReader(), documents, "sample.pdf");
+    }
+
+    @Test
+    @DisplayName("빈 내용 페이지는 건너뛰고 정상 페이지만 변환된다")
+    void emptyPagesAreSkipped() throws Exception {
+        List<Document> input = new ArrayList<>();
+        Map<String, Object> meta = new HashMap<>();
+        input.add(new Document("   ", meta));
+        input.add(new Document("유효한 본문 내용입니다.", new HashMap<>()));
+
+        List<Document> result = invoke(input);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getText()).isEqualTo("유효한 본문 내용입니다.");
+        assertThat(result.get(0).getId()).isEqualTo("pdf-sample_2");
+    }
+}


### PR DESCRIPTION
## 변경 이유

`EgovPdfReader.createDocumentsWithCustomIds()`가 빈(공백뿐인) 페이지를 로깅만 하고 흐름을 멈추지 않습니다.

```java
if (content == null || content.trim().isEmpty()) {
    log.debug("PDF 페이지 {}: 빈 내용 (길이: 0)", i + 1);
} else if ...
```

이 경우 내용 없는 페이지가 그대로 Document로 변환되어 임베딩·벡터스토어에 무의미한 빈 문서로 색인됩니다. 검색 품질을 떨어뜨리고 불필요한 임베딩 비용이 발생합니다.

## 변경 내용

빈 내용 페이지는 건너뛰도록(`continue`) 수정합니다. 내용이 있는 페이지만 ID 재지정·메타데이터 부여 후 변환합니다.

## 테스트 방법

`EgovPdfReaderEmptyPageTest`: 공백뿐인 페이지와 정상 페이지가 섞인 입력에서 빈 페이지는 제외되고 정상 페이지만 변환됨을 검증합니다.

## 영향 범위

빈 페이지 처리만 변경하며 정상 페이지의 변환 결과(ID·메타데이터)는 동일합니다.
