### PR TITLE
fix: langchain4j PDF 리더를 페이지 단위로 파싱해 실제 page_number 기록

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovPdfReader.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovPdfReader.java
@@ -1,10 +1,10 @@
 package com.example.chat.config.etl.readers;
 
 import dev.langchain4j.data.document.Document;
-import dev.langchain4j.data.document.DocumentParser;
 import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.document.parser.apache.pdfbox.ApachePdfBoxDocumentParser;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -17,7 +17,7 @@ import java.util.List;
 
 /**
  * PDF 문서 로더
- * LangChain4j의 ApachePdfBoxDocumentParser 사용
+ * PDFBox로 페이지 단위 파싱하여 각 페이지에 실제 페이지 번호(page_number)를 부여한다.
  */
 @Slf4j
 @Component
@@ -25,8 +25,6 @@ public class EgovPdfReader {
 
     @Value("${document.pdf-path}")
     private String pdfDocumentPath;
-
-    private final DocumentParser pdfParser = new ApachePdfBoxDocumentParser();
 
     /**
      * PDF 문서 로드
@@ -73,40 +71,51 @@ public class EgovPdfReader {
     }
 
     /**
-     * PDF 파일을 파싱하고 페이지별로 문서 생성
+     * PDF 파일을 페이지 단위로 파싱해 페이지당 하나의 문서를 생성한다.
+     *
+     * <p>PDFBox {@link PDFTextStripper}로 페이지별 텍스트를 추출하고, 각 문서에 실제 페이지
+     * 번호({@code page_number})를 부여한다(출처 인용에 필요). 텍스트가 비어 있는 페이지(스캔
+     * 이미지 등)는 색인에서 건너뛴다. 페이지 내 청킹은 {@code EgovEnhancedDocumentTransformer}가
+     * 담당하며, 페이지 단위로 문서가 나뉘므로 청크가 페이지 경계를 넘지 않는다.</p>
      */
-    private List<Document> parsePdfDocument(Resource resource) throws IOException {
+    List<Document> parsePdfDocument(Resource resource) throws IOException {
         String filename = resource.getFilename();
         if (filename == null) {
             filename = "unknown.pdf";
         }
+        String baseFilename = filename.replaceAll("\\.pdf$", "");
+        String safeFilename = baseFilename.replaceAll("[\\/:*?\"<>|]", "").replaceAll("\\s+", "-");
 
         List<Document> documents = new ArrayList<>();
 
-        try (InputStream inputStream = resource.getInputStream()) {
-            // LangChain4j의 PDFBox 파서로 전체 PDF 파싱
-            Document fullDocument = pdfParser.parse(inputStream);
+        try (InputStream inputStream = resource.getInputStream();
+             PDDocument pdf = PDDocument.load(inputStream)) {
 
-            String content = fullDocument.text();
+            int pageCount = pdf.getNumberOfPages();
+            PDFTextStripper stripper = new PDFTextStripper();
 
-            // 페이지별 분할은 생략하고 전체 문서를 하나로 처리
-            // Spring AI의 pagesPerDocument 속성 사용 불가
-            // document 객체의 분할은 EnhancedDocumentTransformer 클래스에서 처리
-            String baseFilename = filename.replaceAll("\\.pdf$", "");
-            String safeFilename = baseFilename.replaceAll("[\\/:*?\"<>|]", "")
-                    .replaceAll("\\s+", "-");
-            String customId = String.format("pdf-%s_1", safeFilename);
+            for (int page = 1; page <= pageCount; page++) {
+                stripper.setStartPage(page);
+                stripper.setEndPage(page);
+                String content = stripper.getText(pdf);
 
-            Metadata metadata = Metadata.from("id", customId);
-            metadata.put("file_name", filename);
-            metadata.put("source", filename);
-            metadata.put("type", "pdf");
-            metadata.put("content_length", String.valueOf(content.length()));
-            metadata.put("page_number", "1");
+                if (content == null || content.isBlank()) {
+                    log.debug("PDF '{}' {}페이지: 빈 내용으로 건너뜀", filename, page);
+                    continue;
+                }
 
-            log.debug("PDF Document ID: {} (길이: {})", customId, content.length());
+                String customId = String.format("pdf-%s_%d", safeFilename, page);
+                Metadata metadata = Metadata.from("id", customId);
+                metadata.put("file_name", filename);
+                metadata.put("source", filename);
+                metadata.put("type", "pdf");
+                metadata.put("content_length", String.valueOf(content.length()));
+                metadata.put("page_number", String.valueOf(page));
 
-            documents.add(Document.from(content, metadata));
+                documents.add(Document.from(content, metadata));
+            }
+
+            log.debug("PDF '{}': {}페이지 중 {}개 문서 생성", filename, pageCount, documents.size());
         }
 
         return documents;

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovPdfReaderPageNumberTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovPdfReaderPageNumberTest.java
@@ -1,0 +1,94 @@
+package com.example.chat.config.etl.readers;
+
+import dev.langchain4j.data.document.Document;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link EgovPdfReader}가 페이지 단위로 문서를 생성하고 실제 페이지 번호를 부여하는지 검증한다.
+ *
+ * <p>PDFBox로 테스트용 다중 페이지 PDF를 즉석 생성해 외부 파일 의존 없이 결정적으로 확인한다.</p>
+ */
+class EgovPdfReaderPageNumberTest {
+
+    /** page당 지정 텍스트를 담은 PDF 바이트를 생성한다. */
+    private byte[] pdfWithPages(String... pageTexts) throws Exception {
+        try (PDDocument doc = new PDDocument(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            for (String text : pageTexts) {
+                PDPage page = new PDPage();
+                doc.addPage(page);
+                try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+                    cs.beginText();
+                    cs.setFont(PDType1Font.HELVETICA, 12);
+                    cs.newLineAtOffset(72, 720);
+                    cs.showText(text);
+                    cs.endText();
+                }
+            }
+            doc.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Document> parse(Resource resource) throws Exception {
+        Method m = EgovPdfReader.class.getDeclaredMethod("parsePdfDocument", Resource.class);
+        m.setAccessible(true);
+        return (List<Document>) m.invoke(new EgovPdfReader(), resource);
+    }
+
+    @Test
+    @DisplayName("페이지마다 문서를 만들고 실제 page_number(1,2)와 내용을 부여한다")
+    void assignsRealPageNumbers() throws Exception {
+        byte[] pdf = pdfWithPages("PAGE ONE ALPHA", "PAGE TWO BRAVO");
+        Resource resource = new ByteArrayResource(pdf) {
+            @Override
+            public String getFilename() {
+                return "guide.pdf";
+            }
+        };
+
+        List<Document> docs = parse(resource);
+
+        assertThat(docs).hasSize(2);
+        assertThat(docs.get(0).metadata().getString("page_number")).isEqualTo("1");
+        assertThat(docs.get(0).metadata().getString("file_name")).isEqualTo("guide.pdf");
+        assertThat(docs.get(0).text()).contains("ALPHA");
+        assertThat(docs.get(1).metadata().getString("page_number")).isEqualTo("2");
+        assertThat(docs.get(1).text()).contains("BRAVO");
+        // 페이지별 고유 id
+        assertThat(docs.get(0).metadata().getString("id")).isEqualTo("pdf-guide_1");
+        assertThat(docs.get(1).metadata().getString("id")).isEqualTo("pdf-guide_2");
+    }
+
+    @Test
+    @DisplayName("빈(텍스트 없는) 페이지는 색인에서 건너뛴다")
+    void skipsBlankPages() throws Exception {
+        byte[] pdf = pdfWithPages("CONTENT PAGE", "   ", "LAST PAGE");
+        Resource resource = new ByteArrayResource(pdf) {
+            @Override
+            public String getFilename() {
+                return "doc.pdf";
+            }
+        };
+
+        List<Document> docs = parse(resource);
+
+        // 빈 2페이지는 제외 → 1·3페이지만, page_number는 실제 페이지 번호 유지
+        assertThat(docs).hasSize(2);
+        assertThat(docs).extracting(d -> d.metadata().getString("page_number"))
+                .containsExactly("1", "3");
+    }
+}


### PR DESCRIPTION
## 배경
출처 인용(#53) 검토에서 지적된 항목입니다. langchain4j `EgovPdfReader`는 전체 PDF를 하나의 Document로 파싱하고 `page_number`를 "1"로 고정해, PDF 출처 페이지가 항상 1로 표시됩니다.

## 변경 내용
`ApachePdfBoxDocumentParser`(전체 파싱) 대신 PDFBox `PDFTextStripper`로 **페이지 단위 파싱**합니다.
- 페이지당 하나의 Document + 실제 `page_number`(1-based)
- 텍스트가 없는 페이지(스캔 이미지 등)는 색인에서 제외
- 페이지 단위로 문서가 나뉘므로 이후 청킹이 페이지 경계를 넘지 않음
- spring-ai 모듈의 `EgovPdfReader`는 이미 페이지 단위(i+1)라 무관

## 테스트
PDFBox로 다중 페이지 PDF를 즉석 생성해 각 페이지에 실제 `page_number`(1,2)가 부여되는지, 빈 중간 페이지가 제외되고 남은 페이지 번호(1,3)가 유지되는지 검증합니다. 모듈 전체 테스트 통과.

## 참고
색인 파이프라인은 `addAll` 기반(기존 벡터 삭제 없음)이므로, 기존 인덱스에 반영하려면 깨끗한 재색인(빈 스토어)을 권장합니다. 재색인 시 소스별 기존 벡터 제거는 별도 개선으로 다룰 수 있습니다.