### PR TITLE
fix: 마크다운 리더 file_name 메타데이터 추가 및 확장 리더 병합으로 깨진 업로드 검증 테스트 컴파일 복구

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
@@ -85,6 +85,8 @@ public class EgovMarkdownReader {
 
         Metadata metadata = Metadata.from("id", docId);
         metadata.put("source", filename);
+        // PDF·HWP·HWPX 리더와 동일하게 file_name을 남긴다(출처 표기 시 리더 간 메타데이터 정합).
+        metadata.put("file_name", filename);
         metadata.put("type", "markdown");
         metadata.put("content_length", String.valueOf(content.length()));
         // (?s) DOTALL: 여러 줄 마크다운에서도 '.'이 줄바꿈을 포함해 전체 매칭되도록 한다

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovMarkdownReaderMetadataTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovMarkdownReaderMetadataTest.java
@@ -48,4 +48,13 @@ class EgovMarkdownReaderMetadataTest {
         assertThat(metadata.getString("has_links")).isEqualTo("false");
         assertThat(metadata.getString("has_images")).isEqualTo("false");
     }
+
+    @Test
+    @DisplayName("파일명이 file_name 키로 기록된다(PDF·HWP 리더와 정합)")
+    void fileNameIsRecorded() throws Exception {
+        Metadata metadata = metadata("# 제목\n본문\n");
+
+        assertThat(metadata.getString("file_name")).isEqualTo("sample.md");
+        assertThat(metadata.getString("source")).isEqualTo("sample.md");
+    }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/service/impl/EgovDocumentServiceImplUploadValidationTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/service/impl/EgovDocumentServiceImplUploadValidationTest.java
@@ -22,8 +22,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class EgovDocumentServiceImplUploadValidationTest {
 
+    // 검증 거부 분기만 대상으로 하므로 모든 협력 객체는 null로 둔다. 인자 수는
+    // EgovDocumentServiceImpl 생성자(리더 5 + 변환 2 + writer + repository + executor = 10)와 일치.
     private final EgovDocumentServiceImpl service =
-            new EgovDocumentServiceImpl(null, null, null, null, null, null, null);
+            new EgovDocumentServiceImpl(null, null, null, null, null, null, null, null, null, null);
 
     private MockMultipartFile md(String filename, int size) {
         return new MockMultipartFile("files", filename, "text/markdown", new byte[size]);

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
@@ -82,6 +82,8 @@ public class EgovMarkdownReader implements DocumentReader {
     private Map<String, Object> createEnhancedMetadata(String filename, String content) {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("source", filename);
+        // PDF·HWP·HWPX 리더와 동일하게 file_name을 남긴다(출처 표기 시 리더 간 메타데이터 정합).
+        metadata.put("file_name", filename);
         metadata.put("type", "markdown");
         metadata.put("content_length", content.length());
         // (?s) DOTALL: 여러 줄 마크다운에서도 '.'이 줄바꿈을 포함해 전체 매칭되도록 한다

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovMarkdownReaderMetadataTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovMarkdownReaderMetadataTest.java
@@ -48,4 +48,13 @@ class EgovMarkdownReaderMetadataTest {
         assertThat(metadata.get("has_links")).isEqualTo(Boolean.FALSE);
         assertThat(metadata.get("has_images")).isEqualTo(Boolean.FALSE);
     }
+
+    @Test
+    @DisplayName("파일명이 file_name 키로 기록된다(PDF·HWP 리더와 정합)")
+    void fileNameIsRecorded() throws Exception {
+        Map<String, Object> metadata = metadata("# 제목\n본문\n");
+
+        assertThat(metadata.get("file_name")).isEqualTo("sample.md");
+        assertThat(metadata.get("source")).isEqualTo("sample.md");
+    }
 }

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/service/impl/EgovDocumentServiceImplUploadValidationTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/service/impl/EgovDocumentServiceImplUploadValidationTest.java
@@ -23,7 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EgovDocumentServiceImplUploadValidationTest {
 
     private final EgovDocumentServiceImpl service =
-            new EgovDocumentServiceImpl(null, null, null, null, null, null, null, null);
+            // 인자 수는 EgovDocumentServiceImpl 생성자(리더 5 + 변환 2 + writer + vectorStore
+            // + stringRedisTemplate + executor = 11)와 일치.
+            new EgovDocumentServiceImpl(null, null, null, null, null, null, null, null, null, null, null);
 
     private MockMultipartFile md(String filename, int size) {
         return new MockMultipartFile("files", filename, "text/markdown", new byte[size]);


### PR DESCRIPTION
## 배경
출처 인용(citation) 제안(#53) 검토 과정에서 메인테이너가 지적한 리더 간 메타데이터 불일치를 정리하고, 그 과정에서 발견한 테스트 컴파일 실패를 함께 복구합니다.

## 변경 내용

### 1. 마크다운 리더에 `file_name` 메타데이터 추가 (양 모듈)
`EgovMarkdownReader`는 `source`만 저장하고 `file_name` 키를 남기지 않아, `file_name`을 기록하는 PDF·HWP·HWPX 리더와 메타데이터가 어긋났습니다. 동일하게 `file_name`을 추가해 출처 표기 시 리더 간 정합을 맞춥니다.

### 2. 깨진 업로드 검증 테스트 컴파일 복구 (양 모듈)
DOCX·HWP·HWPX 리더가 추가되며 `EgovDocumentServiceImpl` 생성자 인자 수가 늘었으나, `EgovDocumentServiceImplUploadValidationTest`의 생성자 호출이 갱신되지 않아 **테스트 모듈이 컴파일되지 않는 상태**였습니다. 인자 수를 현재 생성자(langchain4j 10 · spring-ai 11)에 맞춰 복구합니다. (검증 거부 분기만 대상으로 하므로 협력 객체는 모두 `null`입니다.)

## 검증
- 마크다운 메타데이터 테스트에 `file_name` 단언 추가.
- 양 모듈 전체 테스트 통과(langchain4j 32 / spring-ai 37).

## 비고
citation의 나머지 통합 지점(langchain4j PDF page_number, ChatbotFactory 체인 등)은 성격이 달라 후속으로 다루겠습니다.