### PR TITLE
feat: spring-ai 모듈에 하이브리드(키워드+벡터) RRF 융합 retriever 추가 (#49)

### DIFF
--- a/README-spring-ai-rag-redis-stack.md
+++ b/README-spring-ai-rag-redis-stack.md
@@ -403,6 +403,37 @@ chat:
     max-messages: 20                  # 최대 메시지 수
 ```
 
+### 하이브리드 검색 (dense 벡터 + lexical RediSearch)
+
+의미 기반 dense 벡터 검색에 키워드 기반 lexical 검색(RediSearch `FT.SEARCH`)을 더해 [RRF(Reciprocal Rank Fusion)](https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf)로 융합한다. 정확한 용어·고유명사 질의에서 dense 채널이 놓치는 문서를 lexical 채널이 보완한다. 기본값은 off이며, 켜면 dense 단독 검색은 그대로 두고 lexical 채널과 융합만 추가된다.
+
+#### 활성화 방법
+
+```yaml
+rag:
+  retrieval:
+    hybrid:
+      enabled: true          # 하이브리드 활성화 (기본 false)
+      weight:
+        dense: 1.0           # dense 채널 RRF 가중치
+        lexical: 1.0         # lexical 채널 RRF 가중치
+      # top-k: 3             # 융합 결과 개수 (미지정 시 rag.top-k)
+```
+
+`enabled: true`일 때만 lexical 채널(`JedisPooled`)과 하이브리드 retriever 빈이 등록된다. off(기본)에서는 기존 dense 단독 검색이 그대로 동작하므로 빈 모호성이 발생하지 않는다.
+
+#### 동작 원리
+
+- **dense 채널**: 기존 `VectorStoreDocumentRetriever`의 벡터 유사도 검색(임베딩 최근접).
+- **lexical 채널**: RediSearch가 색인 시 구축한 역 인덱스(inverted index)를 `FT.SEARCH`로 조회한다. `EgovLexicalQueryBuilder`가 질의를 단계적으로 완화하며 — 어절을 모두 포함하는 정확매칭(`@content:(t1 t2 …)`, AND) → 접두 일치(`@content:(t1* | t2* …)`, OR) → 부분 포함(`@content:(*t1* | *t2* …)`, OR) — 결과가 처음 나오는 단계의 결과를 즉시 사용한다.
+- **융합**: 두 채널의 순위를 RRF(`score = Σ weight / (k + rank)`, k=60)로 합산해 상위 Top K를 반환한다. lexical 단독 문서(dense 결과에 없는 키)는 순위 가중치로만 반영되고, 본문은 dense 채널이 보유한 문서만 최종 결과에 포함된다.
+
+별도의 lexical 인덱스를 새로 만들지 않고, dense 검색이 사용하는 것과 동일한 인덱스(`spring.ai.vectorstore.redis.index-name`, 기본 `document-index`)를 재사용한다.
+
+#### 주의 사항
+
+lexical `FT.SEARCH`는 벡터 스키마가 구성된 인덱스 위에서 동작한다. 따라서 최초 1회는 `spring.ai.vectorstore.redis.initialize-schema: true`로 실행해 스키마·인덱스를 생성한 뒤(이후 `false`) 하이브리드를 활성화하는 것을 권장한다. 인덱스가 없거나 `FT.SEARCH`가 실패하면 예외를 잡아 해당 요청은 dense 결과만 반환하므로(graceful fallback) 검색이 중단되지는 않지만, 그 요청에서 lexical 채널은 무력화된다.
+
 ## 문제 해결
 
 ### Ollama 연결 실패

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovHybridDocumentRetriever.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovHybridDocumentRetriever.java
@@ -132,6 +132,7 @@ public class EgovHybridDocumentRetriever implements DocumentRetriever {
         // 가중치로만 반영된다(본문 중복 적재·차원 불일치 우회 - 확정 설계).
         List<Document> result = new ArrayList<>(fusedKeys.size());
         for (String key : fusedKeys) {
+            // byKey에는 dense 결과만 담겨 있으므로, lexical 단독 키는 여기서 null이 되어 조용히 제외된다(위 주석 참조).
             Document doc = byKey.get(key);
             if (doc != null) {
                 result.add(doc);

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovHybridDocumentRetriever.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovHybridDocumentRetriever.java
@@ -1,0 +1,177 @@
+package com.example.chat.config;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+import org.springframework.ai.rag.retrieval.search.DocumentRetriever;
+
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.search.SearchResult;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 하이브리드 DocumentRetriever
+ *
+ * <p>dense 벡터 검색({@link DocumentRetriever} 위임)과 lexical 키워드 검색
+ * (RediSearch {@code FT.SEARCH})을 각각 수행한 뒤 {@link EgovRrfFusion}으로
+ * 융합해 최종 결과를 반환한다. 두 채널은 단순성을 위해 순차로 호출한다.</p>
+ *
+ * <p>융합 키는 {@link Document#getId()}를 사용한다. lexical 채널은 RediSearch가
+ * 색인한 문서 키 {@code embedding:<id>}에서 prefix를 벗긴 {@code <id>}를 키로
+ * 사용하므로(= dense 채널의 {@code getId()}와 동일 값), 같은 문서는 양 채널에서
+ * 동일한 융합 키를 가진다.</p>
+ *
+ * <p>lexical 검색이나 융합 과정에서 오류가 발생하면 dense 결과만 반환해 RAG
+ * 기능 자체는 보존한다(graceful degrade). 본 빈은
+ * {@code rag.retrieval.hybrid.enabled=true} 일 때만 등록되므로, 기본(off)
+ * 상태에서는 dense {@code VectorStoreDocumentRetriever} 빈만 존재해 빈 모호성이
+ * 발생하지 않는다.</p>
+ */
+@Slf4j
+public class EgovHybridDocumentRetriever implements DocumentRetriever {
+
+    /** RedisVectorStore가 색인하는 문서 키 prefix. lexical 채널 키 정규화에 사용. */
+    static final String KEY_PREFIX = "embedding:";
+
+    /** RediSearch 인덱스의 본문(TEXT) 필드명. RedisVectorStore 기본값. */
+    static final String CONTENT_FIELD = "content";
+
+    private final DocumentRetriever denseRetriever;
+    private final LexicalSearch lexicalSearch;
+    private final String indexName;
+    private final double denseWeight;
+    private final double lexicalWeight;
+    private final int topK;
+
+    /**
+     * lexical 채널 추상화. 질의 문자열을 받아 매칭 문서의 id 순위(상위가 앞)를
+     * 반환한다. Redis 비의존 단위 테스트를 위해 별도 인터페이스로 분리한다.
+     */
+    @FunctionalInterface
+    public interface LexicalSearch {
+        /**
+         * @param queryText 사용자 질의(원본)
+         * @param topK      최대 회수 개수
+         * @return 매칭 문서의 id 순위 리스트(상위가 앞). 매칭 없으면 빈 리스트
+         */
+        List<String> search(String queryText, int topK);
+    }
+
+    /**
+     * 운영용 생성자. JedisPooled FT.SEARCH 기반 lexical 채널을 구성한다.
+     *
+     * @param denseRetriever dense 벡터 검색 빈
+     * @param jedisPooled    lexical 검색용 JedisPooled
+     * @param indexName      RediSearch 인덱스명(dense와 동일 인덱스 재사용)
+     * @param denseWeight    dense 채널 가중치
+     * @param lexicalWeight  lexical 채널 가중치
+     * @param topK           반환할 상위 문서 개수
+     */
+    public EgovHybridDocumentRetriever(DocumentRetriever denseRetriever,
+                                       JedisPooled jedisPooled,
+                                       String indexName,
+                                       double denseWeight,
+                                       double lexicalWeight,
+                                       int topK) {
+        this(denseRetriever,
+                (queryText, k) -> ftSearch(jedisPooled, indexName, queryText, k),
+                indexName, denseWeight, lexicalWeight, topK);
+    }
+
+    /**
+     * 테스트용 생성자. lexical 채널을 임의로 주입한다.
+     */
+    EgovHybridDocumentRetriever(DocumentRetriever denseRetriever,
+                                LexicalSearch lexicalSearch,
+                                String indexName,
+                                double denseWeight,
+                                double lexicalWeight,
+                                int topK) {
+        this.denseRetriever = denseRetriever;
+        this.lexicalSearch = lexicalSearch;
+        this.indexName = indexName;
+        this.denseWeight = denseWeight;
+        this.lexicalWeight = lexicalWeight;
+        this.topK = topK;
+    }
+
+    @Override
+    public List<Document> retrieve(Query query) {
+        // 1) dense 채널 검색 (벡터 유사도)
+        List<Document> denseDocuments = denseRetriever.retrieve(query);
+
+        // 2) lexical 채널 검색 (FT.SEARCH). 실패해도 dense 결과는 보존한다.
+        List<String> lexicalRanking;
+        try {
+            lexicalRanking = lexicalSearch.search(query.text(), topK);
+        } catch (Exception e) {
+            log.warn("lexical 검색 실패 - dense 결과만 사용합니다. 원인: {}", e.getMessage());
+            return denseDocuments;
+        }
+
+        // 3) 융합 키 → Document 매핑 구성 (먼저 등장한 Document를 대표로 유지)
+        Map<String, Document> byKey = new LinkedHashMap<>();
+        List<String> denseRanking = new ArrayList<>(denseDocuments.size());
+        for (Document doc : denseDocuments) {
+            String key = doc.getId();
+            denseRanking.add(key);
+            byKey.putIfAbsent(key, doc);
+        }
+
+        // 4) RRF 융합
+        List<String> fusedKeys = EgovRrfFusion.fuse(
+                denseRanking, lexicalRanking, denseWeight, lexicalWeight, EgovRrfFusion.DEFAULT_K, topK);
+
+        // lexical 단독 문서(dense에 없는 키)는 본문이 dense 결과에 없으므로 제외하고,
+        // 융합 점수로 재정렬된 dense 문서만 컨텍스트에 포함한다. lexical 신호는 순위
+        // 가중치로만 반영된다(본문 중복 적재·차원 불일치 우회 - 확정 설계).
+        List<Document> result = new ArrayList<>(fusedKeys.size());
+        for (String key : fusedKeys) {
+            Document doc = byKey.get(key);
+            if (doc != null) {
+                result.add(doc);
+            }
+        }
+
+        log.debug("하이브리드 검색 - dense: {}, lexical: {}, 융합: {}",
+                denseDocuments.size(), lexicalRanking.size(), result.size());
+        return result;
+    }
+
+    /**
+     * JedisPooled FT.SEARCH로 lexical 검색을 수행한다. 정확→접두→중위 순으로
+     * 폴백하며, 회수가 발생한 첫 단계의 결과를 사용한다.
+     *
+     * @return 매칭 문서의 id 순위(상위가 앞). prefix를 벗긴 순수 id
+     */
+    static List<String> ftSearch(JedisPooled jedis, String indexName, String queryText, int topK) {
+        for (String q : EgovLexicalQueryBuilder.buildStagedQueries(queryText)) {
+            redis.clients.jedis.search.Query searchQuery =
+                    new redis.clients.jedis.search.Query(q)
+                            .limit(0, Math.max(topK, 0))
+                            .setNoContent();
+            SearchResult r = jedis.ftSearch(indexName, searchQuery);
+            if (r.getTotalResults() > 0) {
+                List<String> ids = new ArrayList<>();
+                for (redis.clients.jedis.search.Document d : r.getDocuments()) {
+                    ids.add(stripPrefix(d.getId()));
+                }
+                return ids;
+            }
+        }
+        return List.of();
+    }
+
+    /** FT.SEARCH 반환 키 {@code embedding:<id>}에서 prefix를 벗겨 순수 id로 만든다. */
+    static String stripPrefix(String key) {
+        if (key != null && key.startsWith(KEY_PREFIX)) {
+            return key.substring(KEY_PREFIX.length());
+        }
+        return key;
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovHybridRedisConfig.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovHybridRedisConfig.java
@@ -1,0 +1,90 @@
+package com.example.chat.config;
+
+import org.springframework.ai.rag.retrieval.search.VectorStoreDocumentRetriever;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import redis.clients.jedis.JedisPooled;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 하이브리드 검색용 Redis 구성
+ *
+ * <p>{@code rag.retrieval.hybrid.enabled=true} 일 때만 lexical 채널용
+ * {@link JedisPooled} 와 {@link EgovHybridDocumentRetriever} 빈을 등록한다.
+ * off(기본) 상태에서는 빈이 만들어지지 않으므로 dense
+ * {@link VectorStoreDocumentRetriever} 빈만 존재하여 빈 모호성이 발생하지
+ * 않는다.</p>
+ *
+ * <p>Spring AI {@code RedisVectorStore}는 내부 Jedis 클라이언트를 노출하지
+ * 않으므로, {@code spring.data.redis.host/port} 값으로 lexical 채널 전용
+ * JedisPooled를 별도 구성한다. 인덱스는 dense와 동일한
+ * {@code spring.ai.vectorstore.redis.index-name}을 재사용한다(보조 인덱스
+ * 신설 없음 - 차원 불일치 방지).</p>
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(prefix = "rag.retrieval.hybrid", name = "enabled", havingValue = "true")
+public class EgovHybridRedisConfig {
+
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+
+    @Value("${spring.ai.vectorstore.redis.index-name:spring-ai-index}")
+    private String indexName;
+
+    @Value("${rag.top-k:3}")
+    private int topK;
+
+    @Value("${rag.retrieval.hybrid.weight.dense:1.0}")
+    private double hybridDenseWeight;
+
+    @Value("${rag.retrieval.hybrid.weight.lexical:1.0}")
+    private double hybridLexicalWeight;
+
+    @Value("${rag.retrieval.hybrid.top-k:#{null}}")
+    private Integer hybridTopK;
+
+    /**
+     * lexical 채널용 JedisPooled 빈.
+     *
+     * <p>RedisVectorStore의 내부 클라이언트와 별개로 {@code spring.data.redis}
+     * 접속 정보로 직접 구성한다. FT.SEARCH 호출에만 사용한다.</p>
+     */
+    @Bean
+    public JedisPooled hybridJedisPooled() {
+        log.info("하이브리드 lexical 채널 JedisPooled 구성 - {}:{}", redisHost, redisPort);
+        return new JedisPooled(redisHost, redisPort);
+    }
+
+    /**
+     * 하이브리드 DocumentRetriever 빈.
+     *
+     * <p>dense 검색({@link VectorStoreDocumentRetriever})과 lexical 검색
+     * (RediSearch FT.SEARCH)을 RRF로 융합한다. dense 빈은 구체 타입으로 주입되어
+     * 모호성이 없다.</p>
+     *
+     * @param denseRetriever dense 벡터 검색 빈
+     * @param jedisPooled    lexical 검색용 JedisPooled
+     * @return 하이브리드 DocumentRetriever
+     */
+    @Bean
+    public EgovHybridDocumentRetriever hybridDocumentRetriever(
+            VectorStoreDocumentRetriever denseRetriever,
+            JedisPooled jedisPooled) {
+
+        int effectiveTopK = (hybridTopK != null) ? hybridTopK : topK;
+        log.info("EgovHybridDocumentRetriever 초기화 - index: {}, topK: {}, weight(dense/lexical): {}/{}",
+                indexName, effectiveTopK, hybridDenseWeight, hybridLexicalWeight);
+
+        return new EgovHybridDocumentRetriever(
+                denseRetriever, jedisPooled, indexName,
+                hybridDenseWeight, hybridLexicalWeight, effectiveTopK);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovHybridRedisConfig.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovHybridRedisConfig.java
@@ -36,7 +36,7 @@ public class EgovHybridRedisConfig {
     @Value("${spring.data.redis.port:6379}")
     private int redisPort;
 
-    @Value("${spring.ai.vectorstore.redis.index-name:spring-ai-index}")
+    @Value("${spring.ai.vectorstore.redis.index-name:document-index}")
     private String indexName;
 
     @Value("${rag.top-k:3}")

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovLexicalQueryBuilder.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovLexicalQueryBuilder.java
@@ -1,0 +1,125 @@
+package com.example.chat.config;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * RediSearch 어휘(lexical) 질의 문자열 빌더
+ *
+ * <p>사용자 질의를 공백 기준 어절로 분해해 RediSearch {@code FT.SEARCH} 질의를
+ * 단계적으로 생성한다. RediSearch 기본 토크나이저는 한글을 형태소가 아닌
+ * 공백/문장부호 단위 어절로 색인하므로, 다음 순서로 회수율을 높인다.</p>
+ *
+ * <ol>
+ *   <li>정확매칭: {@code @content:(어절1 어절2 ...)} — 어절 전체 일치</li>
+ *   <li>접두매칭: {@code @content:(어절1* | 어절2* | ...)} — 어절 시작 일치</li>
+ *   <li>중위매칭: {@code @content:(*어절1* | *어절2* | ...)} — 어절 부분 포함</li>
+ * </ol>
+ *
+ * <p>외부 의존성이 없는 순수 함수 모음으로, 동일 입력에 대해 항상 동일한
+ * 질의 문자열을 반환한다. RediSearch 특수문자는 이스케이프한다.</p>
+ */
+public final class EgovLexicalQueryBuilder {
+
+    /** RediSearch 질의 구문에서 의미를 갖는 특수문자(이스케이프 대상). */
+    private static final String SPECIAL_CHARS = ",.<>{}[]\"':;!@#$%^&*()-+=~|/\\ ";
+
+    /** 단일 어절로 인정할 최소 길이(1글자 노이즈 토큰 억제). */
+    private static final int MIN_TERM_LENGTH = 1;
+
+    private EgovLexicalQueryBuilder() {
+    }
+
+    /**
+     * 질의를 공백 기준 어절로 분해한다. 빈 토큰은 제거하고 등장 순서를 보존하며
+     * 중복은 제거한다.
+     *
+     * @param query 사용자 질의
+     * @return 어절 리스트(순서 보존·중복 제거). 입력이 비어 있으면 빈 리스트
+     */
+    public static List<String> tokenize(String query) {
+        if (query == null || query.isBlank()) {
+            return List.of();
+        }
+        Set<String> terms = new LinkedHashSet<>();
+        for (String raw : query.trim().split("\\s+")) {
+            String term = raw.trim();
+            if (term.length() >= MIN_TERM_LENGTH) {
+                terms.add(term);
+            }
+        }
+        return new ArrayList<>(terms);
+    }
+
+    /**
+     * 폴백 단계를 모두 포함한 질의 리스트를 순서대로 생성한다.
+     *
+     * <p>호출 측은 첫 단계부터 차례로 검색해, 회수 결과가 충분하면 멈추고
+     * 부족하면 다음 단계로 폴백한다. 어절이 없으면 빈 리스트를 반환한다.</p>
+     *
+     * @param query 사용자 질의
+     * @return [정확, 접두, 중위] 순의 질의 문자열(어절이 없으면 빈 리스트)
+     */
+    public static List<String> buildStagedQueries(String query) {
+        List<String> terms = tokenize(query);
+        if (terms.isEmpty()) {
+            return List.of();
+        }
+        List<String> staged = new ArrayList<>(3);
+        staged.add(exactQuery(terms));
+        staged.add(prefixQuery(terms));
+        staged.add(infixQuery(terms));
+        return staged;
+    }
+
+    /** 정확매칭 질의: {@code @content:(t1 t2 ...)} (어절 모두 포함, AND). */
+    static String exactQuery(List<String> terms) {
+        StringBuilder sb = new StringBuilder("@content:(");
+        for (int i = 0; i < terms.size(); i++) {
+            if (i > 0) {
+                sb.append(' ');
+            }
+            sb.append(escape(terms.get(i)));
+        }
+        return sb.append(')').toString();
+    }
+
+    /** 접두매칭 질의: {@code @content:(t1* | t2* | ...)} (어절 시작 일치, OR). */
+    static String prefixQuery(List<String> terms) {
+        return wildcardQuery(terms, "", "*");
+    }
+
+    /** 중위매칭 질의: {@code @content:(*t1* | *t2* | ...)} (어절 부분 포함, OR). */
+    static String infixQuery(List<String> terms) {
+        return wildcardQuery(terms, "*", "*");
+    }
+
+    private static String wildcardQuery(List<String> terms, String pre, String post) {
+        StringBuilder sb = new StringBuilder("@content:(");
+        for (int i = 0; i < terms.size(); i++) {
+            if (i > 0) {
+                sb.append(" | ");
+            }
+            sb.append(pre).append(escape(terms.get(i))).append(post);
+        }
+        return sb.append(')').toString();
+    }
+
+    /**
+     * RediSearch 질의 특수문자를 백슬래시로 이스케이프한다. 와일드카드({@code *})는
+     * 호출 측에서 별도로 부착하므로 어절 본문에는 포함되지 않는다.
+     */
+    static String escape(String term) {
+        StringBuilder sb = new StringBuilder(term.length());
+        for (int i = 0; i < term.length(); i++) {
+            char c = term.charAt(i);
+            if (SPECIAL_CHARS.indexOf(c) >= 0) {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovLexicalQueryBuilder.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovLexicalQueryBuilder.java
@@ -26,7 +26,7 @@ public final class EgovLexicalQueryBuilder {
     /** RediSearch 질의 구문에서 의미를 갖는 특수문자(이스케이프 대상). */
     private static final String SPECIAL_CHARS = ",.<>{}[]\"':;!@#$%^&*()-+=~|/\\ ";
 
-    /** 단일 어절로 인정할 최소 길이(1글자 노이즈 토큰 억제). */
+    /** 어절로 인정할 최소 길이. 값 1은 빈 문자열(0글자)만 제외하고 1글자 이상을 허용한다. */
     private static final int MIN_TERM_LENGTH = 1;
 
     private EgovLexicalQueryBuilder() {

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovRagConfig.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovRagConfig.java
@@ -60,7 +60,7 @@ public class EgovRagConfig {
      */
     public static Advisor createRagAdvisor(String sessionId,
                                          EgovCompressionQueryTransformer compressionTransformer,
-                                         VectorStoreDocumentRetriever documentRetriever,
+                                         DocumentRetriever documentRetriever,
                                          boolean enableQueryCompression) {
         log.info("RAG 어드바이저 생성 시작 - 세션: {}, 질문 압축: {}", sessionId, enableQueryCompression);
 

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovRrfFusion.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovRrfFusion.java
@@ -1,0 +1,74 @@
+package com.example.chat.config;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RRF(Reciprocal Rank Fusion) 융합 유틸리티
+ *
+ * <p>여러 검색 채널(예: dense 벡터 검색, lexical 키워드 검색)이 각각 반환한
+ * 순위 리스트를 하나의 순위로 융합한다. 각 키의 융합 점수는 채널별 순위의
+ * 역수 합으로 계산한다.</p>
+ *
+ * <pre>
+ *   score(d) = Σ_channel  weight / (k + rank)
+ * </pre>
+ *
+ * <p>여기서 {@code rank}는 해당 채널에서 키가 등장한 0-based 순위이며,
+ * {@code k}는 상위권 항목의 영향력을 완화하는 상수(표준값 60)이다.
+ * 외부 의존성이 없는 순수 함수로, 동일 입력에 대해 항상 동일한 순서를 반환한다.</p>
+ */
+public final class EgovRrfFusion {
+
+    /** RRF 표준 상수. 상위 순위 항목의 가중치를 완화한다. */
+    public static final int DEFAULT_K = 60;
+
+    private EgovRrfFusion() {
+    }
+
+    /**
+     * 두 채널(dense, lexical)의 순위 리스트를 RRF로 융합한다.
+     *
+     * @param denseRanking   dense 채널이 반환한 키 순서(상위가 앞)
+     * @param lexicalRanking lexical 채널이 반환한 키 순서(상위가 앞)
+     * @param denseWeight    dense 채널 가중치
+     * @param lexicalWeight  lexical 채널 가중치
+     * @param k              RRF 상수(일반적으로 {@link #DEFAULT_K})
+     * @param topK           반환할 상위 키 개수
+     * @param <T>            융합 키 타입
+     * @return 융합 점수 내림차순으로 정렬된 상위 {@code topK} 키
+     */
+    public static <T> List<T> fuse(List<T> denseRanking,
+                                   List<T> lexicalRanking,
+                                   double denseWeight,
+                                   double lexicalWeight,
+                                   int k,
+                                   int topK) {
+        // 키 등장 순서를 보존해 동점 시 결정적 정렬을 보장한다.
+        Map<T, Double> scores = new LinkedHashMap<>();
+        accumulate(scores, denseRanking, denseWeight, k);
+        accumulate(scores, lexicalRanking, lexicalWeight, k);
+
+        return scores.entrySet().stream()
+                // 점수 내림차순. 동점은 LinkedHashMap의 삽입 순서(=등장 순서)를 유지한다.
+                .sorted((a, b) -> Double.compare(b.getValue(), a.getValue()))
+                .limit(Math.max(topK, 0))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    private static <T> void accumulate(Map<T, Double> scores, List<T> ranking, double weight, int k) {
+        if (ranking == null) {
+            return;
+        }
+        for (int rank = 0; rank < ranking.size(); rank++) {
+            T key = ranking.get(rank);
+            if (key == null) {
+                continue;
+            }
+            double contribution = weight / (k + rank);
+            scores.merge(key, contribution, Double::sum);
+        }
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/service/impl/EgovSessionAwareChatServiceImpl.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/service/impl/EgovSessionAwareChatServiceImpl.java
@@ -13,9 +13,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.example.chat.context.SessionContext;
+import com.example.chat.config.EgovHybridDocumentRetriever;
 import com.example.chat.config.EgovRagConfig;
 import com.example.chat.config.rag.transformers.EgovCompressionQueryTransformer;
+import org.springframework.ai.rag.retrieval.search.DocumentRetriever;
 import org.springframework.ai.rag.retrieval.search.VectorStoreDocumentRetriever;
+import org.springframework.beans.factory.ObjectProvider;
 import com.example.chat.response.TechnologyResponse;
 import com.example.chat.service.EgovSessionAwareChatService;
 import com.example.chat.util.EgovThinkTagOutputConverter;
@@ -33,6 +36,11 @@ public class EgovSessionAwareChatServiceImpl extends EgovAbstractServiceImpl imp
     private final MessageChatMemoryAdvisor messageChatMemoryAdvisor;
     private final EgovCompressionQueryTransformer compressionTransformer;
     private final VectorStoreDocumentRetriever vectorStoreDocumentRetriever;
+    /**
+     * 하이브리드(dense+lexical RRF) DocumentRetriever. {@code rag.retrieval.hybrid.enabled=true}
+     * 일 때만 빈이 등록되므로 ObjectProvider로 선택적으로 주입한다. 없으면 dense로 폴백한다.
+     */
+    private final ObjectProvider<EgovHybridDocumentRetriever> hybridDocumentRetrieverProvider;
 
     @Value("${rag.enable-query-compression:true}")
     private boolean enableQueryCompression;
@@ -57,9 +65,11 @@ public class EgovSessionAwareChatServiceImpl extends EgovAbstractServiceImpl imp
             ChatClientRequestSpec requestSpec = createRequestSpec(query, model);
 
             // RAG 어드바이저 생성 (질문 압축 설정값에 따라 동작 결정)
+            // 하이브리드 빈이 등록되어 있으면(토글 on) 그것을, 없으면 dense를 사용한다.
+            DocumentRetriever activeRetriever = resolveDocumentRetriever();
             log.info("RAG 어드바이저 생성 시작 - 세션: {}, 원본 질문: '{}', 질문 압축: {}", sessionId, query, enableQueryCompression);
             Advisor ragAdvisor = EgovRagConfig.createRagAdvisor(sessionId, compressionTransformer,
-                    vectorStoreDocumentRetriever, enableQueryCompression);
+                    activeRetriever, enableQueryCompression);
             log.info("RAG 어드바이저 생성 완료 - 세션: {}", sessionId);
 
             log.info("RAG 스트리밍 시작 - 세션: {}, 원본 질문: '{}'", sessionId, query);
@@ -129,6 +139,24 @@ public class EgovSessionAwareChatServiceImpl extends EgovAbstractServiceImpl imp
             log.error("기술 정보 JSON 응답 생성 중 오류 발생", e);
             return new TechnologyResponse("알 수 없음", "알 수 없음", "오류가 발생했습니다", null, null);
         }
+    }
+
+    /**
+     * RAG 검색에 사용할 DocumentRetriever를 선택한다.
+     *
+     * <p>{@code rag.retrieval.hybrid.enabled=true}로 하이브리드 빈이 등록된 경우 이를
+     * 사용하고, 그렇지 않으면 dense {@link VectorStoreDocumentRetriever}로 폴백한다.
+     * 하이브리드 빈은 선택적으로 주입되므로 토글 off 시에도 기존 동작이 유지된다.</p>
+     *
+     * @return 활성 DocumentRetriever
+     */
+    private DocumentRetriever resolveDocumentRetriever() {
+        DocumentRetriever hybrid = hybridDocumentRetrieverProvider.getIfAvailable();
+        if (hybrid != null) {
+            log.debug("하이브리드 DocumentRetriever 사용 (dense+lexical RRF)");
+            return hybrid;
+        }
+        return vectorStoreDocumentRetriever;
     }
 
     /**

--- a/spring-ai-rag-redis-stack/src/main/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/main/resources/application.yml
@@ -120,6 +120,19 @@ rag:
   # RAG 검색 결과 개수 (Top K)
   top-k: 3
 
+  # 하이브리드 검색(dense 벡터 + lexical RediSearch FT.SEARCH) 설정
+  # enabled:true 일 때만 lexical 채널(JedisPooled)·하이브리드 retriever 빈이 등록된다.
+  # off(기본)에서는 기존 dense 단독 검색이 그대로 동작한다(빈 모호성 없음).
+  retrieval:
+    hybrid:
+      enabled: false
+      # RRF 채널 가중치(기본 1.0). lexical을 높이면 키워드 일치 문서가 상위로 올라온다.
+      weight:
+        dense: 1.0
+        lexical: 1.0
+      # 하이브리드 결과 개수. 미지정 시 rag.top-k 를 따른다.
+      # top-k: 3
+
 # 채팅 메모리 설정 (기본값: 20)
 chat:
   memory:

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/EgovHybridDocumentRetrieverTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/EgovHybridDocumentRetrieverTest.java
@@ -1,0 +1,118 @@
+package com.example.chat.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+import org.springframework.ai.rag.retrieval.search.DocumentRetriever;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link EgovHybridDocumentRetriever} 의 dense + lexical 융합 동작을 검증한다.
+ *
+ * <p>fake dense 채널({@link DocumentRetriever})과 fake lexical 채널
+ * ({@link EgovHybridDocumentRetriever.LexicalSearch})을 주입해 Redis 없이 융합
+ * 결과를 결정적으로 단정한다. lexical 채널은 dense 문서와 동일한 id 를 반환하므로
+ * 융합 키가 채널 간 일치한다.</p>
+ */
+class EgovHybridDocumentRetrieverTest {
+
+    private static final String INDEX = "document-index";
+
+    private Document doc(String id, String text) {
+        return Document.builder().id(id).text(text).build();
+    }
+
+    /** 항상 같은 결과를 반환하는 dense 채널. */
+    private DocumentRetriever denseOf(Document... docs) {
+        return query -> List.of(docs);
+    }
+
+    @Test
+    @DisplayName("dense·lexical 이 같은 id 문서를 반환하면 융합 키가 일치해 RRF 보강이 일어난다")
+    void crossChannelReinforcementWhenSameId() {
+        // SAME 은 양 채널에서 중위권(r1)이지만, 같은 id 로 양쪽에 등장하므로 순위 역수가
+        // 합산되어 단일 채널 상위 문서보다 위로 올라와야 한다.
+        DocumentRetriever dense = denseOf(
+                doc("DTOP", "dense top"),
+                doc("SAME", "shared body"));
+        // lexical 은 id 순위만 반환한다(상위가 앞).
+        EgovHybridDocumentRetriever.LexicalSearch lexical =
+                (q, k) -> List.of("LTOP", "SAME");
+
+        EgovHybridDocumentRetriever retriever =
+                new EgovHybridDocumentRetriever(dense, lexical, INDEX, 1.0, 1.0, 3);
+
+        List<Document> result = retriever.retrieve(new Query("shared"));
+
+        // SAME: dense r1(1/61) + lexical r1(1/61) = 2/61 > DTOP(1/60)
+        assertThat(result.get(0).getId()).isEqualTo("SAME");
+        // lexical 단독 키(LTOP)는 dense 본문에 없으므로 결과에서 제외, dense 2건만 재정렬된다.
+        assertThat(result).extracting(Document::getId).containsExactly("SAME", "DTOP");
+    }
+
+    @Test
+    @DisplayName("lexical 가중치를 높이면 lexical 상위 문서가 우선된다")
+    void lexicalWeightChangesOrder() {
+        // 두 문서 모두 dense 에 존재(본문 보유). lexical 은 LEXHIT 을 상위로 보강한다.
+        DocumentRetriever dense = denseOf(
+                doc("DENSE_TOP", "dense top"),
+                doc("LEXHIT", "lexical hit body"));
+        EgovHybridDocumentRetriever.LexicalSearch lexical =
+                (q, k) -> List.of("LEXHIT");
+
+        // lexical 가중 3배 -> LEXHIT(dense 1/61 + lexical 3/60) > DENSE_TOP(1/60)
+        EgovHybridDocumentRetriever retriever =
+                new EgovHybridDocumentRetriever(dense, lexical, INDEX, 1.0, 3.0, 3);
+
+        List<Document> result = retriever.retrieve(new Query("top"));
+
+        assertThat(result.get(0).getId()).isEqualTo("LEXHIT");
+    }
+
+    @Test
+    @DisplayName("lexical 검색 실패 시 dense 결과만 반환해 RAG 를 보존한다")
+    void degradesToDenseOnLexicalFailure() {
+        List<Document> denseResult = List.of(doc("D1", "alpha"), doc("D2", "beta"));
+        DocumentRetriever dense = query -> denseResult;
+        EgovHybridDocumentRetriever.LexicalSearch failing = (q, k) -> {
+            throw new RuntimeException("FT.SEARCH unavailable");
+        };
+
+        EgovHybridDocumentRetriever retriever =
+                new EgovHybridDocumentRetriever(dense, failing, INDEX, 1.0, 1.0, 3);
+
+        List<Document> result = retriever.retrieve(new Query("alpha"));
+
+        assertThat(result).isEqualTo(denseResult);
+    }
+
+    @Test
+    @DisplayName("lexical 결과가 비어도 dense 순서가 유지된다")
+    void emptyLexicalKeepsDenseOrder() {
+        DocumentRetriever dense = denseOf(doc("A", "a"), doc("B", "b"), doc("C", "c"));
+        EgovHybridDocumentRetriever.LexicalSearch lexical = (q, k) -> List.of();
+
+        EgovHybridDocumentRetriever retriever =
+                new EgovHybridDocumentRetriever(dense, lexical, INDEX, 1.0, 1.0, 3);
+
+        List<Document> result = retriever.retrieve(new Query("x"));
+
+        assertThat(result).extracting(Document::getId).containsExactly("A", "B", "C");
+    }
+
+    @Test
+    @DisplayName("FT.SEARCH 반환 키 embedding:<id> 의 prefix 를 벗겨 dense id 와 일치시킨다")
+    void stripsKeyPrefixToAlignWithDenseId() {
+        // RedisVectorStore 는 문서를 'embedding:<id>' 키로 색인한다. stripPrefix 가
+        // 이를 순수 id 로 정규화해 dense Document.getId() 와 융합 키가 일치한다.
+        assertThat(EgovHybridDocumentRetriever.stripPrefix("embedding:abc-123"))
+                .isEqualTo("abc-123");
+        // prefix 가 없으면 원본 유지
+        assertThat(EgovHybridDocumentRetriever.stripPrefix("abc-123"))
+                .isEqualTo("abc-123");
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/EgovHybridRedisConfigToggleTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/EgovHybridRedisConfigToggleTest.java
@@ -1,0 +1,61 @@
+package com.example.chat.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.rag.retrieval.search.VectorStoreDocumentRetriever;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import redis.clients.jedis.JedisPooled;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * {@code rag.retrieval.hybrid.enabled} 토글에 따른 빈 등록 동작을 검증한다.
+ *
+ * <p>off(기본) 상태에서는 {@link EgovHybridRedisConfig} 의 빈(JedisPooled·하이브리드
+ * retriever)이 등록되지 않아, dense {@link VectorStoreDocumentRetriever} 만 존재한다.
+ * on 상태에서는 하이브리드 빈이 추가로 등록된다. JedisPooled 빈은 실제 접속을
+ * 열지 않는다(명령 실행 전까지 lazy).</p>
+ */
+class EgovHybridRedisConfigToggleTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(TestBeans.class, EgovHybridRedisConfig.class)
+            .withPropertyValues(
+                    "spring.data.redis.host=localhost",
+                    "spring.data.redis.port=6379",
+                    "spring.ai.vectorstore.redis.index-name=document-index");
+
+    @Test
+    @DisplayName("토글 off(기본): 하이브리드 빈 미등록")
+    void hybridBeansAbsentWhenDisabled() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean(EgovHybridDocumentRetriever.class);
+            assertThat(context).doesNotHaveBean(JedisPooled.class);
+            assertThat(context).hasSingleBean(VectorStoreDocumentRetriever.class);
+        });
+    }
+
+    @Test
+    @DisplayName("토글 on: 하이브리드 retriever·JedisPooled 빈 등록")
+    void hybridBeansPresentWhenEnabled() {
+        runner.withPropertyValues("rag.retrieval.hybrid.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(EgovHybridDocumentRetriever.class);
+            assertThat(context).hasSingleBean(JedisPooled.class);
+            assertThat(context).hasSingleBean(VectorStoreDocumentRetriever.class);
+        });
+    }
+
+    @Configuration
+    static class TestBeans {
+        @Bean
+        VectorStoreDocumentRetriever vectorStoreDocumentRetriever() {
+            return mock(VectorStoreDocumentRetriever.class);
+        }
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/EgovLexicalQueryBuilderTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/EgovLexicalQueryBuilderTest.java
@@ -1,0 +1,80 @@
+package com.example.chat.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link EgovLexicalQueryBuilder} 의 한글 어절 분해·폴백 질의 생성 로직을
+ * Redis 비의존 순수함수 단위로 검증한다.
+ */
+class EgovLexicalQueryBuilderTest {
+
+    @Test
+    @DisplayName("공백 기준 어절 분해 - 순서 보존·중복 제거")
+    void tokenizeSplitsByWhitespace() {
+        assertThat(EgovLexicalQueryBuilder.tokenize("주민등록번호 변경 신청"))
+                .containsExactly("주민등록번호", "변경", "신청");
+        // 중복·다중 공백 정리
+        assertThat(EgovLexicalQueryBuilder.tokenize("신청   변경 신청"))
+                .containsExactly("신청", "변경");
+    }
+
+    @Test
+    @DisplayName("빈/공백 질의는 빈 어절 리스트")
+    void tokenizeBlankYieldsEmpty() {
+        assertThat(EgovLexicalQueryBuilder.tokenize(null)).isEmpty();
+        assertThat(EgovLexicalQueryBuilder.tokenize("   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("정확매칭 질의는 어절을 AND(공백)로 묶는다")
+    void exactQueryJoinsTermsWithAnd() {
+        assertThat(EgovLexicalQueryBuilder.exactQuery(List.of("주민등록번호", "변경")))
+                .isEqualTo("@content:(주민등록번호 변경)");
+    }
+
+    @Test
+    @DisplayName("접두매칭 질의는 어절 뒤에 * 를 붙여 OR 로 묶는다")
+    void prefixQueryAppendsWildcard() {
+        assertThat(EgovLexicalQueryBuilder.prefixQuery(List.of("주민", "여권")))
+                .isEqualTo("@content:(주민* | 여권*)");
+    }
+
+    @Test
+    @DisplayName("중위매칭 질의는 어절 양쪽에 * 를 붙여 OR 로 묶는다")
+    void infixQueryWrapsWildcard() {
+        assertThat(EgovLexicalQueryBuilder.infixQuery(List.of("등록", "민원")))
+                .isEqualTo("@content:(*등록* | *민원*)");
+    }
+
+    @Test
+    @DisplayName("폴백 단계는 [정확, 접두, 중위] 순으로 생성된다")
+    void stagedQueriesAreOrdered() {
+        List<String> staged = EgovLexicalQueryBuilder.buildStagedQueries("주민등록번호 변경");
+
+        assertThat(staged).hasSize(3);
+        assertThat(staged.get(0)).isEqualTo("@content:(주민등록번호 변경)");
+        assertThat(staged.get(1)).isEqualTo("@content:(주민등록번호* | 변경*)");
+        assertThat(staged.get(2)).isEqualTo("@content:(*주민등록번호* | *변경*)");
+    }
+
+    @Test
+    @DisplayName("어절이 없으면 단계 질의도 비어 있다")
+    void stagedQueriesEmptyForBlank() {
+        assertThat(EgovLexicalQueryBuilder.buildStagedQueries("")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("RediSearch 특수문자는 이스케이프된다")
+    void escapesSpecialChars() {
+        // 콜론·괄호 등은 백슬래시로 이스케이프되어 질의 구문을 깨뜨리지 않는다.
+        assertThat(EgovLexicalQueryBuilder.escape("a:b(c)"))
+                .isEqualTo("a\\:b\\(c\\)");
+        // 일반 한글/영문은 변형 없음
+        assertThat(EgovLexicalQueryBuilder.escape("주민등록")).isEqualTo("주민등록");
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/EgovRrfFusionTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/EgovRrfFusionTest.java
@@ -1,0 +1,152 @@
+package com.example.chat.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * {@link EgovRrfFusion} 의 RRF 융합 로직을 결정적으로 검증한다.
+ *
+ * <p>표준 RRF 수식 {@code score(d) = Σ weight/(k+rank)} 을 골든셋으로 단정하고,
+ * 채널 가중치 변화에 따른 순서 변화, recall@k, MRR 을 확인한다.</p>
+ */
+class EgovRrfFusionTest {
+
+    private static final int K = EgovRrfFusion.DEFAULT_K; // 60
+
+    @Test
+    @DisplayName("표준 RRF 수식(k=60)에 따라 융합 점수가 계산된다")
+    void computesStandardRrfScore() {
+        // dense: [A, B, C], lexical: [B, A, D]
+        // A: 1/60(dense r0) + 1/61(lexical r1) = 0.016666... + 0.016393... = 0.033060...
+        // B: 1/61(dense r1) + 1/60(lexical r0) = 0.016393... + 0.016666... = 0.033060...
+        // 동점 -> 먼저 등장한 A 가 앞 (dense 먼저 누적)
+        // C: 1/62 = 0.016129...
+        // D: 1/62 = 0.016129...  (C 가 먼저 등장)
+        List<String> dense = List.of("A", "B", "C");
+        List<String> lexical = List.of("B", "A", "D");
+
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 10);
+
+        assertThat(fused).containsExactly("A", "B", "C", "D");
+    }
+
+    @Test
+    @DisplayName("양 채널 상위에 모두 등장한 키가 최상위로 융합된다")
+    void itemInBothChannelsRanksHighest() {
+        // X 는 양쪽 모두 0순위 -> 가장 높은 점수
+        List<String> dense = List.of("X", "A", "B");
+        List<String> lexical = List.of("X", "C", "D");
+
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 5);
+
+        assertThat(fused.get(0)).isEqualTo("X");
+        // X 점수 = 1/60 + 1/60 = 0.033333...
+        // 나머지는 단일 채널 최대 1/61 이하이므로 X 가 유일 최상위
+        assertThat(fused).hasSize(5).startsWith("X");
+    }
+
+    @Test
+    @DisplayName("lexical 가중치를 크게 주면 lexical 상위 키가 우선된다")
+    void lexicalWeightShiftsOrder() {
+        // dense 단독 상위 D vs lexical 단독 상위 L
+        List<String> dense = List.of("D");
+        List<String> lexical = List.of("L");
+
+        // 동일 가중: D(1/60) == L(1/60), 먼저 등장한 D 가 앞
+        List<String> equalWeight = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 2);
+        assertThat(equalWeight).containsExactly("D", "L");
+
+        // lexical 가중 3배: L(3/60) > D(1/60)
+        List<String> lexHeavy = EgovRrfFusion.fuse(dense, lexical, 1.0, 3.0, K, 2);
+        assertThat(lexHeavy).containsExactly("L", "D");
+    }
+
+    @Test
+    @DisplayName("topK 만큼만 잘라서 반환한다")
+    void respectsTopK() {
+        List<String> dense = List.of("A", "B", "C", "D", "E");
+        List<String> lexical = List.of("F", "G");
+
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 3);
+
+        assertThat(fused).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("한쪽 채널만 결과가 있어도 융합된다")
+    void singleChannelOnly() {
+        List<String> dense = List.of("A", "B");
+        List<String> lexical = List.of();
+
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 5);
+
+        assertThat(fused).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("null 채널 입력은 무시된다")
+    void nullChannelIgnored() {
+        List<String> dense = List.of("A", "B");
+
+        List<String> fused = EgovRrfFusion.fuse(dense, null, 1.0, 1.0, K, 5);
+
+        assertThat(fused).containsExactly("A", "B");
+    }
+
+    @Test
+    @DisplayName("골든셋 recall@k 와 MRR 이 융합으로 개선된다")
+    void recallAndMrrImproveAfterFusion() {
+        // 정답 키 = {REL1, REL2}
+        // 두 정답은 각 채널에서 중위권이라 단일 채널 top2 에는 들지 못한다.
+        // 그러나 양 채널에 모두 등장하므로 융합 시 순위 역수가 합산되어 상위로 올라온다
+        // (cross-channel reinforcement).
+        List<String> dense = List.of("n1", "REL1", "REL2", "n2");
+        List<String> lexical = List.of("m1", "REL2", "REL1", "m2");
+        List<String> relevant = List.of("REL1", "REL2");
+
+        List<String> denseTop2 = dense.subList(0, 2);
+        List<String> fused = EgovRrfFusion.fuse(dense, lexical, 1.0, 1.0, K, 2);
+
+        // recall@2: dense 단독은 1/2(REL1만), 융합은 2/2
+        assertThat(recallAtK(denseTop2, relevant)).isEqualTo(0.5);
+        assertThat(recallAtK(fused, relevant)).isEqualTo(1.0);
+
+        // MRR: 융합 결과 1순위가 정답이어야 한다
+        assertThat(mrr(fused, relevant)).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("개별 키 융합 점수가 수식값과 일치한다")
+    void exactScoreMatchesFormula() {
+        // A: dense r0 only -> 1/60
+        List<String> single = EgovRrfFusion.fuse(List.of("A"), List.of(), 1.0, 1.0, K, 1);
+        assertThat(single).containsExactly("A");
+
+        // 가중 2.0 적용 시 A 점수 = 2/60, B(lexical r0, weight1) = 1/60 -> A 우선
+        List<String> weighted = EgovRrfFusion.fuse(List.of("A"), List.of("B"), 2.0, 1.0, K, 2);
+        assertThat(weighted).containsExactly("A", "B");
+
+        // 수식값 직접 확인을 위한 sanity: 1/60 ≈ 0.016667
+        double expected = 1.0 / (K + 0);
+        assertThat(expected).isCloseTo(0.016666, within(1e-5));
+    }
+
+    private static double recallAtK(List<String> retrieved, List<String> relevant) {
+        long hit = relevant.stream().filter(retrieved::contains).count();
+        return (double) hit / relevant.size();
+    }
+
+    private static double mrr(List<String> retrieved, List<String> relevant) {
+        for (int i = 0; i < retrieved.size(); i++) {
+            if (relevant.contains(retrieved.get(i))) {
+                return 1.0 / (i + 1);
+            }
+        }
+        return 0.0;
+    }
+}


### PR DESCRIPTION
## 배경

Issue #49에서 제안된 하이브리드 검색 기능을 spring-ai 모듈에도 동일하게 구현합니다.

현재 이 모듈은 `VectorStoreDocumentRetriever` 기반의 단일 밀집 벡터 검색만 수행하고 있어, 행정 도메인 특유의 고유 명사나 정확한 키워드 매칭에 대한 재현율(Recall)이 다소 부족한 상황입니다.

전체적인 아키텍처 구조는 PR 1(langchain4j)과 통일성을 유지하되, 키워드(Lexical) 검색 채널의 백엔드로 Postgres 대신 RediSearch(Redis Stack)를 활용하도록 구현했습니다.

## 키워드 채널 기술 검증 (PoC 결과)

구현에 앞서 실제 라이브 환경의 redis-stack을 대상으로 다음 사항을 사전 검증했습니다.
- Spring AI의 `RedisVectorStore`가 자동 생성하는 `document-index`의 본문 필드는 `content`(TEXT 타입)로 선언되어 있어 별도의 보조 인덱스를 신설하지 않고도 `FT.SEARCH` 전문 검색이 가능합니다.
- `spring.data.redis.host/port` 설정을 재사용하여 내부에 `JedisPooled` 빈을 별도 구성한 뒤, `FT.SEARCH document-index "@content:(질의)"` 형태로 문서 회수가 가능함을 확인했습니다.
- RediSearch 결과로 반환되는 문서 키는 `embedding:<id>` 형식을 취하므로, 접두사(Prefix)를 제거하면 밀집 벡터 검색 결과인 `Document.getId()`와 완전히 동일한 식별자를 확보할 수 있어 문서 ID 정합성(융합 키 정합)이 보장됩니다.

## 변경 내용

**신규 컴포넌트**
- `EgovRrfFusion`: PR 1과 완전히 동일한 RRF 로직 기반의 랭크 융합 유틸리티 클래스입니다(k=60, 채널별 가중치 지원).
- `EgovLexicalQueryBuilder`: 입력된 한글 질의를 공백 어절 단위로 분해하여 정확 매칭 `@content:(t1 t2)`, 접두어(Prefix) 매칭 `(t1*|t2*)`, 부분 일치(Infix, 중위) 매칭 `(*t1*|*t2*)` 순으로 단계적 쿼리를 빌드합니다. 또한 RediSearch 구문 메타문자를 사전에 이스케이프 처리하여 쿼리 인젝션 취약점을 차단하는 순수 함수로 설계되었습니다.
- `EgovHybridDocumentRetriever`: `DocumentRetriever` 인터페이스의 구현체입니다. 벡터 검색 위임 및 RediSearch 기반 키워드 검색을 순차 수행 후 RRF로 병합합니다. 외부 의존성 분리를 위해 `LexicalSearch` 인터페이스를 거치도록 설계하여 Redis 인프라 없이도 독립 단위 테스트가 가능하게 했으며, 운영 환경에서는 `JedisPooled`를 이용한 `FT.SEARCH`로 동작합니다.
- `EgovHybridRedisConfig`: `rag.retrieval.hybrid.enabled=true` 조건 만족 시에만 `JedisPooled` 빈을 컨텍스트에 등록하여 기존 `document-index` 인덱스를 안전하게 재사용합니다.

**기존 코드 수정**
- `EgovRagConfig`: `createRagAdvisor` 메서드의 파라미터 타입을 구체 클래스인 `VectorStoreDocumentRetriever`에서 상위 인터페이스인 `DocumentRetriever`로 변경하여 다형성을 확보하고 결합도를 낮췄습니다.
- `EgovSessionAwareChatServiceImpl`: `ObjectProvider<EgovHybridDocumentRetriever>`를 사용하여 하이브리드 빈을 선택적으로 주입받습니다. 빈이 존재하지 않을 경우(토글 Off) 기존 밀집 벡터 검색기로 안전하게 폴백됩니다.
- `application.yml`: 하이브리드 설정 토글 및 가중치 기본값을 정의했습니다.

## 빈 모호성 예방

이 모듈의 경우, 기존 밀집 벡터 검색기가 인터페이스가 아닌 구체 타입(`VectorStoreDocumentRetriever`)으로 직접 주입되어 사용되고 있었습니다. 따라서 하이브리드 검색기를 상위 인터페이스 타입 기반의 독립 빈으로 구성하고 `ObjectProvider`를 통해 조건부 주입받도록 처리하여, 주입 시점의 빈 충돌 및 모호성 문제를 원천적으로 차단했습니다.

## 테스트 수행 결과

`mvn test` 전체 통과 (Tests run: 31, Failures: 0). 실제 Redis 인프라나 임베딩 모델 인스턴스 없이 구동되는 순수 단위 테스트 체계를 구축했습니다.
- `EgovRrfFusionTest` (8개): 병합 알고리즘 정합성 검증.
- `EgovLexicalQueryBuilderTest` (8개): 한글 어절 분해 알고리즘, 특수문자 이스케이프 및 안전한 쿼리 빌드 프로세스 검증.
- `EgovHybridDocumentRetrieverTest` (5개): 동일 ID 문서 발견 시 RRF 점수 보강 효과, 키워드 검색 에러 발생 시 벡터 검색 결과 정상 폴백 여부 확인.
- `EgovHybridRedisConfigToggleTest` (2개): 프로퍼티 토글 활성화 여부에 따른 빈 생성 조건 검증.

## 영향 범위 및 한계

**영향 범위**
- 하이브리드 토글 기본값이 `false`이므로 기존 RAG 엔진 및 비즈니스 로직에는 어떠한 영향도 주지 않습니다(회귀 위험도 0).
- 추가적인 라이브러리 도입 없이 `spring-ai-starter-vector-store-redis` 내부의 이행적 의존성(Transitive Dependency)인 `jedis` 드라이버를 그대로 사용합니다.

**한계점**
- RediSearch의 기본 토크나이저는 한글을 공백 어절 단위로만 분절하므로, 정밀한 형태소 분석이 이루어지지는 않습니다. 접두어/일치 매칭에는 강하나 어절 중간 단어 매칭은 와일드카드 기법으로 보완하고 있습니다. 한글 표기 변형 및 형태소 처리 유연성 측면에서는 pg_trgm 확장을 활용하는 langchain4j 모듈측 구현이 조금 더 유리한 특성을 가집니다(Issue #49 모듈별 기능 비대칭성 고려 필요).
- 최종 검색 품질(Recall, MRR) 및 레이턴시 변화에 대한 실측 성능 평가는 후속 마일스톤으로 이관합니다.
