### PR TITLE
feat(langchain4j): 멀티턴 질의 압축(재작성) 추가 — spring-ai 모듈과 기능 패리티

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovQueryCompressionConfig.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovQueryCompressionConfig.java
@@ -1,0 +1,74 @@
+package com.example.chat.config;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.input.PromptTemplate;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.rag.query.transformer.CompressingQueryTransformer;
+import dev.langchain4j.rag.query.transformer.QueryTransformer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * 멀티턴 질의 압축(재작성) 설정
+ *
+ * <p>후속 질문("두 번째 항목을 설명해줘")은 그 자체로는 검색어가 되지 못해 RAG 검색 품질이
+ * 떨어진다. 대화 이력을 참고해 후속 질문을 독립형 질의로 재작성한 뒤 검색에 사용한다.
+ * spring-ai 모듈의 EgovCompressionQueryTransformer와 동일한 목적/규칙의 기능으로,
+ * 두 모듈의 기능 패리티를 맞춘다.</p>
+ *
+ * <p>{@code rag.enable-query-compression=true} 일 때만 활성화되며(기본 OFF, 기존 동작 보존),
+ * 재작성에는 스트리밍이 필요 없어 동기 {@link OllamaChatModel}을 별도로 생성해 사용한다.</p>
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(name = "rag.enable-query-compression", havingValue = "true")
+public class EgovQueryCompressionConfig {
+
+    @Value("${langchain4j.ollama.base-url}")
+    private String ollamaBaseUrl;
+
+    /** 재작성용 모델. 미지정 시 채팅 모델과 동일한 모델을 사용한다. */
+    @Value("${rag.query-compression.model-name:${langchain4j.ollama.chat-model.model-name}}")
+    private String modelName;
+
+    @Value("${rag.query-compression.timeout:30s}")
+    private Duration timeout;
+
+    /**
+     * 재작성 프롬프트. spring-ai 모듈의 커스텀 프롬프트와 동일한 규칙(출력은 재작성 질의만,
+     * 원 질문 언어 유지, 대명사·지시어를 대화 이력의 구체 용어로 치환)을 적용한다.
+     * {@code {{chatMemory}}}, {@code {{query}}} 플레이스홀더는 CompressingQueryTransformer 규약이다.
+     */
+    private static final PromptTemplate COMPRESSION_PROMPT = PromptTemplate.from(
+            """
+            You are a query rewriting assistant. Your ONLY job is to rewrite the user's \
+            follow-up query into a standalone query using the conversation.
+
+            STRICT RULES:
+            - Output ONLY the rewritten query, nothing else
+            - NO explanations, NO thinking process, DO NOT use <think> tags or any XML tags
+            - Keep the SAME language as the original query (Korean -> Korean, English -> English)
+            - Replace pronouns and references with specific terms from the conversation
+
+            Conversation:
+            {{chatMemory}}
+
+            User query: {{query}}""");
+
+    @Bean
+    public QueryTransformer compressingQueryTransformer() {
+        ChatModel compressionModel = OllamaChatModel.builder()
+                .baseUrl(ollamaBaseUrl)
+                .modelName(modelName)
+                .temperature(0.0)
+                .timeout(timeout)
+                .build();
+        log.info("질의 압축(CompressingQueryTransformer) 활성화 - model: {}", modelName);
+        return new CompressingQueryTransformer(compressionModel, COMPRESSION_PROMPT);
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovQueryCompressionConfig.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovQueryCompressionConfig.java
@@ -23,6 +23,9 @@ import java.time.Duration;
  *
  * <p>{@code rag.enable-query-compression=true} 일 때만 활성화되며(기본 OFF, 기존 동작 보존),
  * 재작성에는 스트리밍이 필요 없어 동기 {@link OllamaChatModel}을 별도로 생성해 사용한다.</p>
+ *
+ * <p>재작성 결과는 {@link EgovSanitizingQueryTransformer} 를 거쳐 {@code <think>} 블록 제거와
+ * 답변형 결과 복원을 적용한 뒤 검색에 사용된다. spring-ai 모듈과 같은 안전장치다.</p>
  */
 @Slf4j
 @Configuration
@@ -69,6 +72,8 @@ public class EgovQueryCompressionConfig {
                 .timeout(timeout)
                 .build();
         log.info("질의 압축(CompressingQueryTransformer) 활성화 - model: {}", modelName);
-        return new CompressingQueryTransformer(compressionModel, COMPRESSION_PROMPT);
+        // 재작성 결과는 그대로 쓰지 않고 <think> 블록 제거·답변형 결과 복원을 거친다.
+        return new EgovSanitizingQueryTransformer(
+                new CompressingQueryTransformer(compressionModel, COMPRESSION_PROMPT));
     }
 }

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovSanitizingQueryTransformer.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/EgovSanitizingQueryTransformer.java
@@ -1,0 +1,117 @@
+package com.example.chat.config;
+
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.rag.query.transformer.QueryTransformer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * 질의 재작성 결과를 검증·정리하는 위임형 {@link QueryTransformer}.
+ *
+ * <p>재작성에 쓰는 모델을 고정하지 않기 때문에, 프롬프트로 금지해도 모델이 규칙을 어길 수 있다.
+ * 이 클래스는 위임한 트랜스포머의 결과에 두 가지 안전장치를 적용한다.</p>
+ *
+ * <ol>
+ *   <li><b>{@code <think>} 블록 제거</b> — reasoning 모드를 지원하는 모델이 사고 과정을 함께
+ *       출력하면 태그가 포함된 문자열이 그대로 검색어가 된다. 블록을 제거한 뒤 사용한다.</li>
+ *   <li><b>재작성 결과 검증</b> — 모델이 재작성 질의 대신 답변을 반환하면(코드 블록 포함,
+ *       200자 초과 등) 검색 품질이 오히려 떨어진다. 이 경우 원본 질의로 복원한다.</li>
+ * </ol>
+ *
+ * <p>판정 규칙은 spring-ai 모듈의 {@code EgovCompressionQueryTransformer}와 동일하게 맞췄다.
+ * 다만 여러 줄 응답도 걸러지도록 "예시는/예시:" 패턴 매칭에 {@code (?s)} 플래그를 적용했다.</p>
+ *
+ * <p>어느 안전장치도 걸리지 않으면 위임 결과를 그대로 통과시키므로 기존 동작은 보존된다.</p>
+ */
+@Slf4j
+public class EgovSanitizingQueryTransformer implements QueryTransformer {
+
+    /** 이 길이를 넘으면 질의가 아니라 답변으로 판단한다. spring-ai 모듈과 동일한 임계값. */
+    static final int MAX_REWRITTEN_LENGTH = 200;
+
+    private static final String THINK_OPEN = "<think>";
+    private static final String THINK_CLOSE = "</think>";
+
+    private final QueryTransformer delegate;
+
+    public EgovSanitizingQueryTransformer(QueryTransformer delegate) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate must not be null");
+        }
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Collection<Query> transform(Query query) {
+        Collection<Query> transformed = delegate.transform(query);
+        if (transformed == null || transformed.isEmpty()) {
+            log.warn("재작성 결과가 비어 있어 원본 질의를 사용한다: '{}'", query.text());
+            return List.of(query);
+        }
+        List<Query> sanitized = new ArrayList<>(transformed.size());
+        for (Query candidate : transformed) {
+            sanitized.add(sanitize(query, candidate));
+        }
+        return sanitized;
+    }
+
+    private Query sanitize(Query original, Query candidate) {
+        if (candidate == null || candidate.text() == null) {
+            log.warn("재작성 결과가 비어 있어 원본 질의를 사용한다: '{}'", original.text());
+            return original;
+        }
+        String cleaned = stripThinkBlock(candidate.text());
+        if (cleaned.isEmpty() || isLikelyAnswer(cleaned)) {
+            log.warn("재작성 결과를 질의로 볼 수 없어 원본 질의를 사용한다: '{}'", candidate.text());
+            return original;
+        }
+        if (cleaned.equals(candidate.text())) {
+            return candidate;
+        }
+        log.info("<think> 블록 제거 후 재작성 질의: '{}'", cleaned);
+        return candidate.metadata() == null
+                ? Query.from(cleaned)
+                : Query.from(cleaned, candidate.metadata());
+    }
+
+    /**
+     * {@code <think> ... </think>} 블록을 제거한다.
+     * 닫는 태그가 없으면(출력이 잘린 경우) 여는 태그 이후를 사용한다.
+     */
+    static String stripThinkBlock(String text) {
+        if (text == null) {
+            return "";
+        }
+        String result = text;
+        int close = result.lastIndexOf(THINK_CLOSE);
+        if (close >= 0) {
+            result = result.substring(close + THINK_CLOSE.length());
+        } else {
+            int open = result.indexOf(THINK_OPEN);
+            if (open >= 0) {
+                result = result.substring(open + THINK_OPEN.length());
+            }
+        }
+        return result.trim();
+    }
+
+    /** 재작성 결과가 질의가 아니라 답변처럼 보이는지 판단한다. */
+    static boolean isLikelyAnswer(String text) {
+        if (text == null) {
+            return false;
+        }
+        if (text.contains("```") || text.contains("function") || text.contains("const ")
+                || text.contains("return ") || text.contains("class ")) {
+            return true;
+        }
+        if (text.matches("(?s).*예시[는은:].*") || text.contains("다음과 같습니다")
+                || text.contains("설명:") || text.contains("코드는")) {
+            return true;
+        }
+        return text.length() > MAX_REWRITTEN_LENGTH;
+    }
+}
+

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/service/ChatbotFactory.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/service/ChatbotFactory.java
@@ -4,7 +4,9 @@ import com.example.chat.repository.PersistentChatMemoryStore;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
+import dev.langchain4j.rag.DefaultRetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.transformer.QueryTransformer;
 import dev.langchain4j.service.AiServices;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +27,7 @@ import java.time.Duration;
 public class ChatbotFactory {
 
     private final ContentRetriever contentRetriever;
+    private final QueryTransformer queryTransformer;
     private final PersistentChatMemoryStore chatMemoryStore;
     private final OllamaStreamingChatModel defaultStreamingModel;
 
@@ -47,19 +50,26 @@ public class ChatbotFactory {
      * @param hybridContentRetriever 하이브리드 검색 빈. {@code rag.retrieval.hybrid.enabled=true}
      *                               일 때만 등록되며 off(기본) 상태에서는 null 이다.
      * @param denseContentRetriever  dense 벡터 검색 빈. 항상 존재한다.
+     * @param queryTransformer       멀티턴 질의 압축 빈. {@code rag.enable-query-compression=true}
+     *                               일 때만 등록되며 off(기본) 상태에서는 null 이다.
      */
     public ChatbotFactory(
             @Qualifier("hybridContentRetriever") @Autowired(required = false) ContentRetriever hybridContentRetriever,
             @Qualifier("contentRetriever") ContentRetriever denseContentRetriever,
+            @Autowired(required = false) QueryTransformer queryTransformer,
             PersistentChatMemoryStore chatMemoryStore,
             OllamaStreamingChatModel defaultStreamingModel) {
         // 하이브리드 빈이 등록된 경우 우선 사용하고, 없으면 기존 dense 경로를 유지한다.
         this.contentRetriever = (hybridContentRetriever != null) ? hybridContentRetriever : denseContentRetriever;
+        this.queryTransformer = queryTransformer;
         this.chatMemoryStore = chatMemoryStore;
         this.defaultStreamingModel = defaultStreamingModel;
 
         if (hybridContentRetriever != null) {
             log.info("ChatbotFactory - 하이브리드 ContentRetriever 사용");
+        }
+        if (queryTransformer != null) {
+            log.info("ChatbotFactory - 멀티턴 질의 압축(QueryTransformer) 사용");
         }
     }
 
@@ -80,11 +90,22 @@ public class ChatbotFactory {
         log.info("RAG 챗봇 생성 - 모델: {}, 세션: {}",
                 isDefaultModel(modelName) ? defaultModelName : modelName, sessionId);
 
-        return AiServices.builder(RagChatbot.class)
+        AiServices<RagChatbot> builder = AiServices.builder(RagChatbot.class)
                 .streamingChatModel(streamingModel)
-                .contentRetriever(contentRetriever)
-                .chatMemory(createChatMemory(sessionId))
-                .build();
+                .chatMemory(createChatMemory(sessionId));
+
+        if (queryTransformer != null) {
+            // 질의 압축이 켜진 경우: 대화 이력 기반으로 재작성된 질의로 검색하도록
+            // RetrievalAugmentor 경로를 사용한다 (기존 contentRetriever 경로와 동일 검색기 사용).
+            builder.retrievalAugmentor(DefaultRetrievalAugmentor.builder()
+                    .queryTransformer(queryTransformer)
+                    .contentRetriever(contentRetriever)
+                    .build());
+        } else {
+            builder.contentRetriever(contentRetriever);
+        }
+
+        return builder.build();
     }
 
     /**

--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -107,6 +107,9 @@ document:
 
 # RAG 설정
 rag:
+  # 멀티턴 질의 압축(재작성): 후속 질문을 대화 이력 기반 독립형 질의로 재작성해 검색 품질을 높인다.
+  # spring-ai 모듈의 enable-query-compression과 동일 키. 기본 OFF(기존 동작 보존).
+  enable-query-compression: false
   # RAG 유사도 임계값 설정 (0.0 ~ 1.0)
   similarity:
     threshold: 0.70

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovSanitizingQueryTransformerTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovSanitizingQueryTransformerTest.java
@@ -1,0 +1,127 @@
+package com.example.chat.config;
+
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.rag.query.transformer.QueryTransformer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link EgovSanitizingQueryTransformer} 의 후처리 동작을 검증한다.
+ *
+ * <p>위임 대상은 고정 문자열을 돌려주는 스텁이라 Ollama·네트워크 없이 실행된다.
+ * 검증 대상은 {@code <think>} 블록 제거와 답변형 결과의 원본 복원 두 가지다.</p>
+ */
+class EgovSanitizingQueryTransformerTest {
+
+    private static final String ORIGINAL = "세 번째 사항의 예시를 알려 줘";
+
+    /** 재작성 결과를 그대로 돌려주는 스텁. */
+    private static QueryTransformer stub(String rewritten) {
+        return query -> List.of(Query.from(rewritten));
+    }
+
+    private static Query transformOne(String rewritten) {
+        Collection<Query> out = new EgovSanitizingQueryTransformer(stub(rewritten))
+                .transform(Query.from(ORIGINAL));
+        assertThat(out).hasSize(1);
+        return out.iterator().next();
+    }
+
+    @Test
+    @DisplayName("정상 재작성 결과는 그대로 통과한다")
+    void passesThroughCleanRewrite() {
+        String rewritten = "전자정부 실행환경 AOP의 Pointcut 표현식 예시";
+        assertThat(transformOne(rewritten).text()).isEqualTo(rewritten);
+    }
+
+    @Test
+    @DisplayName("<think>...</think> 블록이 있으면 제거하고 뒤쪽 텍스트를 쓴다")
+    void stripsThinkBlock() {
+        String rewritten = "<think>사용자가 세 번째 항목을 물었다. 히스토리에서 찾자.</think>\n"
+                + "전자정부 실행환경 AOP의 Pointcut 표현식";
+        assertThat(transformOne(rewritten).text())
+                .isEqualTo("전자정부 실행환경 AOP의 Pointcut 표현식")
+                .doesNotContain("<think>");
+    }
+
+    @Test
+    @DisplayName("닫는 </think> 가 없어도 여는 태그 이후를 사용한다")
+    void stripsUnclosedThinkBlock() {
+        String rewritten = "<think>이건 후속 질문이다 전자정부 실행환경 AOP의 Pointcut 표현식";
+        assertThat(transformOne(rewritten).text())
+                .isEqualTo("이건 후속 질문이다 전자정부 실행환경 AOP의 Pointcut 표현식");
+    }
+
+    @Test
+    @DisplayName("</think> 가 여러 번 나오면 마지막 블록 뒤를 쓴다")
+    void stripsNestedThinkBlocks() {
+        String rewritten = "<think>a</think><think>b</think>실제 질의";
+        assertThat(transformOne(rewritten).text()).isEqualTo("실제 질의");
+    }
+
+    @Test
+    @DisplayName("코드 블록이 섞인 답변형 결과는 원본 질의로 복원한다")
+    void fallsBackWhenAnswerContainsCodeBlock() {
+        String rewritten = "다음처럼 쓰면 됩니다.\n```java\n@Around(\"execution(* *(..))\")\n```";
+        assertThat(transformOne(rewritten).text()).isEqualTo(ORIGINAL);
+    }
+
+    @Test
+    @DisplayName("200자를 넘는 결과는 답변으로 보고 원본 질의로 복원한다")
+    void fallsBackWhenTooLong() {
+        String rewritten = "가".repeat(EgovSanitizingQueryTransformer.MAX_REWRITTEN_LENGTH + 1);
+        assertThat(transformOne(rewritten).text()).isEqualTo(ORIGINAL);
+    }
+
+    @Test
+    @DisplayName("200자 이하 경계값은 답변으로 보지 않는다")
+    void keepsRewriteAtLengthBoundary() {
+        String rewritten = "가".repeat(EgovSanitizingQueryTransformer.MAX_REWRITTEN_LENGTH);
+        assertThat(transformOne(rewritten).text()).isEqualTo(rewritten);
+    }
+
+    @Test
+    @DisplayName("여러 줄 설명형 결과도 원본 질의로 복원한다")
+    void fallsBackOnMultilineExplanation() {
+        String rewritten = "AOP는 관점 지향 프로그래밍입니다.\n예시는 아래와 같습니다.";
+        assertThat(transformOne(rewritten).text()).isEqualTo(ORIGINAL);
+    }
+
+    @Test
+    @DisplayName("<think> 제거 후 남는 텍스트가 없으면 원본 질의로 복원한다")
+    void fallsBackWhenNothingLeftAfterStrip() {
+        assertThat(transformOne("<think>고민만 하고 끝났다</think>   ").text()).isEqualTo(ORIGINAL);
+    }
+
+    @Test
+    @DisplayName("위임 결과가 비어 있으면 원본 질의를 사용한다")
+    void fallsBackOnEmptyDelegateResult() {
+        Collection<Query> out = new EgovSanitizingQueryTransformer(query -> List.of())
+                .transform(Query.from(ORIGINAL));
+        assertThat(out).extracting(Query::text).containsExactly(ORIGINAL);
+    }
+
+    @Test
+    @DisplayName("위임 결과가 여러 건이면 각각을 정리한다")
+    void sanitizesEachOfMultipleQueries() {
+        QueryTransformer multi = query -> List.of(
+                Query.from("<think>t</think>정상 재작성 질의"),
+                Query.from("설명: 이건 답변입니다"));
+        Collection<Query> out = new EgovSanitizingQueryTransformer(multi).transform(Query.from(ORIGINAL));
+        assertThat(out).extracting(Query::text).containsExactly("정상 재작성 질의", ORIGINAL);
+    }
+
+    @Test
+    @DisplayName("delegate 가 null 이면 생성 시점에 거부한다")
+    void rejectsNullDelegate() {
+        assertThatThrownBy(() -> new EgovSanitizingQueryTransformer(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}
+


### PR DESCRIPTION
## 배경

spring-ai 모듈에는 EgovCompressionQueryTransformer(대화 이력 기반 후속 질문 재작성)가 있지만 langchain4j 모듈에는 대응 기능이 없어, 같은 멀티턴 질문("두 번째 항목을 설명해줘")에 두 모듈의 검색 품질이 달라집니다. 두 스택의 동등 비교가 이 저장소의 존재 이유인 만큼 기능 패리티를 맞췄습니다.

## 변경 내용

- **EgovQueryCompressionConfig(신규)**: `rag.enable-query-compression=true`일 때만 등록되는 CompressingQueryTransformer 빈. spring-ai 모듈 커스텀 프롬프트와 동일 규칙(출력은 재작성 질의만, 원 질문 언어 유지, 대명사→구체 용어 치환). 재작성엔 스트리밍이 불필요해 동기 OllamaChatModel(temperature 0)을 별도 생성 — 모델·타임아웃은 `rag.query-compression.*`로 조정 가능
- **ChatbotFactory**: 압축 빈이 있으면 `DefaultRetrievalAugmentor(queryTransformer + 기존 contentRetriever)` 경로로, 없으면 기존 `contentRetriever` 경로 그대로 — **기본 OFF, 기존 동작 불변**. 하이브리드 retriever(#51)와도 그대로 결합됩니다
- **application.yml**: `rag.enable-query-compression: false` 항목·주석 추가 (spring-ai 모듈과 동일 키)

## 검증

- `mvn -DskipTests compile` BUILD SUCCESS (JDK 17)
- OFF(기본): 신규 빈 미등록, 기존 코드 경로와 동일 — 회귀 없음
- CompressingQueryTransformer는 대화 이력이 없으면 원 질의를 그대로 통과시키므로 첫 질문 동작도 불변

## 관련

- spring-ai 모듈의 EgovCompressionQueryTransformer (패리티 대상)
- #67, #68 (별개 축의 제안들 — 본 PR과 독립)