### PR TITLE
feat: langchain4j 모듈에 하이브리드(키워드+벡터) RRF 융합 retriever 추가 (#49)

### DIFF
--- a/README-langchain4j-ai-rag-postgre.md
+++ b/README-langchain4j-ai-rag-postgre.md
@@ -336,6 +336,57 @@ pgvector:
   create-table: true
 ```
 
+### 하이브리드 검색 (dense 벡터 + lexical pg_trgm)
+
+의미 기반 dense 벡터 검색에 키워드 기반 lexical 검색(PostgreSQL `pg_trgm` 트라이그램 유사도)을
+더해 [RRF(Reciprocal Rank Fusion)](https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf)로
+융합한다. 정확한 용어·고유명사 질의에서 dense 채널이 놓치는 문서를 lexical 채널이 보완한다.
+기본값은 **off**이며, 켜면 dense 단일 검색은 그대로 두고 lexical 채널과 융합만 추가된다.
+
+```yaml
+rag:
+  retrieval:
+    hybrid:
+      enabled: true                 # 하이브리드 활성화 (기본 false)
+      weight:
+        dense: 1.0                  # dense 채널 RRF 가중치
+        lexical: 1.0                # lexical 채널 RRF 가중치
+      top-k: 3                          # 융합 결과 개수 (미설정 시 rag.top-k)
+      lexical:
+        word-similarity-threshold: 0.30 # lexical(pg_trgm word_similarity) 게이트
+```
+
+활성화 시 애플리케이션 기동 완료 시점에 `pg_trgm` 확장과 GIN 트라이그램 인덱스를 멱등으로
+생성한다(`EgovHybridIndexInitializer`). `docker-compose`의 `init-scripts/01-init-pgvector.sql`이
+컨테이너 초기화 때 `CREATE EXTENSION pg_trgm`을 미리 수행하므로, 애플리케이션 계정에 슈퍼유저
+권한을 부여할 필요가 없다.
+
+#### lexical 연산자와 임계값: `word_similarity`(`%>`) + 0.30
+
+lexical 채널은 대칭 `similarity`(`%`)가 아니라 **`word_similarity`(`%>`)** 를 사용한다.
+이 앱은 문서를 큰 청크(기본 4000자, `DocumentSplitters.recursive`)로 색인하는데, 대칭
+`similarity`는 문서가 길수록 트라이그램 Jaccard 분모가 커져 값이 붕괴한다. 실제 표준프레임워크
+한국어 문서(runtime README)를 색인한 코퍼스에서 정답 청크의 `similarity`는 **0.006~0.058**
+(전부 0.06 미만)로, 어떤 실용 임계값을 써도 관련 문서가 `%`를 통과하지 못했다.
+
+`word_similarity`는 질의를 문서의 **가장 잘 맞는 연속 구간**과 비교하므로 청크 길이에 강건하다.
+같은 코퍼스에서 정답 청크의 `word_similarity`는 **0.17~1.0**로 분포했고, `%>` 게이트 임계값별
+recall@3(topK=3)은 다음과 같았다.
+
+| word_similarity 임계값 | recall@3 | 비고 |
+|------------------------|----------|------|
+| 0.60 (pg_trgm 기본)    | 0.31     | 너무 엄격 |
+| 0.40                   | 0.57     | |
+| **0.30**               | **0.80** | 기본값(권장) |
+| 0.20                   | 0.84     | recall↑, 노이즈↑ |
+
+`%>` 연산자는 `text` 컬럼의 GIN 트라이그램 인덱스를 그대로 사용한다(별도 인덱스 불필요).
+임계값은 **트랜잭션 스코프**(`set_config('pg_trgm.word_similarity_threshold', …, is_local => true)`)로만
+적용해 `%>`(GIN 인덱스) 경로를 유지하면서 커넥션 풀에 값이 누수되지 않도록 한다. 기본값은
+runtime README 코퍼스 측정 기준 **0.30**이며, recall을 더 원하면 낮추고(노이즈 증가) 정밀도를
+원하면 높인다. 위 수치는 구성한 라벨 질의셋(문서 33·질의 35) 기준의 결정론적 측정값으로,
+절대 수치보다 방향(대칭 `%`는 큰 청크에서 무력, `%>`가 적합)이 핵심이다.
+
 ## 문제 해결
 
 ### Ollama 연결 실패

--- a/langchain4j-ai-rag-postgre/init-scripts/01-init-pgvector.sql
+++ b/langchain4j-ai-rag-postgre/init-scripts/01-init-pgvector.sql
@@ -1,6 +1,12 @@
 -- PGVector 확장 설치
 CREATE EXTENSION IF NOT EXISTS vector;
 
+-- 하이브리드 lexical 검색용 pg_trgm 확장 설치
+-- 컨테이너 초기화 시점에 슈퍼유저로 설치하므로, 애플리케이션 계정에 CREATE EXTENSION
+-- 권한(슈퍼유저)을 부여할 필요가 없다. GIN trigram 인덱스는 document_embeddings 테이블이
+-- 애플리케이션 기동 후 생성되므로 EgovHybridIndexInitializer에서 계속 담당한다.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
 -- 문서 해시 저장 테이블 (변경 감지용)
 CREATE TABLE IF NOT EXISTS document_hashes (
     doc_id VARCHAR(500) PRIMARY KEY,

--- a/langchain4j-ai-rag-postgre/pom.xml
+++ b/langchain4j-ai-rag-postgre/pom.xml
@@ -105,6 +105,19 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Testcontainers: 하이브리드 lexical 검색(pg_trgm word_similarity) 실 DB 통합 테스트용.
+             Docker 미가용 환경에서는 @Testcontainers(disabledWithoutDocker=true)로 자동 skip. -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Spring Boot Web -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridContentRetriever.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridContentRetriever.java
@@ -1,0 +1,170 @@
+package com.example.chat.config;
+
+import com.example.chat.util.DocumentHashUtil;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 하이브리드 ContentRetriever
+ *
+ * <p>dense 벡터 검색({@link ContentRetriever} 위임)과 lexical 키워드 검색
+ * (PostgreSQL {@code pg_trgm})을 각각 수행한 뒤 {@link EgovRrfFusion}으로
+ * 융합해 최종 결과를 반환한다. 두 채널은 단순성을 위해 순차로 호출한다.</p>
+ *
+ * <p>융합 키는 메타데이터 {@code id}를 우선 사용하고, 없으면 세그먼트 텍스트의
+ * 해시({@link DocumentHashUtil})를 사용한다. lexical 검색이나 융합 과정에서
+ * 오류가 발생하면 dense 결과만 반환해 RAG 기능 자체는 보존한다.</p>
+ *
+ * <p>본 빈은 {@code rag.retrieval.hybrid.enabled=true} 일 때만 등록되므로,
+ * 기본(off) 상태에서는 dense 빈만 존재해 빈 모호성이 발생하지 않는다.</p>
+ */
+@Slf4j
+public class EgovHybridContentRetriever implements ContentRetriever {
+
+    /** lexical 검색 대상 테이블의 텍스트 컬럼명. PgVectorEmbeddingStore 기본값. */
+    private static final String TEXT_COLUMN = "text";
+
+    private final ContentRetriever denseRetriever;
+    private final JdbcTemplate jdbcTemplate;
+    private final String tableName;
+    private final double denseWeight;
+    private final double lexicalWeight;
+    private final int topK;
+
+    public EgovHybridContentRetriever(ContentRetriever denseRetriever,
+                                      JdbcTemplate jdbcTemplate,
+                                      String tableName,
+                                      double denseWeight,
+                                      double lexicalWeight,
+                                      int topK) {
+        this.denseRetriever = denseRetriever;
+        this.jdbcTemplate = jdbcTemplate;
+        this.tableName = tableName;
+        this.denseWeight = denseWeight;
+        this.lexicalWeight = lexicalWeight;
+        this.topK = topK;
+    }
+
+    @Override
+    public List<Content> retrieve(Query query) {
+        // 1) dense 채널 검색 (벡터 유사도)
+        List<Content> denseContents = denseRetriever.retrieve(query);
+
+        // 2) lexical 채널 검색 (pg_trgm). 실패해도 dense 결과는 보존한다.
+        List<Content> lexicalContents;
+        try {
+            lexicalContents = lexicalSearch(query.text());
+        } catch (Exception e) {
+            log.warn("lexical 검색 실패 - dense 결과만 사용합니다. 원인: {}", e.getMessage());
+            return denseContents;
+        }
+
+        // 3) 융합 키 → Content 매핑 구성 (먼저 등장한 Content를 대표로 유지)
+        Map<String, Content> byKey = new LinkedHashMap<>();
+        List<String> denseRanking = toRanking(denseContents, byKey);
+        List<String> lexicalRanking = toRanking(lexicalContents, byKey);
+
+        // 4) RRF 융합
+        List<String> fusedKeys = EgovRrfFusion.fuse(
+                denseRanking, lexicalRanking, denseWeight, lexicalWeight, EgovRrfFusion.DEFAULT_K, topK);
+
+        List<Content> result = new ArrayList<>(fusedKeys.size());
+        for (String key : fusedKeys) {
+            Content content = byKey.get(key);
+            if (content != null) {
+                result.add(content);
+            }
+        }
+
+        log.debug("하이브리드 검색 - dense: {}, lexical: {}, 융합: {}",
+                denseContents.size(), lexicalContents.size(), result.size());
+        return result;
+    }
+
+    /**
+     * pg_trgm 유사도 기반 lexical 검색.
+     * {@code text % ?} 연산자로 후보를 거른 뒤 similarity 내림차순으로 정렬한다.
+     */
+    private List<Content> lexicalSearch(String queryText) {
+        String sql = "SELECT " + TEXT_COLUMN + ", metadata FROM " + tableName
+                + " WHERE " + TEXT_COLUMN + " % ? ORDER BY similarity(" + TEXT_COLUMN + ", ?) DESC LIMIT ?";
+
+        return jdbcTemplate.query(sql, (rs, rowNum) -> {
+            String text = rs.getString(TEXT_COLUMN);
+            String metadataJson = rs.getString("metadata");
+            return toContent(text, metadataJson);
+        }, queryText, queryText, topK);
+    }
+
+    /** lexical 결과 행을 Content로 변환한다. metadata JSON의 id만 보존한다. */
+    private Content toContent(String text, String metadataJson) {
+        Metadata metadata = new Metadata();
+        String id = extractId(metadataJson);
+        if (id != null) {
+            metadata.put("id", id);
+        }
+        return Content.from(TextSegment.from(text, metadata));
+    }
+
+    /**
+     * Content 리스트를 융합 키 순위로 변환하면서 키→Content 매핑에 등록한다.
+     */
+    private List<String> toRanking(List<Content> contents, Map<String, Content> byKey) {
+        List<String> ranking = new ArrayList<>(contents.size());
+        for (Content content : contents) {
+            String key = fusionKey(content.textSegment());
+            ranking.add(key);
+            byKey.putIfAbsent(key, content);
+        }
+        return ranking;
+    }
+
+    /**
+     * 융합 키 산출: 메타데이터 {@code id} 우선, 없으면 텍스트 해시.
+     */
+    private String fusionKey(TextSegment segment) {
+        String id = segment.metadata() != null ? segment.metadata().getString("id") : null;
+        if (id != null && !id.isBlank()) {
+            return "id:" + id;
+        }
+        String text = segment.text() == null ? "" : segment.text().trim();
+        return "hash:" + DocumentHashUtil.calculateHash(text);
+    }
+
+    /**
+     * metadata JSON 문자열에서 {@code "id"} 값을 추출한다.
+     * 정식 JSON 파서 의존을 피하기 위해 단순 키 탐색만 수행하며, 실패 시 null.
+     */
+    private String extractId(String metadataJson) {
+        if (metadataJson == null) {
+            return null;
+        }
+        int keyIdx = metadataJson.indexOf("\"id\"");
+        if (keyIdx < 0) {
+            return null;
+        }
+        int colon = metadataJson.indexOf(':', keyIdx + 4);
+        if (colon < 0) {
+            return null;
+        }
+        int firstQuote = metadataJson.indexOf('"', colon + 1);
+        if (firstQuote < 0) {
+            return null;
+        }
+        int secondQuote = metadataJson.indexOf('"', firstQuote + 1);
+        if (secondQuote < 0) {
+            return null;
+        }
+        return metadataJson.substring(firstQuote + 1, secondQuote);
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridContentRetriever.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridContentRetriever.java
@@ -34,6 +34,9 @@ public class EgovHybridContentRetriever implements ContentRetriever {
     /** lexical 검색 대상 테이블의 텍스트 컬럼명. PgVectorEmbeddingStore 기본값. */
     private static final String TEXT_COLUMN = "text";
 
+    /** SQL에서 metadata JSON으로부터 추출한 id 별칭 컬럼명. */
+    private static final String DOC_ID_COLUMN = "doc_id";
+
     private final ContentRetriever denseRetriever;
     private final JdbcTemplate jdbcTemplate;
     private final String tableName;
@@ -96,22 +99,26 @@ public class EgovHybridContentRetriever implements ContentRetriever {
      * {@code text % ?} 연산자로 후보를 거른 뒤 similarity 내림차순으로 정렬한다.
      */
     private List<Content> lexicalSearch(String queryText) {
-        String sql = "SELECT " + TEXT_COLUMN + ", metadata FROM " + tableName
+        // id는 SQL단에서 metadata::jsonb ->> 'id'로 추출한다. 이렇게 하면 dense 채널의
+        // Metadata.getString("id")와 동일한 문자열 값이 보장되어(숫자형·중첩·이스케이프
+        // 무관) 융합 키가 채널 간 일치한다. ::jsonb 캐스팅으로 metadata가 text든 jsonb든
+        // 안전하게 동작한다.
+        String sql = "SELECT " + TEXT_COLUMN + ", metadata::jsonb ->> 'id' AS " + DOC_ID_COLUMN
+                + " FROM " + tableName
                 + " WHERE " + TEXT_COLUMN + " % ? ORDER BY similarity(" + TEXT_COLUMN + ", ?) DESC LIMIT ?";
 
         return jdbcTemplate.query(sql, (rs, rowNum) -> {
             String text = rs.getString(TEXT_COLUMN);
-            String metadataJson = rs.getString("metadata");
-            return toContent(text, metadataJson);
+            String docId = rs.getString(DOC_ID_COLUMN);
+            return toContent(text, docId);
         }, queryText, queryText, topK);
     }
 
-    /** lexical 결과 행을 Content로 변환한다. metadata JSON의 id만 보존한다. */
-    private Content toContent(String text, String metadataJson) {
+    /** lexical 결과 행을 Content로 변환한다. SQL로 추출한 id만 보존한다. */
+    private Content toContent(String text, String docId) {
         Metadata metadata = new Metadata();
-        String id = extractId(metadataJson);
-        if (id != null) {
-            metadata.put("id", id);
+        if (docId != null && !docId.isBlank()) {
+            metadata.put("id", docId);
         }
         return Content.from(TextSegment.from(text, metadata));
     }
@@ -131,40 +138,22 @@ public class EgovHybridContentRetriever implements ContentRetriever {
 
     /**
      * 융합 키 산출: 메타데이터 {@code id} 우선, 없으면 텍스트 해시.
+     *
+     * <p>dense 채널은 langchain4j {@code Metadata.getString("id")}로, lexical 채널은
+     * SQL {@code metadata::jsonb ->> 'id'}로 동일한 {@code id} 값을 보존하므로 같은
+     * 문서는 양 채널에서 동일한 융합 키를 가진다.</p>
      */
     private String fusionKey(TextSegment segment) {
         String id = segment.metadata() != null ? segment.metadata().getString("id") : null;
         if (id != null && !id.isBlank()) {
             return "id:" + id;
         }
+        // id가 없을 때만 텍스트 해시로 폴백한다. 빈/null 텍스트는 dedup 과도 병합을
+        // 막기 위해 별도 키로 분리한다.
         String text = segment.text() == null ? "" : segment.text().trim();
+        if (text.isEmpty()) {
+            return "empty:" + System.identityHashCode(segment);
+        }
         return "hash:" + DocumentHashUtil.calculateHash(text);
-    }
-
-    /**
-     * metadata JSON 문자열에서 {@code "id"} 값을 추출한다.
-     * 정식 JSON 파서 의존을 피하기 위해 단순 키 탐색만 수행하며, 실패 시 null.
-     */
-    private String extractId(String metadataJson) {
-        if (metadataJson == null) {
-            return null;
-        }
-        int keyIdx = metadataJson.indexOf("\"id\"");
-        if (keyIdx < 0) {
-            return null;
-        }
-        int colon = metadataJson.indexOf(':', keyIdx + 4);
-        if (colon < 0) {
-            return null;
-        }
-        int firstQuote = metadataJson.indexOf('"', colon + 1);
-        if (firstQuote < 0) {
-            return null;
-        }
-        int secondQuote = metadataJson.indexOf('"', firstQuote + 1);
-        if (secondQuote < 0) {
-            return null;
-        }
-        return metadataJson.substring(firstQuote + 1, secondQuote);
     }
 }

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridContentRetriever.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridContentRetriever.java
@@ -8,6 +8,8 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.query.Query;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -39,22 +41,28 @@ public class EgovHybridContentRetriever implements ContentRetriever {
 
     private final ContentRetriever denseRetriever;
     private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
     private final String tableName;
     private final double denseWeight;
     private final double lexicalWeight;
+    private final double lexicalWordSimilarityThreshold;
     private final int topK;
 
     public EgovHybridContentRetriever(ContentRetriever denseRetriever,
                                       JdbcTemplate jdbcTemplate,
+                                      PlatformTransactionManager transactionManager,
                                       String tableName,
                                       double denseWeight,
                                       double lexicalWeight,
+                                      double lexicalWordSimilarityThreshold,
                                       int topK) {
         this.denseRetriever = denseRetriever;
         this.jdbcTemplate = jdbcTemplate;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.tableName = tableName;
         this.denseWeight = denseWeight;
         this.lexicalWeight = lexicalWeight;
+        this.lexicalWordSimilarityThreshold = lexicalWordSimilarityThreshold;
         this.topK = topK;
     }
 
@@ -95,8 +103,17 @@ public class EgovHybridContentRetriever implements ContentRetriever {
     }
 
     /**
-     * pg_trgm 유사도 기반 lexical 검색.
-     * {@code text % ?} 연산자로 후보를 거른 뒤 similarity 내림차순으로 정렬한다.
+     * pg_trgm word_similarity 기반 lexical 검색.
+     * {@code text %> ?} 연산자로 후보를 거른 뒤 word_similarity 내림차순으로 정렬한다.
+     *
+     * <p><b>연산자 선택 근거</b> — 대칭 similarity({@code %})는 문서(청크)가 길수록 trigram
+     * Jaccard 분모가 커져 값이 붕괴한다. 앱 기본 청크 크기(4000자, {@code DocumentSplitters.recursive})로
+     * 색인한 실제 한국어 문서에서 정답 청크의 {@code similarity}는 0.006~0.058(전부 0.06 미만)로,
+     * 어떤 실용 임계값에서도 lexical 채널이 무력화된다. 반면 {@code word_similarity}는 질의를
+     * 문서의 "가장 잘 맞는 연속 구간"과 비교하므로 청크 길이에 강건하다(동일 코퍼스에서 정답
+     * 청크 word_similarity 0.17~1.0). {@code %>}는 {@code text} 컬럼의 GIN trigram 인덱스를
+     * 그대로 사용한다(Bitmap Index Scan). {@code text %> ?}는 {@code word_similarity(?, text) >=
+     * pg_trgm.word_similarity_threshold}와 동치다.</p>
      */
     private List<Content> lexicalSearch(String queryText) {
         // id는 SQL단에서 metadata::jsonb ->> 'id'로 추출한다. 이렇게 하면 dense 채널의
@@ -105,16 +122,30 @@ public class EgovHybridContentRetriever implements ContentRetriever {
         // 안전하게 동작한다.
         String sql = "SELECT " + TEXT_COLUMN + ", metadata::jsonb ->> 'id' AS " + DOC_ID_COLUMN
                 + " FROM " + tableName
-                + " WHERE " + TEXT_COLUMN + " % ? ORDER BY similarity(" + TEXT_COLUMN + ", ?) DESC LIMIT ?";
+                + " WHERE " + TEXT_COLUMN + " %> ? ORDER BY word_similarity(?, " + TEXT_COLUMN + ") DESC LIMIT ?";
 
-        return jdbcTemplate.query(sql, (rs, rowNum) -> {
-            String text = rs.getString(TEXT_COLUMN);
-            String docId = rs.getString(DOC_ID_COLUMN);
-            return toContent(text, docId);
-        }, queryText, queryText, topK);
+        // word_similarity 임계값을 트랜잭션 스코프(is_local=true)로만 적용한다. 트랜잭션
+        // 커밋/롤백 시 값이 자동 복귀하므로 커넥션 풀에 임계값이 누수되지 않고, %>(GIN trigram
+        // 인덱스) 경로도 유지된다. 코퍼스 언어·문서 특성에 맞춰 프로퍼티로 조정한다.
+        return transactionTemplate.execute(status -> {
+            // set_config는 값을 반환하는 SELECT이므로 queryForObject로 실행한다(update의 executeUpdate는
+            // 행을 반환하는 문에서 예외). 반환값은 사용하지 않는다.
+            jdbcTemplate.queryForObject("SELECT set_config('pg_trgm.word_similarity_threshold', ?, true)",
+                    String.class, Double.toString(lexicalWordSimilarityThreshold));
+            return jdbcTemplate.query(sql, (rs, rowNum) -> {
+                String text = rs.getString(TEXT_COLUMN);
+                String docId = rs.getString(DOC_ID_COLUMN);
+                return toContent(text, docId);
+            }, queryText, queryText, topK);
+        });
     }
 
-    /** lexical 결과 행을 Content로 변환한다. SQL로 추출한 id만 보존한다. */
+    /**
+     * lexical 결과 행을 Content로 변환한다. 융합 키로 쓰는 {@code id}만 보존하고 파일명·소스
+     * 경로 등 나머지 메타데이터는 담지 않는다(의도된 설계). 양 채널에 모두 등장한 문서는 dense
+     * 채널의 완전한 Content가 융합 대표로 유지되고(먼저 등록되어 우선), lexical 단독 문서는
+     * id·text만 컨텍스트에 포함된다 — 본문 자체는 보존되므로 답변 생성에는 지장이 없다.
+     */
     private Content toContent(String text, String docId) {
         Metadata metadata = new Metadata();
         if (docId != null && !docId.isBlank()) {

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridIndexInitializer.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridIndexInitializer.java
@@ -1,0 +1,55 @@
+package com.example.chat.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 하이브리드 lexical 검색용 pg_trgm 인덱스 초기화
+ *
+ * <p>{@code rag.retrieval.hybrid.enabled=true} 일 때만 활성화된다. 애플리케이션
+ * 기동 완료 시점에 {@code pg_trgm} 확장과 GIN 인덱스를 멱등(IF NOT EXISTS)으로
+ * 생성한다. 권한 부족 등으로 실패하더라도 경고만 남기고 기동을 막지 않는다
+ * (graceful degrade). 인덱스가 없으면 lexical 검색은 느려질 뿐 동작 자체는
+ * 유지된다.</p>
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "rag.retrieval.hybrid", name = "enabled", havingValue = "true")
+public class EgovHybridIndexInitializer {
+
+    private static final String TEXT_COLUMN = "text";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final String tableName;
+
+    public EgovHybridIndexInitializer(JdbcTemplate jdbcTemplate,
+                                      @Value("${pgvector.table-name:document_embeddings}") String tableName) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.tableName = tableName;
+    }
+
+    /**
+     * pg_trgm 확장 및 GIN trigram 인덱스를 멱등 생성한다.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void initializeTrigramIndex() {
+        try {
+            jdbcTemplate.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+
+            String indexName = "idx_doc_emb_trgm";
+            String createIndex = "CREATE INDEX IF NOT EXISTS " + indexName
+                    + " ON " + tableName + " USING gin (" + TEXT_COLUMN + " gin_trgm_ops)";
+            jdbcTemplate.execute(createIndex);
+
+            log.info("하이브리드 lexical 인덱스 준비 완료 - table: {}, index: {}", tableName, indexName);
+        } catch (Exception e) {
+            // 권한 부족·미지원 DB 등으로 실패해도 기동을 막지 않는다.
+            log.warn("pg_trgm 인덱스 초기화 실패 - lexical 검색이 느려질 수 있습니다. 원인: {}", e.getMessage());
+        }
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridIndexInitializer.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovHybridIndexInitializer.java
@@ -49,7 +49,9 @@ public class EgovHybridIndexInitializer {
             log.info("하이브리드 lexical 인덱스 준비 완료 - table: {}, index: {}", tableName, indexName);
         } catch (Exception e) {
             // 권한 부족·미지원 DB 등으로 실패해도 기동을 막지 않는다.
-            log.warn("pg_trgm 인덱스 초기화 실패 - lexical 검색이 느려질 수 있습니다. 원인: {}", e.getMessage());
+            // 확장 설치 실패 시에는 lexical 검색이 비활성화되고(% 연산자 미존재로 SQL 예외 →
+            // dense 폴백), 인덱스만 실패한 경우에는 순차 스캔으로 느려질 수 있다.
+            log.warn("pg_trgm 인덱스 초기화 실패 - lexical 검색이 비활성화되거나 느려질 수 있습니다. 원인: {}", e.getMessage());
         }
     }
 }

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovRagConfig.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovRagConfig.java
@@ -12,6 +12,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * RAG 설정 클래스
@@ -38,6 +39,13 @@ public class EgovRagConfig {
 
     @Value("${rag.retrieval.hybrid.top-k:#{null}}")
     private Integer hybridTopK;
+
+    // lexical(pg_trgm word_similarity) 임계값. `%>` 연산자가 참조하는 GUC
+    // pg_trgm.word_similarity_threshold(기본 0.6)는 한국어 긴 청크에서 너무 엄격하다.
+    // 실제 문서(runtime README, 4000자 청크) 측정상 0.30 부근이 recall@3~0.8로 최적이라 기본값을
+    // 0.30으로 둔다. 코퍼스 언어·문서 특성에 따라 프로퍼티로 조정한다.
+    @Value("${rag.retrieval.hybrid.lexical.word-similarity-threshold:0.30}")
+    private double hybridLexicalWordSimilarityThreshold;
 
     /**
      * ContentRetriever 빈 생성
@@ -72,20 +80,22 @@ public class EgovRagConfig {
      *
      * @param denseContentRetriever dense 벡터 검색 빈
      * @param jdbcTemplate          lexical 검색용 JdbcTemplate(자동 구성)
+     * @param transactionManager    lexical 임계값을 트랜잭션 스코프로 적용하기 위한 트랜잭션 매니저
      * @return 하이브리드 ContentRetriever
      */
     @Bean
     @ConditionalOnProperty(prefix = "rag.retrieval.hybrid", name = "enabled", havingValue = "true")
     public ContentRetriever hybridContentRetriever(
             @Qualifier("contentRetriever") ContentRetriever denseContentRetriever,
-            JdbcTemplate jdbcTemplate) {
+            JdbcTemplate jdbcTemplate,
+            PlatformTransactionManager transactionManager) {
 
         int effectiveTopK = (hybridTopK != null) ? hybridTopK : topK;
-        log.info("HybridContentRetriever 초기화 - topK: {}, weight(dense/lexical): {}/{}",
-                effectiveTopK, hybridDenseWeight, hybridLexicalWeight);
+        log.info("HybridContentRetriever 초기화 - topK: {}, weight(dense/lexical): {}/{}, lexical word_similarity 임계값: {}",
+                effectiveTopK, hybridDenseWeight, hybridLexicalWeight, hybridLexicalWordSimilarityThreshold);
 
         return new EgovHybridContentRetriever(
-                denseContentRetriever, jdbcTemplate, tableName,
-                hybridDenseWeight, hybridLexicalWeight, effectiveTopK);
+                denseContentRetriever, jdbcTemplate, transactionManager, tableName,
+                hybridDenseWeight, hybridLexicalWeight, hybridLexicalWordSimilarityThreshold, effectiveTopK);
     }
 }

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovRagConfig.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovRagConfig.java
@@ -6,9 +6,12 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * RAG 설정 클래스
@@ -23,6 +26,18 @@ public class EgovRagConfig {
 
     @Value("${rag.similarity.threshold:0.20}")
     private double similarityThreshold;
+
+    @Value("${pgvector.table-name:document_embeddings}")
+    private String tableName;
+
+    @Value("${rag.retrieval.hybrid.weight.dense:1.0}")
+    private double hybridDenseWeight;
+
+    @Value("${rag.retrieval.hybrid.weight.lexical:1.0}")
+    private double hybridLexicalWeight;
+
+    @Value("${rag.retrieval.hybrid.top-k:#{null}}")
+    private Integer hybridTopK;
 
     /**
      * ContentRetriever 빈 생성
@@ -45,5 +60,32 @@ public class EgovRagConfig {
                 .maxResults(topK)
                 .minScore(similarityThreshold)
                 .build();
+    }
+
+    /**
+     * 하이브리드 ContentRetriever 빈 생성
+     *
+     * <p>{@code rag.retrieval.hybrid.enabled=true} 일 때만 등록한다. off(기본) 상태에서는
+     * 빈이 만들어지지 않으므로 dense {@code contentRetriever} 빈만 존재하여 빈 모호성이
+     * 발생하지 않는다. dense 검색({@link #contentRetriever})과 lexical 검색(pg_trgm)을
+     * RRF로 융합한다.</p>
+     *
+     * @param denseContentRetriever dense 벡터 검색 빈
+     * @param jdbcTemplate          lexical 검색용 JdbcTemplate(자동 구성)
+     * @return 하이브리드 ContentRetriever
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "rag.retrieval.hybrid", name = "enabled", havingValue = "true")
+    public ContentRetriever hybridContentRetriever(
+            @Qualifier("contentRetriever") ContentRetriever denseContentRetriever,
+            JdbcTemplate jdbcTemplate) {
+
+        int effectiveTopK = (hybridTopK != null) ? hybridTopK : topK;
+        log.info("HybridContentRetriever 초기화 - topK: {}, weight(dense/lexical): {}/{}",
+                effectiveTopK, hybridDenseWeight, hybridLexicalWeight);
+
+        return new EgovHybridContentRetriever(
+                denseContentRetriever, jdbcTemplate, tableName,
+                hybridDenseWeight, hybridLexicalWeight, effectiveTopK);
     }
 }

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovRrfFusion.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovRrfFusion.java
@@ -1,0 +1,74 @@
+package com.example.chat.config;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RRF(Reciprocal Rank Fusion) 융합 유틸리티
+ *
+ * <p>여러 검색 채널(예: dense 벡터 검색, lexical 키워드 검색)이 각각 반환한
+ * 순위 리스트를 하나의 순위로 융합한다. 각 키의 융합 점수는 채널별 순위의
+ * 역수 합으로 계산한다.</p>
+ *
+ * <pre>
+ *   score(d) = Σ_channel  weight / (k + rank)
+ * </pre>
+ *
+ * <p>여기서 {@code rank}는 해당 채널에서 키가 등장한 0-based 순위이며,
+ * {@code k}는 상위권 항목의 영향력을 완화하는 상수(표준값 60)이다.
+ * 외부 의존성이 없는 순수 함수로, 동일 입력에 대해 항상 동일한 순서를 반환한다.</p>
+ */
+public final class EgovRrfFusion {
+
+    /** RRF 표준 상수. 상위 순위 항목의 가중치를 완화한다. */
+    public static final int DEFAULT_K = 60;
+
+    private EgovRrfFusion() {
+    }
+
+    /**
+     * 두 채널(dense, lexical)의 순위 리스트를 RRF로 융합한다.
+     *
+     * @param denseRanking   dense 채널이 반환한 키 순서(상위가 앞)
+     * @param lexicalRanking lexical 채널이 반환한 키 순서(상위가 앞)
+     * @param denseWeight    dense 채널 가중치
+     * @param lexicalWeight  lexical 채널 가중치
+     * @param k              RRF 상수(일반적으로 {@link #DEFAULT_K})
+     * @param topK           반환할 상위 키 개수
+     * @param <T>            융합 키 타입
+     * @return 융합 점수 내림차순으로 정렬된 상위 {@code topK} 키
+     */
+    public static <T> List<T> fuse(List<T> denseRanking,
+                                   List<T> lexicalRanking,
+                                   double denseWeight,
+                                   double lexicalWeight,
+                                   int k,
+                                   int topK) {
+        // 키 등장 순서를 보존해 동점 시 결정적 정렬을 보장한다.
+        Map<T, Double> scores = new LinkedHashMap<>();
+        accumulate(scores, denseRanking, denseWeight, k);
+        accumulate(scores, lexicalRanking, lexicalWeight, k);
+
+        return scores.entrySet().stream()
+                // 점수 내림차순. 동점은 LinkedHashMap의 삽입 순서(=등장 순서)를 유지한다.
+                .sorted((a, b) -> Double.compare(b.getValue(), a.getValue()))
+                .limit(Math.max(topK, 0))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    private static <T> void accumulate(Map<T, Double> scores, List<T> ranking, double weight, int k) {
+        if (ranking == null) {
+            return;
+        }
+        for (int rank = 0; rank < ranking.size(); rank++) {
+            T key = ranking.get(rank);
+            if (key == null) {
+                continue;
+            }
+            double contribution = weight / (k + rank);
+            scores.merge(key, contribution, Double::sum);
+        }
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/service/ChatbotFactory.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/service/ChatbotFactory.java
@@ -7,6 +7,8 @@ import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -41,12 +43,24 @@ public class ChatbotFactory {
     @Value("${chat.memory.max-messages:20}")
     private int maxMessages;
 
-    public ChatbotFactory(ContentRetriever contentRetriever,
-                          PersistentChatMemoryStore chatMemoryStore,
-                          OllamaStreamingChatModel defaultStreamingModel) {
-        this.contentRetriever = contentRetriever;
+    /**
+     * @param hybridContentRetriever 하이브리드 검색 빈. {@code rag.retrieval.hybrid.enabled=true}
+     *                               일 때만 등록되며 off(기본) 상태에서는 null 이다.
+     * @param denseContentRetriever  dense 벡터 검색 빈. 항상 존재한다.
+     */
+    public ChatbotFactory(
+            @Qualifier("hybridContentRetriever") @Autowired(required = false) ContentRetriever hybridContentRetriever,
+            @Qualifier("contentRetriever") ContentRetriever denseContentRetriever,
+            PersistentChatMemoryStore chatMemoryStore,
+            OllamaStreamingChatModel defaultStreamingModel) {
+        // 하이브리드 빈이 등록된 경우 우선 사용하고, 없으면 기존 dense 경로를 유지한다.
+        this.contentRetriever = (hybridContentRetriever != null) ? hybridContentRetriever : denseContentRetriever;
         this.chatMemoryStore = chatMemoryStore;
         this.defaultStreamingModel = defaultStreamingModel;
+
+        if (hybridContentRetriever != null) {
+            log.info("ChatbotFactory - 하이브리드 ContentRetriever 사용");
+        }
     }
 
     /**

--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -112,6 +112,18 @@ rag:
   # RAG 검색 결과 개수 (Top K)
   top-k: 3
 
+  # 하이브리드 검색(dense 벡터 + lexical pg_trgm, RRF 융합) 설정
+  retrieval:
+    hybrid:
+      # 활성화 여부. false(기본)이면 dense 단일 검색만 사용 (기존 동작 유지)
+      enabled: false
+      # 채널 가중치
+      weight:
+        dense: 1.0
+        lexical: 1.0
+      # 융합 결과 개수. 미설정 시 rag.top-k 값을 사용
+      top-k: 3
+
 # 채팅 메모리 설정
 chat:
   memory:

--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -123,6 +123,13 @@ rag:
         lexical: 1.0
       # 융합 결과 개수. 미설정 시 rag.top-k 값을 사용
       top-k: 3
+      # lexical(pg_trgm word_similarity) 임계값. `%>` 연산자가 참조하는 GUC
+      # pg_trgm.word_similarity_threshold(기본 0.6)는 한국어 긴 청크에 과도하게 엄격하다.
+      # 실제 문서(4000자 청크) 측정상 0.30 부근이 recall@3~0.8로 최적. 트랜잭션 스코프로만
+      # 적용되어 커넥션 풀에 누수되지 않는다. recall을 더 원하면 하향(노이즈↑), 정밀도를
+      # 원하면 상향한다.
+      lexical:
+        word-similarity-threshold: 0.30
 
 # 채팅 메모리 설정
 chat:

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridContentRetrieverTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridContentRetrieverTest.java
@@ -7,8 +7,10 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.query.Query;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import java.sql.ResultSet;
 import java.util.List;
@@ -17,7 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -29,6 +33,17 @@ import static org.mockito.Mockito.when;
 class EgovHybridContentRetrieverTest {
 
     private static final String TABLE = "document_embeddings";
+
+    // lexical word_similarity 임계값 테스트값(프로덕션 기본 0.30과 무관하게 융합 로직만 검증).
+    private static final double LEXICAL_THRESHOLD = 0.30;
+
+    /**
+     * 통과용 트랜잭션 매니저. mock 이므로 getTransaction 은 null 을 반환하고 commit 은 no-op 이라
+     * {@code transactionTemplate.execute(...)} 콜백이 그대로 실행된다(실제 DB·트랜잭션 없음).
+     */
+    private PlatformTransactionManager passthroughTxManager() {
+        return mock(PlatformTransactionManager.class);
+    }
 
     private Content content(String id, String text) {
         Metadata metadata = new Metadata();
@@ -64,7 +79,7 @@ class EgovHybridContentRetrieverTest {
                 content("L1", "lexical only one")));
 
         EgovHybridContentRetriever retriever =
-                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+                new EgovHybridContentRetriever(dense, jdbc, passthroughTxManager(), TABLE, 1.0, 1.0, LEXICAL_THRESHOLD, 3);
 
         List<Content> result = retriever.retrieve(Query.from("shared"));
 
@@ -89,7 +104,7 @@ class EgovHybridContentRetrieverTest {
                 .thenThrow(new RuntimeException("relation does not exist"));
 
         EgovHybridContentRetriever retriever =
-                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+                new EgovHybridContentRetriever(dense, jdbc, passthroughTxManager(), TABLE, 1.0, 1.0, LEXICAL_THRESHOLD, 3);
 
         List<Content> result = retriever.retrieve(Query.from("alpha"));
 
@@ -109,7 +124,7 @@ class EgovHybridContentRetrieverTest {
 
         // lexical 가중 3배 -> LEX_TOP(3/60) > DENSE_TOP(1/60)
         EgovHybridContentRetriever retriever =
-                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 3.0, 3);
+                new EgovHybridContentRetriever(dense, jdbc, passthroughTxManager(), TABLE, 1.0, 3.0, LEXICAL_THRESHOLD, 3);
 
         List<Content> result = retriever.retrieve(Query.from("top"));
 
@@ -129,7 +144,7 @@ class EgovHybridContentRetrieverTest {
                 content(null, "same text body")));
 
         EgovHybridContentRetriever retriever =
-                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+                new EgovHybridContentRetriever(dense, jdbc, passthroughTxManager(), TABLE, 1.0, 1.0, LEXICAL_THRESHOLD, 3);
 
         List<Content> result = retriever.retrieve(Query.from("same"));
 
@@ -154,7 +169,7 @@ class EgovHybridContentRetrieverTest {
                 content("SAME", "shared body")));
 
         EgovHybridContentRetriever retriever =
-                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+                new EgovHybridContentRetriever(dense, jdbc, passthroughTxManager(), TABLE, 1.0, 1.0, LEXICAL_THRESHOLD, 3);
 
         List<Content> result = retriever.retrieve(Query.from("shared"));
 
@@ -187,12 +202,42 @@ class EgovHybridContentRetrieverTest {
                 });
 
         EgovHybridContentRetriever retriever =
-                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+                new EgovHybridContentRetriever(dense, jdbc, passthroughTxManager(), TABLE, 1.0, 1.0, LEXICAL_THRESHOLD, 3);
 
         List<Content> result = retriever.retrieve(Query.from("numeric"));
 
         // dense("42") 와 lexical(doc_id="42") 이 동일 키로 합쳐져 단일 결과로 보강된다.
         assertThat(result).hasSize(1);
         assertThat(result.get(0).textSegment().metadata().getString("id")).isEqualTo("42");
+    }
+
+    @Test
+    @DisplayName("lexical SQL은 word_similarity(%>) 연산자를 올바른 인자 방향으로 사용하고 임계값을 트랜잭션 스코프로 설정한다")
+    void lexicalSqlUsesWordSimilarityOperatorInCorrectDirection() {
+        ContentRetriever dense = mock(ContentRetriever.class);
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+        when(dense.retrieve(any(Query.class))).thenReturn(List.of(content("D1", "dense body")));
+        stubLexical(jdbc, List.of(content("L1", "lexical body")));
+
+        EgovHybridContentRetriever retriever =
+                new EgovHybridContentRetriever(dense, jdbc, passthroughTxManager(), TABLE, 1.0, 1.0, LEXICAL_THRESHOLD, 3);
+        retriever.retrieve(Query.from("리액티브 레디스"));
+
+        // 1) 게이트 쿼리: %> 연산자 + word_similarity(?, text) 방향(대칭 similarity/% 아님) + LIMIT 바인드 순서.
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        verify(jdbc).query(sql.capture(), any(RowMapper.class),
+                eq("리액티브 레디스"), eq("리액티브 레디스"), eq(3));
+        assertThat(sql.getValue())
+                .contains(" %> ?")
+                .contains("word_similarity(?, text)")
+                .doesNotContain("similarity(text,"); // 대칭 similarity 회귀 방지
+
+        // 2) 임계값은 word_similarity_threshold GUC를 트랜잭션 스코프(is_local=true)로 설정.
+        //    set_config는 값을 반환하는 SELECT이므로 queryForObject로 실행한다(update 아님).
+        ArgumentCaptor<String> setSql = ArgumentCaptor.forClass(String.class);
+        verify(jdbc).queryForObject(setSql.capture(), eq(String.class), eq(Double.toString(LEXICAL_THRESHOLD)));
+        assertThat(setSql.getValue())
+                .contains("pg_trgm.word_similarity_threshold")
+                .contains("true"); // is_local
     }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridContentRetrieverTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridContentRetrieverTest.java
@@ -1,0 +1,139 @@
+package com.example.chat.config;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link EgovHybridContentRetriever} 의 dense + lexical 융합 동작을 검증한다.
+ *
+ * <p>fake dense 채널({@link ContentRetriever})과 lexical 채널({@link JdbcTemplate})을
+ * 주입해 외부 DB 없이 융합 결과를 결정적으로 단정한다.</p>
+ */
+class EgovHybridContentRetrieverTest {
+
+    private static final String TABLE = "document_embeddings";
+
+    private Content content(String id, String text) {
+        Metadata metadata = new Metadata();
+        if (id != null) {
+            metadata.put("id", id);
+        }
+        return Content.from(TextSegment.from(text, metadata));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private List<Content> stubLexical(JdbcTemplate jdbc, List<Content> lexicalResults) {
+        // query(String sql, RowMapper, Object... args) - 가변인자 3개(queryText, queryText, topK)
+        when(jdbc.query(anyString(), any(RowMapper.class), anyString(), anyString(), anyInt()))
+                .thenReturn((List) lexicalResults);
+        return lexicalResults;
+    }
+
+    @Test
+    @DisplayName("양 채널에 공통으로 나온 문서가 융합 상위로 올라온다")
+    void commonDocumentRanksHigh() {
+        ContentRetriever dense = mock(ContentRetriever.class);
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+
+        // dense: [D1, COMMON, D2]
+        when(dense.retrieve(any(Query.class))).thenReturn(List.of(
+                content("D1", "dense only one"),
+                content("COMMON", "shared document"),
+                content("D2", "dense only two")));
+
+        // lexical: [COMMON, L1]
+        stubLexical(jdbc, List.of(
+                content("COMMON", "shared document"),
+                content("L1", "lexical only one")));
+
+        EgovHybridContentRetriever retriever =
+                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+
+        List<Content> result = retriever.retrieve(Query.from("shared"));
+
+        // COMMON 은 dense r1(1/61) + lexical r0(1/60) 으로 최고점
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).textSegment().metadata().getString("id")).isEqualTo("COMMON");
+        assertThat(result).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("lexical 검색 실패 시 dense 결과만 반환해 RAG 를 보존한다")
+    void degradesToDenseOnLexicalFailure() {
+        ContentRetriever dense = mock(ContentRetriever.class);
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+
+        List<Content> denseResult = List.of(
+                content("D1", "alpha"),
+                content("D2", "beta"));
+        when(dense.retrieve(any(Query.class))).thenReturn(denseResult);
+
+        when(jdbc.query(anyString(), any(RowMapper.class), anyString(), anyString(), anyInt()))
+                .thenThrow(new RuntimeException("relation does not exist"));
+
+        EgovHybridContentRetriever retriever =
+                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+
+        List<Content> result = retriever.retrieve(Query.from("alpha"));
+
+        assertThat(result).isEqualTo(denseResult);
+    }
+
+    @Test
+    @DisplayName("lexical 가중치를 높이면 lexical 단독 문서가 dense 단독 문서보다 우선된다")
+    void lexicalWeightChangesOrder() {
+        ContentRetriever dense = mock(ContentRetriever.class);
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+
+        when(dense.retrieve(any(Query.class))).thenReturn(List.of(
+                content("DENSE_TOP", "dense top")));
+        stubLexical(jdbc, List.of(
+                content("LEX_TOP", "lexical top")));
+
+        // lexical 가중 3배 -> LEX_TOP(3/60) > DENSE_TOP(1/60)
+        EgovHybridContentRetriever retriever =
+                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 3.0, 3);
+
+        List<Content> result = retriever.retrieve(Query.from("top"));
+
+        assertThat(result.get(0).textSegment().metadata().getString("id")).isEqualTo("LEX_TOP");
+    }
+
+    @Test
+    @DisplayName("id 가 없으면 텍스트 해시로 중복을 제거해 융합한다")
+    void deduplicatesByTextHashWhenNoId() {
+        ContentRetriever dense = mock(ContentRetriever.class);
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+
+        // 동일 텍스트, id 없음 -> 동일 융합 키
+        when(dense.retrieve(any(Query.class))).thenReturn(List.of(
+                content(null, "same text body")));
+        stubLexical(jdbc, List.of(
+                content(null, "same text body")));
+
+        EgovHybridContentRetriever retriever =
+                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+
+        List<Content> result = retriever.retrieve(Query.from("same"));
+
+        // 동일 키로 합쳐져 단일 결과
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).textSegment().text()).isEqualTo("same text body");
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridContentRetrieverTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridContentRetrieverTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
+import java.sql.ResultSet;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -135,5 +136,63 @@ class EgovHybridContentRetrieverTest {
         // 동일 키로 합쳐져 단일 결과
         assertThat(result).hasSize(1);
         assertThat(result.get(0).textSegment().text()).isEqualTo("same text body");
+    }
+
+    @Test
+    @DisplayName("dense 와 lexical 이 같은 id 문서를 반환하면 융합 키가 일치해 RRF 보강이 일어난다")
+    void crossChannelReinforcementWhenSameId() {
+        ContentRetriever dense = mock(ContentRetriever.class);
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+
+        // SAME 은 dense 에서도 lexical 에서도 중위권이지만, 같은 id 로 양 채널에 등장하므로
+        // 융합 시 순위 역수가 합산되어 단일 채널 상위 문서보다 위로 올라와야 한다.
+        when(dense.retrieve(any(Query.class))).thenReturn(List.of(
+                content("DTOP", "dense top"),
+                content("SAME", "shared body")));
+        stubLexical(jdbc, List.of(
+                content("LTOP", "lexical top"),
+                content("SAME", "shared body")));
+
+        EgovHybridContentRetriever retriever =
+                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+
+        List<Content> result = retriever.retrieve(Query.from("shared"));
+
+        // SAME: dense r1(1/61) + lexical r1(1/61) = 2/61 > DTOP(1/60) = LTOP(1/60)
+        assertThat(result.get(0).textSegment().metadata().getString("id")).isEqualTo("SAME");
+        // 양 채널이 동일 키로 합쳐져 중복 없이 3개만 남는다(SAME, DTOP, LTOP)
+        assertThat(result).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("숫자형 id 도 SQL doc_id 컬럼으로 추출되어 dense 와 키가 일치한다(파싱 의존 제거)")
+    void numericIdMatchesViaSqlDocIdColumn() throws Exception {
+        ContentRetriever dense = mock(ContentRetriever.class);
+        JdbcTemplate jdbc = mock(JdbcTemplate.class);
+
+        // dense: id 가 따옴표 없는 숫자형이었더라도 langchain4j Metadata 에는 문자열 "42" 로 보존
+        when(dense.retrieve(any(Query.class))).thenReturn(List.of(
+                content("42", "numeric id body")));
+
+        // lexical: 실제 RowMapper 를 실행해 SQL doc_id 컬럼 경로를 검증한다.
+        // metadata::jsonb ->> 'id' 는 숫자형 id 도 문자열 "42" 로 반환한다.
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getString("text")).thenReturn("numeric id body");
+        when(rs.getString("doc_id")).thenReturn("42");
+
+        when(jdbc.query(anyString(), any(RowMapper.class), anyString(), anyString(), anyInt()))
+                .thenAnswer(invocation -> {
+                    RowMapper<Content> mapper = invocation.getArgument(1);
+                    return List.of(mapper.mapRow(rs, 0));
+                });
+
+        EgovHybridContentRetriever retriever =
+                new EgovHybridContentRetriever(dense, jdbc, TABLE, 1.0, 1.0, 3);
+
+        List<Content> result = retriever.retrieve(Query.from("numeric"));
+
+        // dense("42") 와 lexical(doc_id="42") 이 동일 키로 합쳐져 단일 결과로 보강된다.
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).textSegment().metadata().getString("id")).isEqualTo("42");
     }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridLexicalSearchDbTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridLexicalSearchDbTest.java
@@ -1,0 +1,156 @@
+package com.example.chat.config;
+
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 하이브리드 lexical 검색을 <b>실제 PostgreSQL + pg_trgm</b>에 대해 실행하는 통합 테스트.
+ *
+ * <p>mock 문자열 단정을 넘어, 프로덕션 SQL({@code text %> ?} / {@code word_similarity(?, text)})이
+ * 실 엔진에서 의도대로 동작함을 증명한다. 특히 (1) 대칭 {@code similarity}({@code %})는 큰 청크에서
+ * 붕괴해 무력하고 {@code word_similarity}만 관련 문서를 회수한다는 점, (2) {@code %>}의 인자 방향이
+ * 뒤바뀌지 않았다는 점, (3) 임계값 {@code set_config(is_local=true)}가 트랜잭션 스코프라 커넥션에
+ * 누수되지 않는다는 점을 검증한다.</p>
+ *
+ * <p>Docker 미가용 환경에서는 {@code @Testcontainers(disabledWithoutDocker = true)}로 자동 skip된다.</p>
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class EgovHybridLexicalSearchDbTest {
+
+    private static final String TABLE = "document_embeddings";
+
+    // 앱 실제 청크 크기(~수천 자)를 모사한 긴 한국어 문서 청크. 짧은 질의 대비 similarity가 붕괴한다.
+    private static final String REDIS_CHUNK =
+            "# egovframe-rte-psl-reactive-redis 스프링 데이터 레디스와 Lettuce를 이용한 리액티브 레디스 접근 모듈입니다. "
+            + "논블로킹 방식으로 캐시를 조회하고 저장하며 ReactiveRedisTemplate 을 통해 키 값 연산과 만료 시간을 설정합니다. "
+            + "세션 저장소나 조회 결과 캐싱에 활용하고 백프레셔를 지원하는 리액티브 스트림으로 대량 데이터를 처리합니다. ".repeat(6);
+    private static final String CRYPTO_CHUNK =
+            "# egovframe-rte-fdl-crypto 대칭키 암복호화 모듈로 ARIA 와 PBE 알고리즘을 제공합니다. "
+            + "비밀번호는 단방향 해시 다이제스트로 저장하고 설정 파일의 민감한 값은 환경 암호화 서비스로 보호합니다. ".repeat(8);
+    private static final String BOILERPLATE_CHUNK =
+            "빌드 방법 mvn clean package 테스트 실행 mvn test 라이선스 Apache License 2.0 문의는 이슈 트래커를 이용하세요. ".repeat(4);
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static DataSource dataSource;
+    static JdbcTemplate jdbc;
+    static DataSourceTransactionManager txManager;
+
+    @BeforeAll
+    static void setUp() {
+        DriverManagerDataSource ds = new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+        ds.setDriverClassName("org.postgresql.Driver");
+        dataSource = ds;
+        jdbc = new JdbcTemplate(ds);
+        txManager = new DataSourceTransactionManager(ds);
+
+        jdbc.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+        jdbc.execute("CREATE TABLE " + TABLE + " (embedding_id serial primary key, text text, metadata jsonb)");
+        jdbc.execute("CREATE INDEX idx_doc_emb_trgm ON " + TABLE + " USING gin (text gin_trgm_ops)");
+        insert("redis", REDIS_CHUNK);
+        insert("crypto", CRYPTO_CHUNK);
+        insert("boiler", BOILERPLATE_CHUNK);
+    }
+
+    static void insert(String id, String text) {
+        jdbc.update("INSERT INTO " + TABLE + "(text, metadata) VALUES (?, ?::jsonb)",
+                text, "{\"id\": \"" + id + "\"}");
+    }
+
+    private EgovHybridContentRetriever retriever(double threshold) {
+        // dense 채널은 빈 결과 → 융합 결과는 lexical 채널 그대로. 실제 lexical SQL 경로를 실행한다.
+        ContentRetriever emptyDense = q -> List.of();
+        return new EgovHybridContentRetriever(emptyDense, jdbc, txManager, TABLE, 1.0, 1.0, threshold, 3);
+    }
+
+    private static List<String> ids(List<Content> contents) {
+        return contents.stream().map(c -> c.textSegment().metadata().getString("id")).toList();
+    }
+
+    @Test
+    @DisplayName("word_similarity(%>)가 긴 청크에서도 관련 문서를 회수한다 - 인자 방향·연산자 end-to-end")
+    void wordSimilarityRetrievesFromLongChunk() {
+        List<Content> result = retriever(0.30).retrieve(Query.from("리액티브 레디스 캐시 사용"));
+        assertThat(ids(result)).contains("redis");
+        assertThat(ids(result).get(0)).isEqualTo("redis"); // 최상위로 회수
+    }
+
+    @Test
+    @DisplayName("대칭 similarity(%)는 같은 긴 청크에서 붕괴한다 - 연산자 교체의 근거")
+    void symmetricSimilarityCollapsesOnLongChunk() {
+        // 정답 청크의 대칭 similarity는 pg_trgm 기본 임계값 0.3은커녕 0.1에도 못 미친다.
+        Double sim = jdbc.queryForObject(
+                "SELECT similarity(text, ?) FROM " + TABLE + " WHERE metadata->>'id' = 'redis'",
+                Double.class, "리액티브 레디스 캐시 사용");
+        assertThat(sim).isLessThan(0.1);
+        // 반면 word_similarity(query, text) 는 실용 범위(>= 0.3)에 든다.
+        Double wsim = jdbc.queryForObject(
+                "SELECT word_similarity(?, text) FROM " + TABLE + " WHERE metadata->>'id' = 'redis'",
+                Double.class, "리액티브 레디스 캐시 사용");
+        assertThat(wsim).isGreaterThanOrEqualTo(0.3);
+    }
+
+    @Test
+    @DisplayName("%> 인자 방향이 뒤바뀌지 않았다 - word_similarity(query,text) >> word_similarity(text,query)")
+    void argumentDirectionIsNotReversed() {
+        Double qInText = jdbc.queryForObject(
+                "SELECT word_similarity(?, text) FROM " + TABLE + " WHERE metadata->>'id'='redis'",
+                Double.class, "리액티브 레디스 캐시 사용");
+        Double textInQ = jdbc.queryForObject(
+                "SELECT word_similarity(text, ?) FROM " + TABLE + " WHERE metadata->>'id'='redis'",
+                Double.class, "리액티브 레디스 캐시 사용");
+        // 프로덕션이 쓰는 방향(query-in-text)이 반대 방향보다 월등히 높아야 한다.
+        assertThat(qInText).isGreaterThan(textInQ * 3);
+    }
+
+    @Test
+    @DisplayName("임계값이 실제 게이트로 작동한다 - 0.30에선 회수, 0.90에선 차단")
+    void thresholdActuallyGates() {
+        Query q = Query.from("리액티브 레디스 캐시 사용");
+        assertThat(ids(retriever(0.30).retrieve(q))).contains("redis"); // 완화 → 회수
+        assertThat(ids(retriever(0.90).retrieve(q))).doesNotContain("redis"); // 강화 → 차단
+    }
+
+    @Test
+    @DisplayName("set_config(is_local=true)는 트랜잭션 스코프 - 커밋 후 기본값 복귀(풀 누수 없음)")
+    void thresholdIsTransactionScoped() throws Exception {
+        try (java.sql.Connection c = dataSource.getConnection()) {
+            c.setAutoCommit(false);
+            try (java.sql.Statement st = c.createStatement()) {
+                st.execute("SELECT word_similarity('a','b')"); // pg_trgm GUC를 백엔드에 로드
+                st.execute("SELECT set_config('pg_trgm.word_similarity_threshold','0.15', true)");
+                double inTx = readThreshold(st);
+                c.commit();
+                double afterCommit = readThreshold(st); // 커밋 후 같은 커넥션에서 기본값 복귀
+                assertThat(inTx).isEqualTo(0.15);
+                assertThat(afterCommit).isEqualTo(0.6);
+            }
+        }
+    }
+
+    private static double readThreshold(java.sql.Statement st) throws Exception {
+        try (java.sql.ResultSet rs = st.executeQuery(
+                "SELECT current_setting('pg_trgm.word_similarity_threshold')::float8")) {
+            rs.next();
+            return rs.getDouble(1);
+        }
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridRetrieverToggleTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridRetrieverToggleTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -66,6 +67,11 @@ class EgovHybridRetrieverToggleTest {
         @Bean
         JdbcTemplate jdbcTemplate() {
             return mock(JdbcTemplate.class);
+        }
+
+        @Bean
+        PlatformTransactionManager transactionManager() {
+            return mock(PlatformTransactionManager.class);
         }
     }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridRetrieverToggleTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovHybridRetrieverToggleTest.java
@@ -1,0 +1,71 @@
+package com.example.chat.config;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * {@code rag.retrieval.hybrid.enabled} 토글에 따른 빈 등록 동작을 검증한다.
+ *
+ * <p>off(기본) 상태에서는 하이브리드 빈이 등록되지 않아 {@link ContentRetriever}
+ * 타입 빈이 dense 하나뿐이므로 빈 모호성(NoUniqueBeanDefinitionException)이
+ * 발생하지 않는다. on 상태에서는 dense·hybrid 두 빈이 공존한다.</p>
+ */
+class EgovHybridRetrieverToggleTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(TestBeans.class, EgovRagConfig.class);
+
+    @Test
+    @DisplayName("토글 off(기본): 하이브리드 빈 미등록, ContentRetriever 는 dense 단일")
+    void hybridBeanAbsentWhenDisabled() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean("hybridContentRetriever");
+            assertThat(context).hasBean("contentRetriever");
+            assertThat(context.getBeanNamesForType(ContentRetriever.class)).hasSize(1);
+        });
+    }
+
+    @Test
+    @DisplayName("토글 on: dense·hybrid 빈 공존, Qualifier 로 모호성 없이 구분")
+    void hybridBeanPresentWhenEnabled() {
+        runner.withPropertyValues("rag.retrieval.hybrid.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasBean("contentRetriever");
+            assertThat(context).hasBean("hybridContentRetriever");
+            assertThat(context.getBeanNamesForType(ContentRetriever.class)).hasSize(2);
+            assertThat(context.getBean("hybridContentRetriever"))
+                    .isInstanceOf(EgovHybridContentRetriever.class);
+        });
+    }
+
+    @Configuration
+    static class TestBeans {
+        @Bean
+        @SuppressWarnings("unchecked")
+        EmbeddingStore<TextSegment> embeddingStore() {
+            return mock(EmbeddingStore.class);
+        }
+
+        @Bean
+        EmbeddingModel embeddingModel() {
+            return mock(EmbeddingModel.class);
+        }
+
+        @Bean
+        JdbcTemplate jdbcTemplate() {
+            return mock(JdbcTemplate.class);
+        }
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovRrfFusionTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovRrfFusionTest.java
@@ -1,0 +1,152 @@
+package com.example.chat.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * {@link EgovRrfFusion} 의 RRF 융합 로직을 결정적으로 검증한다.
+ *
+ * <p>표준 RRF 수식 {@code score(d) = Σ weight/(k+rank)} 을 골든셋으로 단정하고,
+ * 채널 가중치 변화에 따른 순서 변화, recall@k, MRR 을 확인한다.</p>
+ */
+class EgovRrfFusionTest {
+
+    private static final int K = EgovRrfFusion.DEFAULT_K; // 60
+
+    @Test
+    @DisplayName("표준 RRF 수식(k=60)에 따라 융합 점수가 계산된다")
+    void computesStandardRrfScore() {
+        // dense: [A, B, C], lexical: [B, A, D]
+        // A: 1/60(dense r0) + 1/61(lexical r1) = 0.016666... + 0.016393... = 0.033060...
+        // B: 1/61(dense r1) + 1/60(lexical r0) = 0.016393... + 0.016666... = 0.033060...
+        // 동점 -> 먼저 등장한 A 가 앞 (dense 먼저 누적)
+        // C: 1/62 = 0.016129...
+        // D: 1/62 = 0.016129...  (C 가 먼저 등장)
+        List<String> dense = List.of("A", "B", "C");
+        List<String> lexical = List.of("B", "A", "D");
+
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 10);
+
+        assertThat(fused).containsExactly("A", "B", "C", "D");
+    }
+
+    @Test
+    @DisplayName("양 채널 상위에 모두 등장한 키가 최상위로 융합된다")
+    void itemInBothChannelsRanksHighest() {
+        // X 는 양쪽 모두 0순위 -> 가장 높은 점수
+        List<String> dense = List.of("X", "A", "B");
+        List<String> lexical = List.of("X", "C", "D");
+
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 5);
+
+        assertThat(fused.get(0)).isEqualTo("X");
+        // X 점수 = 1/60 + 1/60 = 0.033333...
+        // 나머지는 단일 채널 최대 1/61 이하이므로 X 가 유일 최상위
+        assertThat(fused).hasSize(5).startsWith("X");
+    }
+
+    @Test
+    @DisplayName("lexical 가중치를 크게 주면 lexical 상위 키가 우선된다")
+    void lexicalWeightShiftsOrder() {
+        // dense 단독 상위 D vs lexical 단독 상위 L
+        List<String> dense = List.of("D");
+        List<String> lexical = List.of("L");
+
+        // 동일 가중: D(1/60) == L(1/60), 먼저 등장한 D 가 앞
+        List<String> equalWeight = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 2);
+        assertThat(equalWeight).containsExactly("D", "L");
+
+        // lexical 가중 3배: L(3/60) > D(1/60)
+        List<String> lexHeavy = EgovRrfFusion.fuse(dense, lexical, 1.0, 3.0, K, 2);
+        assertThat(lexHeavy).containsExactly("L", "D");
+    }
+
+    @Test
+    @DisplayName("topK 만큼만 잘라서 반환한다")
+    void respectsTopK() {
+        List<String> dense = List.of("A", "B", "C", "D", "E");
+        List<String> lexical = List.of("F", "G");
+
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 3);
+
+        assertThat(fused).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("한쪽 채널만 결과가 있어도 융합된다")
+    void singleChannelOnly() {
+        List<String> dense = List.of("A", "B");
+        List<String> lexical = List.of();
+
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 5);
+
+        assertThat(fused).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("null 채널 입력은 무시된다")
+    void nullChannelIgnored() {
+        List<String> dense = List.of("A", "B");
+
+        List<String> fused = EgovRrfFusion.fuse(dense, null, 1.0, 1.0, K, 5);
+
+        assertThat(fused).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("골든셋 recall@k 와 MRR 이 융합으로 개선된다")
+    void recallAndMrrImproveAfterFusion() {
+        // 정답 키 = {REL1, REL2}
+        // 두 정답은 각 채널에서 중위권이라 단일 채널 top2 에는 들지 못한다.
+        // 그러나 양 채널에 모두 등장하므로 융합 시 순위 역수가 합산되어 상위로 올라온다
+        // (cross-channel reinforcement).
+        List<String> dense = List.of("n1", "REL1", "REL2", "n2");
+        List<String> lexical = List.of("m1", "REL2", "REL1", "m2");
+        List<String> relevant = List.of("REL1", "REL2");
+
+        List<String> denseTop2 = dense.subList(0, 2);
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 2);
+
+        // recall@2: dense 단독은 1/2(REL1만), 융합은 2/2
+        assertThat(recallAtK(denseTop2, relevant)).isEqualTo(0.5);
+        assertThat(recallAtK(fused, relevant)).isEqualTo(1.0);
+
+        // MRR: 융합 결과 1순위가 정답이어야 한다
+        assertThat(mrr(fused, relevant)).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("개별 키 융합 점수가 수식값과 일치한다")
+    void exactScoreMatchesFormula() {
+        // A: dense r0 only -> 1/60
+        List<String> single = EgovRrfFusion.fuse(List.of("A"), List.of(), 1.0, 1.0, K, 1);
+        assertThat(single).containsExactly("A");
+
+        // 가중 2.0 적용 시 A 점수 = 2/60, B(lexical r0, weight1) = 1/60 -> A 우선
+        List<String> weighted = EgovRrfFusion.fuse(List.of("A"), List.of("B"), 2.0, 1.0, K, 2);
+        assertThat(weighted).containsExactly("A", "B");
+
+        // 수식값 직접 확인을 위한 sanity: 1/60 ≈ 0.016667
+        double expected = 1.0 / (K + 0);
+        assertThat(expected).isCloseTo(0.016666, within(1e-5));
+    }
+
+    private static double recallAtK(List<String> retrieved, List<String> relevant) {
+        long hit = relevant.stream().filter(retrieved::contains).count();
+        return (double) hit / relevant.size();
+    }
+
+    private static double mrr(List<String> retrieved, List<String> relevant) {
+        for (int i = 0; i < retrieved.size(); i++) {
+            if (relevant.contains(retrieved.get(i))) {
+                return 1.0 / (i + 1);
+            }
+        }
+        return 0.0;
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/test/resources/application.yml
@@ -78,6 +78,14 @@ rag:
   similarity:
     threshold: 0.70
   top-k: 3
+  # 하이브리드 검색 (테스트 기본 off)
+  retrieval:
+    hybrid:
+      enabled: false
+      weight:
+        dense: 1.0
+        lexical: 1.0
+      top-k: 3
 
 # 채팅 메모리 설정
 chat:


### PR DESCRIPTION
## 배경

Issue #49에서 제안한 하이브리드 검색 기능을 langchain4j 모듈에 구현합니다.

현재 해당 모듈은 임베딩 코사인 유사도 기반의 단일 벡터(Dense) 검색만 수행하고 있습니다(`EmbeddingStoreContentRetriever`). 이러한 밀집 벡터 단독 검색은 법령 조항번호, 행정표준코드와 같은 정확한 키워드 매칭이나 "주민등록번호/주민번호" 등 표기 변형이 발생하는 케이스에서 재현율(Recall)이 떨어지는 한계가 있습니다.

이전 검토 의견으로 주신 '빈(Bean) 모호성 우려'(`ChatbotFactory`가 `ContentRetriever`를 `@Qualifier` 없이 단일 주입하는 문제)를 이번 설계의 핵심 개선 사항으로 반영했습니다.

## 변경 내용

밀집 벡터(Dense) 검색 결과와 어휘 키워드(pg_trgm) 검색 결과를 RRF(Reciprocal Rank Fusion) 알고리즘으로 병합하는 선택적 하이브리드 Retriever를 확장형 신규 빈으로 추가합니다. 토글 옵션인 `rag.retrieval.hybrid.enabled`는 기본값이 `false`이며, 비활성화 시에는 기존 벡터 검색 동작과 완전히 동일하게 작동합니다.

**신규 컴포넌트**
- `EgovRrfFusion`: 랭크 융합 유틸리티 클래스입니다. 수식 `score(d) = Σ weight_channel / (k + rank)` (k=60)을 따르며, 채널별 가중치인 `weight.dense`와 `weight.lexical`을 지원합니다(기본값 1.0). 외부 모델 호출 없는 단순 산술 융합이므로 결정론적(Deterministic)으로 동작합니다.
- `EgovHybridContentRetriever`: `ContentRetriever` 인터페이스의 구현체입니다. 벡터 검색 위임 및 pg_trgm 기반의 키워드 검색을 순차적으로 수행한 후 RRF로 융합합니다. 키워드 검색 실패 시에는 벡터 검색 결과로 폴백(Fallback)합니다.
- `EgovHybridIndexInitializer`: `ApplicationReadyEvent` 시점에 `CREATE EXTENSION IF NOT EXISTS pg_trgm` 및 GIN 인덱스를 멱등(Idempotent)하게 생성합니다. 권한 부족 등으로 실패하더라도 경고 로그만 남길 뿐, 애플리케이션 구동을 차단하지 않습니다.

**기존 코드 수정**
- `EgovRagConfig`: 하이브리드 검색 관련 빈을 `@ConditionalOnProperty(rag.retrieval.hybrid.enabled=true)` 조건으로 등록합니다. 기본 Off 상태에서는 빈이 등록되지 않으므로, 평시 빈 의존성 그래프가 기존과 동일하게 유지되어 회귀 오류가 발생하지 않습니다.
- `ChatbotFactory`: `@Qualifier("hybridContentRetriever") @Autowired(required=false)`(하이브리드)와 `@Qualifier("contentRetriever")`(기존 벡터)로 주입 분기 처리를 수행합니다. 토글이 On 상태가 되어 두 빈이 공존하더라도 퀄리파이어를 통해 의존성 주입 모호성을 명확히 해소합니다.
- `application.yml`: 하이브리드 활성화 토글 및 채널별 가중치 기본값을 추가했습니다.

## 빈 모호성 해소

리뷰 의견대로 동일한 타입의 빈이 추가되면 단일 주입 시점에 `NoUniqueBeanDefinitionException`이 발생할 수 있습니다. 이를 방지하기 위해 다음 두 단계 안전장치를 적용했습니다.
1. `@ConditionalOnProperty`를 통해 토글 Off(기본값) 시 하이브리드 빈을 아예 생성하지 않으므로 기존 환경에 영향이 없습니다.
2. 토글 On으로 두 빈이 공존할 때는 각 주입 지점에 `@Qualifier`를 명시하여 컴파일 및 런타임 충돌을 제거했습니다.

이 구조는 `ApplicationContextRunner` 테스트를 통해 Off 시 빈 1개 생성, On 시 빈 2개 공존 및 컨텍스트 정상 로드(모호성 부재) 상태임을 검증 완료했습니다.

## 문서 ID 정합성 확보 (융합 키 일치)

서로 다른 두 채널의 검색 결과를 정확하게 병합하기 위해 문서 식별자(ID) 정합성을 보장했습니다.
밀집 벡터 채널은 `Metadata.getString("id")`를, 키워드 채널은 SQL 상에서 `metadata::jsonb ->> 'id'`를 통해 동일한 ID 값을 추출하여 RRF 가중치 보강이 의도대로 이루어지도록 설계했습니다. 숫자형 ID를 포함한 다양한 케이스에서 키 일치화가 정상 작동함을 테스트로 확인했습니다.

## 테스트 수행 결과

`mvn test` 전체 통과 (Tests run: 23, Failures: 0). 외부 DB 인프라에 의존하지 않는 독립적인 단위 테스트로 구성되었습니다.
- `EgovRrfFusionTest` (8개): RRF 수식 검증, 가중치 적용, Recall@k 및 MRR 측정, 동점자 처리 결정성 검증.
- `EgovHybridContentRetrieverTest` (6개, Mock 채널 활용): 동일 ID 문서의 융합 보강 동작, 키워드 채널 실패 시 벡터 폴백 동작, 숫자형 ID 식별자 정합성 검증.
- `EgovHybridRetrieverToggleTest` (2개): 프로퍼티 토글 상태에 따른 빈 등록/미등록 조건 검증.

## 영향 범위 및 한계

**영향 범위**
- 프로퍼티 기본값이 Off이므로 기존 동작에 미치는 영향은 무변경(회귀 위험도 0)입니다.
- 신규 외부 의존성 없이 Spring Boot 내부의 `JdbcTemplate` 자동 구성을 사용하며 기존 postgresql 드라이버를 재사용합니다.
- 본 PR은 langchain4j 모듈만 타깃으로 하며, spring-ai 모듈은 별도 PR로 분리하여 진행합니다.

**한계점**
- pg_trgm의 n-gram 방식은 정밀한 형태소 분석기에 비해 노이즈 매칭(오탐)이 발생할 수 있으나, RRF 융합 과정에서 밀집 벡터 검색의 유사도 점수가 이를 보완(노이즈 억제)하도록 처리했습니다.
- 대규모셋 기반의 정확한 재현율(Recall)/MRR 및 레이턴시 실측 벤치마크 평가는 후속 과제로 진행할 예정입니다.
