### PR TITLE
feat: 두 RAG 모듈에 한국어 문장경계 인지 청킹 추가(기본 OFF)

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/EgovKoreanChunkingConfig.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/EgovKoreanChunkingConfig.java
@@ -20,7 +20,10 @@ public class EgovKoreanChunkingConfig {
             @Value("${document.chunk-size:4000}") int chunkSize,
             @Value("${document.chunking.korean-sentence.overlap-size-chars:#{null}}") Integer overlapSizeChars) {
 
-        int effectiveOverlapSizeChars = overlapSizeChars != null ? overlapSizeChars : Math.max(chunkSize / 10, 50);
+        // 기본 오버랩은 기존 recursive 분할기와 같은 값을 쓰되, 청크가 작을 때 상한(절반)을 넘지 않게 맞춘다.
+        int effectiveOverlapSizeChars = overlapSizeChars != null
+                ? overlapSizeChars
+                : Math.min(Math.max(chunkSize / 10, 50), chunkSize / 2);
         log.info("한국어 문장경계 청킹 초기화 - chunkSize: {}, overlapSizeChars: {}",
                 chunkSize, effectiveOverlapSizeChars);
         return new EgovKoreanSentenceSplitter(chunkSize, effectiveOverlapSizeChars);

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/EgovKoreanChunkingConfig.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/EgovKoreanChunkingConfig.java
@@ -1,0 +1,28 @@
+package com.example.chat.config.etl;
+
+import com.example.chat.config.etl.transformers.EgovKoreanSentenceSplitter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 한국어 문장경계 인지 청킹 설정.
+ */
+@Slf4j
+@Configuration
+public class EgovKoreanChunkingConfig {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "document.chunking.korean-sentence", name = "enabled", havingValue = "true")
+    public EgovKoreanSentenceSplitter koreanSentenceDocumentSplitter(
+            @Value("${document.chunk-size:4000}") int chunkSize,
+            @Value("${document.chunking.korean-sentence.overlap-size-chars:#{null}}") Integer overlapSizeChars) {
+
+        int effectiveOverlapSizeChars = overlapSizeChars != null ? overlapSizeChars : Math.max(chunkSize / 10, 50);
+        log.info("한국어 문장경계 청킹 초기화 - chunkSize: {}, overlapSizeChars: {}",
+                chunkSize, effectiveOverlapSizeChars);
+        return new EgovKoreanSentenceSplitter(chunkSize, effectiveOverlapSizeChars);
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovEnhancedDocumentTransformer.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovEnhancedDocumentTransformer.java
@@ -6,6 +6,7 @@ import dev.langchain4j.data.document.DocumentTransformer;
 import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.data.segment.TextSegment;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -25,15 +26,20 @@ public class EgovEnhancedDocumentTransformer implements DocumentTransformer {
 
     public EgovEnhancedDocumentTransformer(
             @Value("${document.chunk-size}") int chunkSize,
-            @Value("${document.min-chunk-size-chars}") int minChunkSizeChars) {
+            @Value("${document.min-chunk-size-chars}") int minChunkSizeChars,
+            ObjectProvider<EgovKoreanSentenceSplitter> koreanSentenceSplitterProvider) {
 
         // LangChain4j의 DocumentSplitter 생성
         // 토큰 기반 분할 (최대 토큰 수, 오버랩)
-        this.documentSplitter = DocumentSplitters.recursive(
+        EgovKoreanSentenceSplitter koreanSentenceSplitter = koreanSentenceSplitterProvider.getIfAvailable();
+        this.documentSplitter = koreanSentenceSplitter != null ? koreanSentenceSplitter : DocumentSplitters.recursive(
                 chunkSize, // 최대 토큰 수
                 Math.max(chunkSize / 10, 50) // 오버랩 (청크 크기의 10%)
         );
 
+        if (koreanSentenceSplitter != null) {
+            log.info("문서 분할기 선택 - splitter: {}", this.documentSplitter.getClass().getSimpleName());
+        }
         log.info("EnhancedDocumentTransformer 초기화 - chunkSize: {}, minChunkSize: {}",
                 chunkSize, minChunkSizeChars);
     }

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -5,7 +5,6 @@ import com.example.chat.util.EgovKoreanSentenceSupport.SentenceSpan;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentSplitter;
 import dev.langchain4j.data.document.Metadata;
-import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.data.segment.TextSegment;
 
 import java.util.ArrayList;
@@ -18,7 +17,6 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
 
     private final int maxSegmentSizeInChars;
     private final int maxOverlapSizeInChars;
-    private final DocumentSplitter fallbackSplitter;
 
     public EgovKoreanSentenceSplitter(int maxSegmentSizeInChars, int maxOverlapSizeInChars) {
         if (maxSegmentSizeInChars <= 0) {
@@ -26,7 +24,6 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
         }
         this.maxSegmentSizeInChars = maxSegmentSizeInChars;
         this.maxOverlapSizeInChars = maxOverlapSizeInChars;
-        this.fallbackSplitter = DocumentSplitters.recursive(maxSegmentSizeInChars, maxOverlapSizeInChars);
     }
 
     @Override
@@ -54,12 +51,7 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
                     bufferEnd = -1;
                 }
 
-                Document fallbackDocument = Document.from(
-                        text.substring(span.start(), span.end()), document.metadata().copy());
-                List<TextSegment> fallbackSegments = fallbackSplitter.split(fallbackDocument);
-                for (TextSegment fallbackSegment : fallbackSegments) {
-                    segmentTexts.add(fallbackSegment.text());
-                }
+                addOversizedSpanChunks(segmentTexts, text, span);
                 lastSegmentStart = -1;
                 lastSegmentEnd = -1;
                 continue;
@@ -107,6 +99,37 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
             segments.add(TextSegment.from(segmentTexts.get(i), metadata));
         }
         return List.copyOf(segments);
+    }
+
+    // 한 문장이 청크 한도를 넘으면 원문 offset 창으로 잘라 나눈다. 가능하면 공백 위치로 물러나 자르고,
+    // 공백이 없으면 한도에서 끊는다. 어느 경우에도 청크는 원문 부분문자열로 남는다.
+    private void addOversizedSpanChunks(List<String> segmentTexts, String text, SentenceSpan span) {
+        int cursor = span.start();
+        while (cursor < span.end()) {
+            int limit = Math.min(cursor + maxSegmentSizeInChars, span.end());
+            int cut = limit;
+            if (limit < span.end()) {
+                int candidate = limit;
+                while (candidate > cursor && !Character.isWhitespace(text.charAt(candidate))) {
+                    candidate--;
+                }
+                if (candidate > cursor) {
+                    cut = candidate;
+                }
+            }
+
+            String chunk = text.substring(cursor, cut).strip();
+            if (!chunk.isEmpty()) {
+                segmentTexts.add(chunk);
+            }
+
+            if (cut >= span.end()) {
+                return;
+            }
+            cursor = maxOverlapSizeInChars > 0
+                    ? Math.max(cursor + 1, cut - maxOverlapSizeInChars)
+                    : cut;
+        }
     }
 
     private boolean canAppend(List<SentenceSpan> spans, int startIndex, int nextIndex) {

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -22,6 +22,10 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
         if (maxSegmentSizeInChars <= 0) {
             throw new IllegalArgumentException("maxSegmentSizeInChars must be greater than 0");
         }
+        if (maxOverlapSizeInChars < 0 || maxOverlapSizeInChars >= maxSegmentSizeInChars) {
+            throw new IllegalArgumentException(
+                    "maxOverlapSizeInChars must be at least 0 and less than maxSegmentSizeInChars");
+        }
         this.maxSegmentSizeInChars = maxSegmentSizeInChars;
         this.maxOverlapSizeInChars = maxOverlapSizeInChars;
     }
@@ -118,6 +122,8 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
                 }
             }
 
+            cut = alignToCodePointBoundary(text, cursor, cut);
+
             String chunk = text.substring(cursor, cut).strip();
             if (!chunk.isEmpty()) {
                 segmentTexts.add(chunk);
@@ -126,10 +132,21 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
             if (cut >= span.end()) {
                 return;
             }
-            cursor = maxOverlapSizeInChars > 0
+            int next = maxOverlapSizeInChars > 0
                     ? Math.max(cursor + 1, cut - maxOverlapSizeInChars)
                     : cut;
+            // 오버랩 재개 위치도 코드포인트 경계에 맞춘다. 페어 중간에서 시작하면 짝 잃은 문자가 남는다.
+            cursor = alignToCodePointBoundary(text, cursor, next);
         }
+    }
+
+    // 서로게이트 페어 중간에서 자르면 짝 잃은 문자가 남으므로 코드포인트 경계로 물러난다.
+    private static int alignToCodePointBoundary(String text, int start, int cut) {
+        if (cut > start && cut < text.length() && Character.isLowSurrogate(text.charAt(cut))
+                && Character.isHighSurrogate(text.charAt(cut - 1))) {
+            return cut - 1;
+        }
+        return cut;
     }
 
     private boolean canAppend(List<SentenceSpan> spans, int startIndex, int nextIndex) {

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -1,0 +1,136 @@
+package com.example.chat.config.etl.transformers;
+
+import com.example.chat.util.EgovKoreanSentenceSupport;
+import com.example.chat.util.EgovKoreanSentenceSupport.SentenceSpan;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.segment.TextSegment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 한국어 문장 경계를 우선 보존하는 문서 분할기.
+ */
+public class EgovKoreanSentenceSplitter implements DocumentSplitter {
+
+    private final int maxSegmentSizeInChars;
+    private final int maxOverlapSizeInChars;
+    private final DocumentSplitter fallbackSplitter;
+
+    public EgovKoreanSentenceSplitter(int maxSegmentSizeInChars, int maxOverlapSizeInChars) {
+        if (maxSegmentSizeInChars <= 0) {
+            throw new IllegalArgumentException("maxSegmentSizeInChars must be greater than 0");
+        }
+        this.maxSegmentSizeInChars = maxSegmentSizeInChars;
+        this.maxOverlapSizeInChars = maxOverlapSizeInChars;
+        this.fallbackSplitter = DocumentSplitters.recursive(maxSegmentSizeInChars, maxOverlapSizeInChars);
+    }
+
+    @Override
+    public List<TextSegment> split(Document document) {
+        String text = document.text();
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+
+        List<String> segmentTexts = new ArrayList<>();
+        List<SentenceSpan> spans = EgovKoreanSentenceSupport.splitSentenceSpans(text);
+        int bufferStart = -1;
+        int bufferEnd = -1;
+        int lastSegmentStart = -1;
+        int lastSegmentEnd = -1;
+
+        for (int i = 0; i < spans.size(); i++) {
+            SentenceSpan span = spans.get(i);
+            if (span.end() - span.start() > maxSegmentSizeInChars) {
+                if (bufferStart >= 0) {
+                    segmentTexts.add(segmentText(text, spans, bufferStart, bufferEnd));
+                    lastSegmentStart = bufferStart;
+                    lastSegmentEnd = bufferEnd;
+                    bufferStart = -1;
+                    bufferEnd = -1;
+                }
+
+                Document fallbackDocument = Document.from(
+                        text.substring(span.start(), span.end()), document.metadata().copy());
+                List<TextSegment> fallbackSegments = fallbackSplitter.split(fallbackDocument);
+                for (TextSegment fallbackSegment : fallbackSegments) {
+                    segmentTexts.add(fallbackSegment.text());
+                }
+                lastSegmentStart = -1;
+                lastSegmentEnd = -1;
+                continue;
+            }
+
+            if (bufferStart < 0) {
+                bufferStart = i;
+                bufferEnd = i;
+                continue;
+            }
+
+            if (canAppend(spans, bufferStart, i)) {
+                bufferEnd = i;
+                continue;
+            }
+
+            segmentTexts.add(segmentText(text, spans, bufferStart, bufferEnd));
+            lastSegmentStart = bufferStart;
+            lastSegmentEnd = bufferEnd;
+
+            bufferStart = overlapStart(spans, lastSegmentStart, lastSegmentEnd);
+            bufferEnd = bufferStart >= 0 ? lastSegmentEnd : -1;
+            while (bufferStart >= 0 && spans.get(i).end() - spans.get(bufferStart).start() > maxSegmentSizeInChars) {
+                bufferStart++;
+                if (bufferStart > bufferEnd) {
+                    bufferStart = -1;
+                    bufferEnd = -1;
+                    break;
+                }
+            }
+            if (bufferStart < 0) {
+                bufferStart = i;
+            }
+            bufferEnd = i;
+        }
+
+        if (bufferStart >= 0) {
+            segmentTexts.add(segmentText(text, spans, bufferStart, bufferEnd));
+        }
+
+        List<TextSegment> segments = new ArrayList<>(segmentTexts.size());
+        for (int i = 0; i < segmentTexts.size(); i++) {
+            Metadata metadata = document.metadata().copy();
+            metadata.put("index", String.valueOf(i));
+            segments.add(TextSegment.from(segmentTexts.get(i), metadata));
+        }
+        return List.copyOf(segments);
+    }
+
+    private boolean canAppend(List<SentenceSpan> spans, int startIndex, int nextIndex) {
+        return spans.get(nextIndex).end() - spans.get(startIndex).start() <= maxSegmentSizeInChars;
+    }
+
+    private int overlapStart(List<SentenceSpan> spans, int segmentStart, int segmentEnd) {
+        if (maxOverlapSizeInChars <= 0 || segmentStart < 0 || segmentEnd < segmentStart) {
+            return -1;
+        }
+
+        int segmentTextEnd = spans.get(segmentEnd).end();
+        int overlapStart = -1;
+        for (int i = segmentEnd; i >= segmentStart; i--) {
+            // 오버랩은 원문 substring 이 되도록 시작 구간의 offset부터 이어 붙인다.
+            if (segmentTextEnd - spans.get(i).start() > maxOverlapSizeInChars) {
+                break;
+            }
+            overlapStart = i;
+        }
+        return overlapStart;
+    }
+
+    private String segmentText(String text, List<SentenceSpan> spans, int startIndex, int endIndex) {
+        return text.substring(spans.get(startIndex).start(), spans.get(endIndex).end());
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -22,9 +22,10 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
         if (maxSegmentSizeInChars <= 0) {
             throw new IllegalArgumentException("maxSegmentSizeInChars must be greater than 0");
         }
-        if (maxOverlapSizeInChars < 0 || maxOverlapSizeInChars >= maxSegmentSizeInChars) {
+        if (maxOverlapSizeInChars < 0 || maxOverlapSizeInChars > maxSegmentSizeInChars / 2) {
+            // 오버랩이 절반을 넘으면 창이 조금씩만 나아가 청크 수가 문서 길이에 비례해 늘어난다.
             throw new IllegalArgumentException(
-                    "maxOverlapSizeInChars must be at least 0 and less than maxSegmentSizeInChars");
+                    "maxOverlapSizeInChars must be at least 0 and at most half of maxSegmentSizeInChars");
         }
         this.maxSegmentSizeInChars = maxSegmentSizeInChars;
         this.maxOverlapSizeInChars = maxOverlapSizeInChars;
@@ -123,6 +124,10 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
             }
 
             cut = alignToCodePointBoundary(text, cursor, cut);
+            if (cut <= cursor) {
+                // 보정으로 창이 비면 한 코드포인트만큼은 반드시 나아가 진행을 보장한다.
+                cut = nextCodePointIndex(text, cursor);
+            }
 
             String chunk = text.substring(cursor, cut).strip();
             if (!chunk.isEmpty()) {
@@ -136,8 +141,14 @@ public class EgovKoreanSentenceSplitter implements DocumentSplitter {
                     ? Math.max(cursor + 1, cut - maxOverlapSizeInChars)
                     : cut;
             // 오버랩 재개 위치도 코드포인트 경계에 맞춘다. 페어 중간에서 시작하면 짝 잃은 문자가 남는다.
-            cursor = alignToCodePointBoundary(text, cursor, next);
+            next = alignToCodePointBoundary(text, cursor, next);
+            // 보정이 커서를 되돌리면 진행이 멈추므로 최소 한 코드포인트는 나아간다.
+            cursor = Math.max(next, nextCodePointIndex(text, cursor));
         }
+    }
+
+    private static int nextCodePointIndex(String text, int index) {
+        return index + Character.charCount(text.codePointAt(index));
     }
 
     // 서로게이트 페어 중간에서 자르면 짝 잃은 문자가 남으므로 코드포인트 경계로 물러난다.

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
@@ -2,32 +2,20 @@ package com.example.chat.util;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 
 /**
  * 한국어 문장 경계를 결정론적으로 분리하는 유틸리티.
  *
- * <p>종결부호({@code . ! ? 。 ！ ？})와 닫는 인용/괄호를 함께 문장 끝으로 보고,
- * 소수점·목록 번호·라틴 약어는 문장 경계에서 제외한다. 한국어 종결어미 뒤의 종결부호는
- * 다음 문장과 공백이 없어도 경계로 인정하며, 빈 줄과 일부 마크다운 블록 시작 줄은 문단/블록
- * 경계로 처리한다. LLM·외부 사전 없이 결정론적으로 동작한다.</p>
+ * <p>경계 판정은 보수적이다. 빈 줄과 마크다운 블록 시작 줄을 문단·블록 경계로 보고,
+ * 마침표는 한국어 종결어미 뒤에 오고 다음이 공백·개행·문서 끝일 때만 문장 끝으로 본다.
+ * 그 밖의 마침표(날짜 표기·소수점·라틴 약어·목록 번호·법령 조항 등)는 경계로 보지 않는다.
+ * 물음표·느낌표는 표기 모호성이 없어 공백·개행·문서 끝이 이어지면 경계로 본다.</p>
+ *
+ * <p>경계를 놓치면 두 문장이 한 구간으로 남을 뿐이고, 청크는 원문 offset을 그대로 잘라내므로
+ * 내용이 훼손되지 않는다. 반대로 경계를 잘못 만들면 문장이 중간에서 끊어지므로, 확신이 없는
+ * 마침표는 자르지 않는다. LLM·외부 사전 없이 결정론적으로 동작한다.</p>
  */
 public final class EgovKoreanSentenceSupport {
-
-    private static final Set<String> ABBREVIATIONS = Set.of(
-            "no", "etc", "eg", "ie", "vs", "cf", "fig", "tbl", "ex",
-            "mr", "mrs", "ms", "dr", "prof", "inc", "ltd", "co", "corp",
-            "dept", "approx", "pp", "vol", "sec",
-            "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "sept",
-            "oct", "nov", "dec",
-            "a.m", "a.m.", "p.m", "p.m.", "e.g", "e.g.", "i.e", "i.e.",
-            "u.s", "u.s."
-    );
-    private static final List<String> QUOTE_PARTICLES = List.of(
-            "이라면서", "이라며", "이라는", "이라고", "라면서", "라고요",
-            "라고", "라며", "라는", "라던", "하고"
-    );
 
     private EgovKoreanSentenceSupport() {
     }
@@ -54,10 +42,11 @@ public final class EgovKoreanSentenceSupport {
         int index = 0;
 
         while (index < text.length()) {
-            if (isCodeFenceLineStart(text, index)) {
+            CodeFence fence = codeFenceAt(text, index);
+            if (fence != null) {
                 // 코드펜스 내부의 마침표는 코드 조각일 수 있으므로 블록 전체를 하나의 구간으로 고정한다.
                 addSentenceSpan(spans, text, sentenceStart, index);
-                int fenceEnd = consumeCodeFenceBlock(text, index);
+                int fenceEnd = consumeCodeFenceBlock(text, index, fence);
                 addSentenceSpan(spans, text, index, fenceEnd);
                 sentenceStart = fenceEnd;
                 index = fenceEnd;
@@ -124,49 +113,36 @@ public final class EgovKoreanSentenceSupport {
             runEnd++;
         }
 
+        // 종결부호 후보 런 전체를 한 번에 소비해 "..."나 "?!"에서 빈 문장이 생기지 않게 한다.
+        // 닫는 인용/괄호는 앞 문장의 일부이므로 종결부호 뒤에 붙은 경우 함께 포함한다.
         int boundaryEnd = runEnd;
         while (boundaryEnd < text.length() && isClosingQuoteOrBracket(text.charAt(boundaryEnd))) {
             boundaryEnd++;
         }
+        boolean consumedClosingQuote = boundaryEnd > runEnd;
 
-        char terminator = text.charAt(terminatorStart);
         char previous = previousChar(text, terminatorStart);
         char next = nextChar(text, boundaryEnd);
+        boolean followedByBreak = next == '\0' || Character.isWhitespace(next);
+        boolean boundary;
 
-        // 종결부호 후보 런 전체를 한 번에 소비해 "..."나 "?!"에서 빈 문장이 생기지 않게 한다.
-        // 닫는 인용/괄호는 앞 문장의 일부이므로 종결부호 뒤에 붙은 경우 함께 포함한다.
-        boolean boundary = false;
-
-        // 기본 경계는 다음 문자가 공백이거나 문자열 끝인 경우로 제한해 URL·확장자·소수 오인을 줄인다.
-        if (next == '\0' || Character.isWhitespace(next)) {
-            boundary = true;
+        if (text.charAt(terminatorStart) == '.') {
+            // 마침표는 날짜 표기·소수점·약어·목록 번호와 구분되지 않으므로 한국어 종결어미 뒤에서만 경계로 본다.
+            boundary = isKoreanSentenceEnding(previous) && followedByBreak;
+        } else {
+            // 물음표·느낌표는 다른 표기로 쓰이지 않아 뒤에 공백·개행·문서 끝이 오면 경계로 본다.
+            boundary = followedByBreak;
         }
 
-        if (terminator == '.') {
-            // 숫자 사이의 마침표는 소수점 또는 버전 표기일 가능성이 높아 경계로 보지 않는다.
-            if (Character.isDigit(previous) && Character.isDigit(next)) {
-                boundary = false;
-            }
-
-            // 줄 시작의 숫자열과 제+숫자 뒤 마침표만 목록 번호·서수 표기로 보고 문장 경계에서 제외한다.
-            if (isNumberedListMarker(text, terminatorStart)) {
-                boundary = false;
-            }
-
-            // 라틴 약어 뒤 마침표는 문장 내부 표기이므로 대소문자와 내부 마침표를 정규화해 제외한다.
-            if (isAbbreviation(text, terminatorStart)) {
-                boundary = false;
-            }
-        }
-
-        // 한국어 종결어미 뒤 마침표는 공백 없이 다음 한글 문장이 이어져도 경계로 인정한다.
-        if (!boundary && isKoreanSentenceEnding(previous) && isSafeNoSpaceNext(next)) {
-            boundary = true;
-        }
-
-        // 닫는 인용 뒤 조사(라고/라며 등)는 앞 인용문을 받는 문장 성분이므로 경계로 자르지 않는다.
-        if (boundary && isFollowedByQuoteParticle(text, boundaryEnd)) {
+        // 인용문을 닫은 뒤 같은 줄에 한국어가 이어지면 인용을 받는 문장 성분(라고 말했다)이므로 자르지 않는다.
+        if (boundary && consumedClosingQuote && continuesWithHangulOnSameLine(text, boundaryEnd)) {
             boundary = false;
+        }
+
+        // 공백 없이 다음 문장이 붙는 표기도 종결어미 뒤라면 경계로 인정한다.
+        // 닫는 인용을 소비한 경우는 위와 같은 이유로 제외한다.
+        if (!boundary && !consumedClosingQuote && isKoreanSentenceEnding(previous) && isSafeNoSpaceNext(next)) {
+            boundary = true;
         }
 
         return new SentenceBoundary(boundary, boundaryEnd);
@@ -244,37 +220,41 @@ public final class EgovKoreanSentenceSupport {
         return numberEnd < text.length() && (text.charAt(numberEnd) == '.' || text.charAt(numberEnd) == ')');
     }
 
-    private static boolean isCodeFenceLineStart(String text, int start) {
+    // 코드펜스 여는 줄이면 마커 문자와 길이를 돌려준다. 백틱과 물결표를 모두 인식한다.
+    private static CodeFence codeFenceAt(String text, int start) {
         if (!isAtLineStart(text, start)) {
-            return false;
+            return null;
         }
-        return codeFenceMarkerIndex(text, start) >= 0;
+
+        int index = skipHorizontalWhitespace(text, start);
+        if (index >= text.length()) {
+            return null;
+        }
+
+        char marker = text.charAt(index);
+        if (marker != '`' && marker != '~') {
+            return null;
+        }
+
+        int length = 0;
+        while (index + length < text.length() && text.charAt(index + length) == marker) {
+            length++;
+        }
+        return length >= 3 ? new CodeFence(marker, length) : null;
     }
 
-    private static int consumeCodeFenceBlock(String text, int fenceLineStart) {
-        int nextLineStart = nextLineStart(text, fenceLineStart);
-        int search = nextLineStart;
+    private static int consumeCodeFenceBlock(String text, int fenceLineStart, CodeFence opening) {
+        int search = nextLineStart(text, fenceLineStart);
         while (search < text.length()) {
-            if (isCodeFenceLineStart(text, search)) {
+            CodeFence closing = codeFenceAt(text, search);
+            // 닫는 펜스는 여는 펜스와 같은 문자이고 길이가 같거나 길어야 한다(네 겹 백틱 블록의 조기 종료 방지).
+            if (closing != null && closing.marker() == opening.marker() && closing.length() >= opening.length()) {
                 // 닫는 펜스 줄 끝까지만 포함하고 뒤 개행은 문장 사이 공백으로 남긴다.
                 return lineEnd(text, search);
             }
             search = nextLineStart(text, search);
         }
         return text.length();
-    }
-
-    private static int codeFenceMarkerIndex(String text, int lineStart) {
-        int index = lineStart;
-        while (index < text.length()) {
-            char ch = text.charAt(index);
-            if (ch == ' ' || ch == '\t') {
-                index++;
-                continue;
-            }
-            break;
-        }
-        return startsWith(text, index, "```") ? index : -1;
     }
 
     private static int lineEnd(String text, int index) {
@@ -308,85 +288,6 @@ public final class EgovKoreanSentenceSupport {
         return index == 0 || isLineBreak(text.charAt(index - 1));
     }
 
-    private static boolean isNumberedListMarker(String text, int dotIndex) {
-        char afterDot = nextChar(text, dotIndex + 1);
-        if (afterDot != '\0' && !Character.isWhitespace(afterDot)) {
-            return false;
-        }
-
-        int markerStart = listMarkerStart(text, dotIndex);
-        if (markerStart < 0) {
-            return false;
-        }
-
-        if (isKoreanOrdinalMarker(text, markerStart, dotIndex)) {
-            return true;
-        }
-
-        if (!Character.isDigit(text.charAt(markerStart))) {
-            return false;
-        }
-
-        for (int i = markerStart; i < dotIndex; i++) {
-            if (!Character.isDigit(text.charAt(i))) {
-                return false;
-            }
-        }
-        return markerStart < dotIndex;
-    }
-
-    private static int listMarkerStart(String text, int dotIndex) {
-        int index = lineStart(text, dotIndex);
-        index = skipHorizontalWhitespace(text, index);
-
-        while (index < dotIndex && isMarkdownListQuoteMarker(text.charAt(index))) {
-            int afterMarker = index + 1;
-            if (afterMarker >= dotIndex || !isHorizontalWhitespace(text.charAt(afterMarker))) {
-                break;
-            }
-            // 줄 시작 불릿/인용 접두어 뒤 공백은 목록번호의 시각적 들여쓰기라서 같은 패턴으로 본다.
-            index = skipHorizontalWhitespace(text, afterMarker);
-        }
-
-        return index < dotIndex ? index : -1;
-    }
-
-    private static boolean isKoreanOrdinalMarker(String text, int markerStart, int dotIndex) {
-        if (text.charAt(markerStart) != '제' || markerStart + 1 >= dotIndex) {
-            return false;
-        }
-
-        for (int i = markerStart + 1; i < dotIndex; i++) {
-            if (!Character.isDigit(text.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean isMarkdownListQuoteMarker(char ch) {
-        return ch == '-' || ch == '*' || ch == '>';
-    }
-
-    private static boolean isAbbreviation(String text, int dotIndex) {
-        int start = dotIndex - 1;
-        while (start >= 0) {
-            char ch = text.charAt(start);
-            if (isLatinLetter(ch) || ch == '.') {
-                start--;
-                continue;
-            }
-            break;
-        }
-
-        String token = text.substring(start + 1, dotIndex).toLowerCase(Locale.ROOT);
-        if (token.isEmpty()) {
-            return false;
-        }
-
-        return ABBREVIATIONS.contains(token) || ABBREVIATIONS.contains(token + ".");
-    }
-
     private static boolean isKoreanSentenceEnding(char ch) {
         return ch == '다' || ch == '요' || ch == '까' || ch == '죠' || ch == '음'
                 || ch == '임' || ch == '함' || ch == '네' || ch == '오' || ch == '쇼';
@@ -403,26 +304,13 @@ public final class EgovKoreanSentenceSupport {
         return ch == '"' || ch == '\'' || ch == '「' || ch == '『' || ch == '(' || ch == '[' || ch == '《';
     }
 
+    private static boolean continuesWithHangulOnSameLine(String text, int start) {
+        int index = skipHorizontalWhitespace(text, start);
+        return index < text.length() && isHangulSyllable(text.charAt(index));
+    }
+
     private static boolean isHangulSyllable(char ch) {
         return ch >= '가' && ch <= '힣';
-    }
-
-    private static boolean isLatinLetter(char ch) {
-        return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
-    }
-
-    private static boolean isFollowedByQuoteParticle(String text, int start) {
-        int index = start;
-        while (index < text.length() && isHorizontalWhitespace(text.charAt(index))) {
-            index++;
-        }
-
-        for (String particle : QUOTE_PARTICLES) {
-            if (startsWith(text, index, particle)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static int skipHorizontalWhitespace(String text, int start) {
@@ -437,17 +325,15 @@ public final class EgovKoreanSentenceSupport {
         return ch == ' ' || ch == '\t';
     }
 
-    private static boolean startsWith(String text, int start, String prefix) {
-        return start >= 0 && start + prefix.length() <= text.length()
-                && text.regionMatches(start, prefix, 0, prefix.length());
-    }
-
     private static char previousChar(String text, int index) {
         return index > 0 ? text.charAt(index - 1) : '\0';
     }
 
     private static char nextChar(String text, int index) {
         return index < text.length() ? text.charAt(index) : '\0';
+    }
+
+    private record CodeFence(char marker, int length) {
     }
 
     private record SentenceBoundary(boolean boundary, int endIndex) {

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
@@ -1,0 +1,458 @@
+package com.example.chat.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * 한국어 문장 경계를 결정론적으로 분리하는 유틸리티.
+ *
+ * <p>종결부호({@code . ! ? 。 ！ ？})와 닫는 인용/괄호를 함께 문장 끝으로 보고,
+ * 소수점·목록 번호·라틴 약어는 문장 경계에서 제외한다. 한국어 종결어미 뒤의 종결부호는
+ * 다음 문장과 공백이 없어도 경계로 인정하며, 빈 줄과 일부 마크다운 블록 시작 줄은 문단/블록
+ * 경계로 처리한다. LLM·외부 사전 없이 결정론적으로 동작한다.</p>
+ */
+public final class EgovKoreanSentenceSupport {
+
+    private static final Set<String> ABBREVIATIONS = Set.of(
+            "no", "etc", "eg", "ie", "vs", "cf", "fig", "tbl", "ex",
+            "mr", "mrs", "ms", "dr", "prof", "inc", "ltd", "co", "corp",
+            "dept", "approx", "pp", "vol", "sec",
+            "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "sept",
+            "oct", "nov", "dec",
+            "a.m", "a.m.", "p.m", "p.m.", "e.g", "e.g.", "i.e", "i.e.",
+            "u.s", "u.s."
+    );
+    private static final List<String> QUOTE_PARTICLES = List.of(
+            "이라면서", "이라며", "이라는", "이라고", "라면서", "라고요",
+            "라고", "라며", "라는", "라던", "하고"
+    );
+
+    private EgovKoreanSentenceSupport() {
+    }
+
+    /**
+     * 원문 내 문장 구간. {@code start} 포함, {@code end} 제외이며 앞뒤 공백은 제외한다.
+     */
+    public record SentenceSpan(int start, int end) {
+    }
+
+    /**
+     * 입력 텍스트의 한국어 문장 구간을 원문 offset 기준으로 분리한다.
+     *
+     * @param text 분리할 텍스트
+     * @return 오름차순·비중첩 문장 구간 목록
+     */
+    public static List<SentenceSpan> splitSentenceSpans(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+
+        List<SentenceSpan> spans = new ArrayList<>();
+        int sentenceStart = 0;
+        int index = 0;
+
+        while (index < text.length()) {
+            if (isCodeFenceLineStart(text, index)) {
+                // 코드펜스 내부의 마침표는 코드 조각일 수 있으므로 블록 전체를 하나의 구간으로 고정한다.
+                addSentenceSpan(spans, text, sentenceStart, index);
+                int fenceEnd = consumeCodeFenceBlock(text, index);
+                addSentenceSpan(spans, text, index, fenceEnd);
+                sentenceStart = fenceEnd;
+                index = fenceEnd;
+                continue;
+            }
+
+            char current = text.charAt(index);
+
+            if (isLineBreak(current)) {
+                LineBreakRun lineBreakRun = consumeLineBreakRun(text, index);
+                if (lineBreakRun.count() >= 2) {
+                    // 빈 줄은 문단이 바뀐 신호이므로 종결부호가 없어도 강제 경계로 본다.
+                    addSentenceSpan(spans, text, sentenceStart, index);
+                    sentenceStart = lineBreakRun.endIndex();
+                } else if (isMarkdownBlockStart(text, lineStart(text, index))
+                        || isMarkdownBlockStart(text, lineBreakRun.endIndex())) {
+                    // 단일 개행은 보통 하드랩이지만, 다음 줄이 마크다운 블록이면 문단 섞임을 막기 위해 경계로 본다.
+                    addSentenceSpan(spans, text, sentenceStart, index);
+                    sentenceStart = lineBreakRun.endIndex();
+                }
+                index = lineBreakRun.endIndex();
+                continue;
+            }
+
+            if (isTerminator(current)) {
+                SentenceBoundary boundary = evaluateTerminatorBoundary(text, index);
+                if (boundary.boundary()) {
+                    addSentenceSpan(spans, text, sentenceStart, boundary.endIndex());
+                    sentenceStart = boundary.endIndex();
+                }
+                index = boundary.endIndex();
+                continue;
+            }
+
+            index++;
+        }
+
+        addSentenceSpan(spans, text, sentenceStart, text.length());
+        return List.copyOf(spans);
+    }
+
+    /**
+     * 입력 텍스트를 한국어 문장 경계 기준으로 분리한다.
+     *
+     * @param text 분리할 텍스트
+     * @return 앞뒤 공백이 제거된 문장 목록
+     */
+    public static List<String> splitSentences(String text) {
+        List<SentenceSpan> spans = splitSentenceSpans(text);
+        if (spans.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> sentences = new ArrayList<>(spans.size());
+        for (SentenceSpan span : spans) {
+            sentences.add(text.substring(span.start(), span.end()));
+        }
+        return List.copyOf(sentences);
+    }
+
+    private static SentenceBoundary evaluateTerminatorBoundary(String text, int terminatorStart) {
+        int runEnd = terminatorStart + 1;
+        while (runEnd < text.length() && isTerminator(text.charAt(runEnd))) {
+            runEnd++;
+        }
+
+        int boundaryEnd = runEnd;
+        while (boundaryEnd < text.length() && isClosingQuoteOrBracket(text.charAt(boundaryEnd))) {
+            boundaryEnd++;
+        }
+
+        char terminator = text.charAt(terminatorStart);
+        char previous = previousChar(text, terminatorStart);
+        char next = nextChar(text, boundaryEnd);
+
+        // 종결부호 후보 런 전체를 한 번에 소비해 "..."나 "?!"에서 빈 문장이 생기지 않게 한다.
+        // 닫는 인용/괄호는 앞 문장의 일부이므로 종결부호 뒤에 붙은 경우 함께 포함한다.
+        boolean boundary = false;
+
+        // 기본 경계는 다음 문자가 공백이거나 문자열 끝인 경우로 제한해 URL·확장자·소수 오인을 줄인다.
+        if (next == '\0' || Character.isWhitespace(next)) {
+            boundary = true;
+        }
+
+        if (terminator == '.') {
+            // 숫자 사이의 마침표는 소수점 또는 버전 표기일 가능성이 높아 경계로 보지 않는다.
+            if (Character.isDigit(previous) && Character.isDigit(next)) {
+                boundary = false;
+            }
+
+            // 줄 시작의 숫자열과 제+숫자 뒤 마침표만 목록 번호·서수 표기로 보고 문장 경계에서 제외한다.
+            if (isNumberedListMarker(text, terminatorStart)) {
+                boundary = false;
+            }
+
+            // 라틴 약어 뒤 마침표는 문장 내부 표기이므로 대소문자와 내부 마침표를 정규화해 제외한다.
+            if (isAbbreviation(text, terminatorStart)) {
+                boundary = false;
+            }
+        }
+
+        // 한국어 종결어미 뒤 마침표는 공백 없이 다음 한글 문장이 이어져도 경계로 인정한다.
+        if (!boundary && isKoreanSentenceEnding(previous) && isSafeNoSpaceNext(next)) {
+            boundary = true;
+        }
+
+        // 닫는 인용 뒤 조사(라고/라며 등)는 앞 인용문을 받는 문장 성분이므로 경계로 자르지 않는다.
+        if (boundary && isFollowedByQuoteParticle(text, boundaryEnd)) {
+            boundary = false;
+        }
+
+        return new SentenceBoundary(boundary, boundaryEnd);
+    }
+
+    private static void addSentenceSpan(List<SentenceSpan> spans, String text, int start, int end) {
+        int trimmedStart = start;
+        int trimmedEnd = end;
+        while (trimmedStart < trimmedEnd && Character.isWhitespace(text.charAt(trimmedStart))) {
+            trimmedStart++;
+        }
+        while (trimmedEnd > trimmedStart && Character.isWhitespace(text.charAt(trimmedEnd - 1))) {
+            trimmedEnd--;
+        }
+        if (trimmedStart < trimmedEnd) {
+            spans.add(new SentenceSpan(trimmedStart, trimmedEnd));
+        }
+    }
+
+    private static boolean isTerminator(char ch) {
+        return ch == '.' || ch == '!' || ch == '?' || ch == '。' || ch == '！' || ch == '？';
+    }
+
+    private static boolean isClosingQuoteOrBracket(char ch) {
+        return ch == '"' || ch == '\'' || ch == '」' || ch == '』' || ch == ')' || ch == ']' || ch == '》';
+    }
+
+    private static boolean isLineBreak(char ch) {
+        return ch == '\n' || ch == '\r';
+    }
+
+    private static LineBreakRun consumeLineBreakRun(String text, int start) {
+        int index = start;
+        int count = 0;
+        while (index < text.length() && isLineBreak(text.charAt(index))) {
+            if (text.charAt(index) == '\r' && index + 1 < text.length() && text.charAt(index + 1) == '\n') {
+                index += 2;
+            } else {
+                index++;
+            }
+            count++;
+        }
+        return new LineBreakRun(count, index);
+    }
+
+    private static boolean isMarkdownBlockStart(String text, int start) {
+        int index = start;
+        while (index < text.length()) {
+            char ch = text.charAt(index);
+            if (ch == ' ' || ch == '\t') {
+                index++;
+                continue;
+            }
+            break;
+        }
+
+        if (index >= text.length()) {
+            return false;
+        }
+
+        char ch = text.charAt(index);
+        if (ch == '#' || ch == '-' || ch == '*' || ch == '>' || ch == '|') {
+            return true;
+        }
+
+        if (!Character.isDigit(ch)) {
+            return false;
+        }
+
+        int numberEnd = index + 1;
+        while (numberEnd < text.length() && Character.isDigit(text.charAt(numberEnd))) {
+            numberEnd++;
+        }
+
+        return numberEnd < text.length() && (text.charAt(numberEnd) == '.' || text.charAt(numberEnd) == ')');
+    }
+
+    private static boolean isCodeFenceLineStart(String text, int start) {
+        if (!isAtLineStart(text, start)) {
+            return false;
+        }
+        return codeFenceMarkerIndex(text, start) >= 0;
+    }
+
+    private static int consumeCodeFenceBlock(String text, int fenceLineStart) {
+        int nextLineStart = nextLineStart(text, fenceLineStart);
+        int search = nextLineStart;
+        while (search < text.length()) {
+            if (isCodeFenceLineStart(text, search)) {
+                // 닫는 펜스 줄 끝까지만 포함하고 뒤 개행은 문장 사이 공백으로 남긴다.
+                return lineEnd(text, search);
+            }
+            search = nextLineStart(text, search);
+        }
+        return text.length();
+    }
+
+    private static int codeFenceMarkerIndex(String text, int lineStart) {
+        int index = lineStart;
+        while (index < text.length()) {
+            char ch = text.charAt(index);
+            if (ch == ' ' || ch == '\t') {
+                index++;
+                continue;
+            }
+            break;
+        }
+        return startsWith(text, index, "```") ? index : -1;
+    }
+
+    private static int lineEnd(String text, int index) {
+        int lineEnd = index;
+        while (lineEnd < text.length() && !isLineBreak(text.charAt(lineEnd))) {
+            lineEnd++;
+        }
+        return lineEnd;
+    }
+
+    private static int nextLineStart(String text, int index) {
+        int lineEnd = lineEnd(text, index);
+        if (lineEnd >= text.length()) {
+            return text.length();
+        }
+        if (text.charAt(lineEnd) == '\r' && lineEnd + 1 < text.length() && text.charAt(lineEnd + 1) == '\n') {
+            return lineEnd + 2;
+        }
+        return lineEnd + 1;
+    }
+
+    private static int lineStart(String text, int index) {
+        int lineStart = index;
+        while (lineStart > 0 && !isLineBreak(text.charAt(lineStart - 1))) {
+            lineStart--;
+        }
+        return lineStart;
+    }
+
+    private static boolean isAtLineStart(String text, int index) {
+        return index == 0 || isLineBreak(text.charAt(index - 1));
+    }
+
+    private static boolean isNumberedListMarker(String text, int dotIndex) {
+        char afterDot = nextChar(text, dotIndex + 1);
+        if (afterDot != '\0' && !Character.isWhitespace(afterDot)) {
+            return false;
+        }
+
+        int markerStart = listMarkerStart(text, dotIndex);
+        if (markerStart < 0) {
+            return false;
+        }
+
+        if (isKoreanOrdinalMarker(text, markerStart, dotIndex)) {
+            return true;
+        }
+
+        if (!Character.isDigit(text.charAt(markerStart))) {
+            return false;
+        }
+
+        for (int i = markerStart; i < dotIndex; i++) {
+            if (!Character.isDigit(text.charAt(i))) {
+                return false;
+            }
+        }
+        return markerStart < dotIndex;
+    }
+
+    private static int listMarkerStart(String text, int dotIndex) {
+        int index = lineStart(text, dotIndex);
+        index = skipHorizontalWhitespace(text, index);
+
+        while (index < dotIndex && isMarkdownListQuoteMarker(text.charAt(index))) {
+            int afterMarker = index + 1;
+            if (afterMarker >= dotIndex || !isHorizontalWhitespace(text.charAt(afterMarker))) {
+                break;
+            }
+            // 줄 시작 불릿/인용 접두어 뒤 공백은 목록번호의 시각적 들여쓰기라서 같은 패턴으로 본다.
+            index = skipHorizontalWhitespace(text, afterMarker);
+        }
+
+        return index < dotIndex ? index : -1;
+    }
+
+    private static boolean isKoreanOrdinalMarker(String text, int markerStart, int dotIndex) {
+        if (text.charAt(markerStart) != '제' || markerStart + 1 >= dotIndex) {
+            return false;
+        }
+
+        for (int i = markerStart + 1; i < dotIndex; i++) {
+            if (!Character.isDigit(text.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isMarkdownListQuoteMarker(char ch) {
+        return ch == '-' || ch == '*' || ch == '>';
+    }
+
+    private static boolean isAbbreviation(String text, int dotIndex) {
+        int start = dotIndex - 1;
+        while (start >= 0) {
+            char ch = text.charAt(start);
+            if (isLatinLetter(ch) || ch == '.') {
+                start--;
+                continue;
+            }
+            break;
+        }
+
+        String token = text.substring(start + 1, dotIndex).toLowerCase(Locale.ROOT);
+        if (token.isEmpty()) {
+            return false;
+        }
+
+        return ABBREVIATIONS.contains(token) || ABBREVIATIONS.contains(token + ".");
+    }
+
+    private static boolean isKoreanSentenceEnding(char ch) {
+        return ch == '다' || ch == '요' || ch == '까' || ch == '죠' || ch == '음'
+                || ch == '임' || ch == '함' || ch == '네' || ch == '오' || ch == '쇼';
+    }
+
+    private static boolean isSafeNoSpaceNext(char ch) {
+        if (ch == '\0' || isLineBreak(ch) || isOpeningQuoteOrBracket(ch)) {
+            return true;
+        }
+        return isHangulSyllable(ch);
+    }
+
+    private static boolean isOpeningQuoteOrBracket(char ch) {
+        return ch == '"' || ch == '\'' || ch == '「' || ch == '『' || ch == '(' || ch == '[' || ch == '《';
+    }
+
+    private static boolean isHangulSyllable(char ch) {
+        return ch >= '가' && ch <= '힣';
+    }
+
+    private static boolean isLatinLetter(char ch) {
+        return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
+    }
+
+    private static boolean isFollowedByQuoteParticle(String text, int start) {
+        int index = start;
+        while (index < text.length() && isHorizontalWhitespace(text.charAt(index))) {
+            index++;
+        }
+
+        for (String particle : QUOTE_PARTICLES) {
+            if (startsWith(text, index, particle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int skipHorizontalWhitespace(String text, int start) {
+        int index = start;
+        while (index < text.length() && isHorizontalWhitespace(text.charAt(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private static boolean isHorizontalWhitespace(char ch) {
+        return ch == ' ' || ch == '\t';
+    }
+
+    private static boolean startsWith(String text, int start, String prefix) {
+        return start >= 0 && start + prefix.length() <= text.length()
+                && text.regionMatches(start, prefix, 0, prefix.length());
+    }
+
+    private static char previousChar(String text, int index) {
+        return index > 0 ? text.charAt(index - 1) : '\0';
+    }
+
+    private static char nextChar(String text, int index) {
+        return index < text.length() ? text.charAt(index) : '\0';
+    }
+
+    private record SentenceBoundary(boolean boundary, int endIndex) {
+    }
+
+    private record LineBreakRun(int count, int endIndex) {
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
@@ -131,7 +131,8 @@ public final class EgovKoreanSentenceSupport {
             boundary = isKoreanSentenceEnding(previous) && followedByBreak;
         } else {
             // 물음표·느낌표는 다른 표기로 쓰이지 않아 뒤에 공백·개행·문서 끝이 오면 경계로 본다.
-            boundary = followedByBreak;
+            // 다만 같은 줄에서 아직 닫히지 않은 마크다운 링크·이미지 안이면 토큰 중간이므로 제외한다.
+            boundary = followedByBreak && !isInsideUnclosedInlineMarkup(text, terminatorStart);
         }
 
         // 인용문을 닫은 뒤 같은 줄에 한국어가 이어지면 인용을 받는 문장 성분(라고 말했다)이므로 자르지 않는다.
@@ -146,6 +147,32 @@ public final class EgovKoreanSentenceSupport {
         }
 
         return new SentenceBoundary(boundary, boundaryEnd);
+    }
+
+    // 닫는 펜스에는 정보문자열이 올 수 없다(CommonMark). 마커 뒤에 수평공백만 있는 줄만 닫는 펜스로 본다.
+    private static boolean isBlankAfterFenceMarker(String text, int lineStart, CodeFence fence) {
+        int index = skipHorizontalWhitespace(text, lineStart) + fence.length();
+        index = skipHorizontalWhitespace(text, index);
+        return index >= text.length() || isLineBreak(text.charAt(index));
+    }
+
+    // 같은 줄 앞쪽에 닫히지 않은 [ 또는 ( 가 있으면 마크다운 링크·이미지 표기 안이다.
+    private static boolean isInsideUnclosedInlineMarkup(String text, int index) {
+        int bracket = 0;
+        int paren = 0;
+        for (int i = lineStart(text, index); i < index; i++) {
+            char ch = text.charAt(i);
+            if (ch == '[') {
+                bracket++;
+            } else if (ch == ']' && bracket > 0) {
+                bracket--;
+            } else if (ch == '(') {
+                paren++;
+            } else if (ch == ')' && paren > 0) {
+                paren--;
+            }
+        }
+        return bracket > 0 || paren > 0;
     }
 
     private static void addSentenceSpan(List<SentenceSpan> spans, String text, int start, int end) {
@@ -248,7 +275,8 @@ public final class EgovKoreanSentenceSupport {
         while (search < text.length()) {
             CodeFence closing = codeFenceAt(text, search);
             // 닫는 펜스는 여는 펜스와 같은 문자이고 길이가 같거나 길어야 한다(네 겹 백틱 블록의 조기 종료 방지).
-            if (closing != null && closing.marker() == opening.marker() && closing.length() >= opening.length()) {
+            if (closing != null && closing.marker() == opening.marker() && closing.length() >= opening.length()
+                    && isBlankAfterFenceMarker(text, search, closing)) {
                 // 닫는 펜스 줄 끝까지만 포함하고 뒤 개행은 문장 사이 공백으로 남긴다.
                 return lineEnd(text, search);
             }

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
@@ -14,6 +14,10 @@ import java.util.List;
  * <p>경계를 놓치면 두 문장이 한 구간으로 남을 뿐이고, 청크는 원문 offset을 그대로 잘라내므로
  * 내용이 훼손되지 않는다. 반대로 경계를 잘못 만들면 문장이 중간에서 끊어지므로, 확신이 없는
  * 마침표는 자르지 않는다. LLM·외부 사전 없이 결정론적으로 동작한다.</p>
+ *
+ * <p>마침표 경계 판정은 한국어 종결어미 뒤에서만 동작하므로 영어 문장 끝 마침표는 경계로 보지 않는다.
+ * 영어 문장과 뒤따르는 한국어 문장은 한 구간으로 남고, 영어 비중이 높은 문서는 구간이 길어질 수 있다.
+ * 이는 약어·소수점 오분리를 피하기 위한 의도된 제약이며, 이런 문서에는 기존 splitter가 더 적합하다.</p>
  */
 public final class EgovKoreanSentenceSupport {
 
@@ -318,7 +322,7 @@ public final class EgovKoreanSentenceSupport {
 
     private static boolean isKoreanSentenceEnding(char ch) {
         return ch == '다' || ch == '요' || ch == '까' || ch == '죠' || ch == '음'
-                || ch == '임' || ch == '함' || ch == '네' || ch == '오' || ch == '쇼';
+                || ch == '임' || ch == '함' || ch == '네' || ch == '오';
     }
 
     private static boolean isSafeNoSpaceNext(char ch) {

--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -85,6 +85,7 @@ document:
   chunking:
     korean-sentence:
       # 활성화 여부. false(기본)이면 기존 DocumentSplitters.recursive 방식만 사용 (기존 동작 유지)
+      # 한국어가 위주인 문서에서 효과적이며, 영어 비중이 높은 문서에는 적합하지 않을 수 있음
       enabled: false
       # 문장 단위 오버랩 최대 문자 수. 미설정 시 chunk-size 의 10%(최소 50)
       # overlap-size-chars: 400

--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -86,6 +86,8 @@ document:
     korean-sentence:
       # 활성화 여부. false(기본)이면 기존 DocumentSplitters.recursive 방식만 사용 (기존 동작 유지)
       # 한국어가 위주인 문서에서 효과적이며, 영어 비중이 높은 문서에는 적합하지 않을 수 있음
+      # 빈 줄(연속 개행) 기준 문단 경계까지 쓰려면 위 normalization.normalize-newlines 를 false 로 둔다.
+      # true(기본)이면 연속 개행이 1개로 축약되어 빈 줄 경계는 동작하지 않고, 마크다운 블록·코드펜스 경계만 적용된다.
       enabled: false
       # 문장 단위 오버랩 최대 문자 수. 미설정 시 chunk-size 의 10%(최소 50)
       # overlap-size-chars: 400

--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -81,6 +81,14 @@ document:
   # 청크 크기 설정 (토큰 단위)
   chunk-size: 4000
 
+  # 한국어 문장경계 인지 청킹 설정
+  chunking:
+    korean-sentence:
+      # 활성화 여부. false(기본)이면 기존 DocumentSplitters.recursive 방식만 사용 (기존 동작 유지)
+      enabled: false
+      # 문장 단위 오버랩 최대 문자 수. 미설정 시 chunk-size 의 10%(최소 50)
+      # overlap-size-chars: 400
+
   # 최소 청크 크기 (문자 단위)
   min-chunk-size-chars: 350
 

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/EgovKoreanChunkingToggleTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/EgovKoreanChunkingToggleTest.java
@@ -1,0 +1,92 @@
+package com.example.chat.config.etl;
+
+import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
+import com.example.chat.config.etl.transformers.EgovKoreanSentenceSplitter;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.segment.TextSegment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code document.chunking.korean-sentence.enabled} 토글에 따른 빈 등록 동작을 검증한다.
+ */
+class EgovKoreanChunkingToggleTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(EgovKoreanChunkingConfig.class);
+
+    @Test
+    @DisplayName("토글 off(기본): 한국어 문장경계 splitter 빈을 등록하지 않는다")
+    void koreanSentenceSplitterAbsentWhenDisabled() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean("koreanSentenceDocumentSplitter");
+            assertThat(context.getBeanNamesForType(EgovKoreanSentenceSplitter.class)).isEmpty();
+        });
+    }
+
+    @Test
+    @DisplayName("토글 on: 한국어 문장경계 splitter 빈을 등록한다")
+    void koreanSentenceSplitterPresentWhenEnabled() {
+        runner.withPropertyValues("document.chunking.korean-sentence.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasBean("koreanSentenceDocumentSplitter");
+            assertThat(context.getBean("koreanSentenceDocumentSplitter"))
+                    .isInstanceOf(EgovKoreanSentenceSplitter.class);
+        });
+    }
+
+    @Test
+    @DisplayName("splitter 빈 부재 시 EnhancedDocumentTransformer 는 기존 recursive 로 폴백한다")
+    void enhancedTransformerFallsBackToRecursiveWhenSplitterAbsent() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(TransformerBeans.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    EgovEnhancedDocumentTransformer transformer = context.getBean(EgovEnhancedDocumentTransformer.class);
+                    Document document = Document.from("""
+                            첫 문장입니다.둘째 문장입니다.
+                            셋째 문장은 조금 더 길게 작성해서 recursive 분할 결과를 직접 비교합니다.
+                            넷째 문장입니다.""");
+
+                    List<String> transformedTexts = transformer.transformAll(List.of(document))
+                            .stream()
+                            .map(Document::text)
+                            .toList();
+                    List<String> recursiveTexts = DocumentSplitters.recursive(500, 50)
+                            .split(document)
+                            .stream()
+                            .map(TextSegment::text)
+                            .toList();
+
+                    assertThat(transformedTexts).isNotEmpty();
+                    assertThat(transformedTexts).isEqualTo(recursiveTexts);
+
+                    DocumentSplitter documentSplitter = (DocumentSplitter) ReflectionTestUtils.getField(
+                            transformer, "documentSplitter");
+                    assertThat(documentSplitter).isNotNull();
+                    assertThat(documentSplitter).isNotInstanceOf(EgovKoreanSentenceSplitter.class);
+                });
+    }
+
+    @Configuration
+    static class TransformerBeans {
+
+        @Bean
+        EgovEnhancedDocumentTransformer egovEnhancedDocumentTransformer(
+                ObjectProvider<EgovKoreanSentenceSplitter> koreanSentenceSplitterProvider) {
+            return new EgovEnhancedDocumentTransformer(500, 1, koreanSentenceSplitterProvider);
+        }
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -184,4 +184,25 @@ class EgovKoreanSentenceSplitterTest {
                 날짜는 2026. 7. 30. 기준입니다. 담당자는 A. B. 홍길동입니다. 마지막 문장입니다.
                 추가 설명은 표와 코드펜스 뒤에서도 원문 순서를 유지하는지 확인한다. 또 다른 문장은 작은 chunkSize 에서 다음 청크로 이동한다.""";
     }
+
+    @Test
+    @DisplayName("청크 한도를 넘는 구간도 원문 부분문자열로 잘라 나눈다")
+    void keepsOriginalSubstringForOversizedSpan() {
+        StringBuilder code = new StringBuilder("```java\n");
+        for (int i = 0; i < 60; i++) {
+            code.append("    public void method").append(i).append("() {\n")
+                    .append("        int value = ").append(i).append("; // 주석\n    }\n");
+        }
+        code.append("```\n");
+        String text = code.toString();
+
+        List<TextSegment> segments = new EgovKoreanSentenceSplitter(300, 50)
+                .split(Document.from(text, new Metadata()));
+
+        assertThat(segments).isNotEmpty();
+        assertThat(segments).allSatisfy(segment -> {
+            assertThat(text).contains(segment.text());
+            assertThat(segment.text().length()).isLessThanOrEqualTo(300);
+        });
+    }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -6,9 +6,11 @@ import dev.langchain4j.data.segment.TextSegment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -258,5 +260,31 @@ class EgovKoreanSentenceSplitterTest {
             }
         }
         return false;
+    }
+
+    @Test
+    @DisplayName("보충면 문자와 작은 청크 크기 조합에서도 유한 시간에 끝난다")
+    void terminatesForSupplementaryCharactersWithTinyChunkSize() {
+        String text = "\uD840\uDC0B".repeat(500);
+
+        for (int chunkSize : new int[] {1, 2, 3, 100}) {
+            int overlap = chunkSize / 2;
+            assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+                List<TextSegment> segments = new EgovKoreanSentenceSplitter(chunkSize, overlap)
+                        .split(Document.from(text, new Metadata()));
+                assertThat(segments).isNotEmpty();
+                assertThat(segments).hasSizeLessThanOrEqualTo(text.length());
+                assertThat(segments).allSatisfy(segment -> assertThat(text).contains(segment.text()));
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("오버랩이 청크 크기의 절반을 넘으면 생성 시점에 거부한다")
+    void rejectsOverlapLargerThanHalfChunkSize() {
+        assertThatThrownBy(() -> new EgovKoreanSentenceSplitter(100, 51))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new EgovKoreanSentenceSplitter(100, 90))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * {@link EgovKoreanSentenceSplitter} 단위 테스트.
@@ -204,5 +205,58 @@ class EgovKoreanSentenceSplitterTest {
             assertThat(text).contains(segment.text());
             assertThat(segment.text().length()).isLessThanOrEqualTo(300);
         });
+    }
+
+    @Test
+    @DisplayName("오버랩이 청크 크기 이상이면 생성 시점에 거부한다")
+    void rejectsOverlapNotSmallerThanChunkSize() {
+        assertThatThrownBy(() -> new EgovKoreanSentenceSplitter(100, 100))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new EgovKoreanSentenceSplitter(100, 500))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new EgovKoreanSentenceSplitter(100, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("공백 없는 긴 문서도 청크 수가 문서 길이에 비례해 늘지 않는다")
+    void doesNotExplodeChunkCountForTextWithoutWhitespace() {
+        String text = "가".repeat(1000);
+
+        List<TextSegment> segments = new EgovKoreanSentenceSplitter(100, 30)
+                .split(Document.from(text, new Metadata()));
+
+        assertThat(segments).hasSizeLessThanOrEqualTo(20);
+        assertThat(segments).allSatisfy(segment -> assertThat(text).contains(segment.text()));
+    }
+
+    @Test
+    @DisplayName("보충면 문자를 코드포인트 경계에서 잘라 짝 잃은 문자를 남기지 않는다")
+    void doesNotSplitSurrogatePairs() {
+        String text = "\uD840\uDC0B\uD842\uDF9F".repeat(120);
+
+        List<TextSegment> segments = new EgovKoreanSentenceSplitter(99, 9)
+                .split(Document.from(text, new Metadata()));
+
+        assertThat(segments).isNotEmpty();
+        assertThat(segments).allSatisfy(segment -> {
+            assertThat(text).contains(segment.text());
+            assertThat(hasUnpairedSurrogate(segment.text())).isFalse();
+        });
+    }
+
+    private static boolean hasUnpairedSurrogate(String text) {
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (Character.isHighSurrogate(ch)) {
+                if (i + 1 >= text.length() || !Character.isLowSurrogate(text.charAt(i + 1))) {
+                    return true;
+                }
+                i++;
+            } else if (Character.isLowSurrogate(ch)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -1,0 +1,187 @@
+package com.example.chat.config.etl.transformers;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.segment.TextSegment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link EgovKoreanSentenceSplitter} 단위 테스트.
+ */
+class EgovKoreanSentenceSplitterTest {
+
+    @Test
+    @DisplayName("세그먼트 길이는 최대 문자 수를 넘지 않는다")
+    void splitSegmentsDoNotExceedMaxSize() {
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(25, 0);
+        Document document = Document.from("첫 문장입니다. 두 번째 문장입니다. 세 번째 문장입니다. 네 번째 문장입니다.");
+
+        List<TextSegment> segments = splitter.split(document);
+
+        assertThat(segments).isNotEmpty();
+        assertThat(segments).allSatisfy(segment -> assertThat(segment.text()).hasSizeLessThanOrEqualTo(25));
+    }
+
+    @Test
+    @DisplayName("일반 세그먼트는 문장 중간에서 끝나지 않는다")
+    void regularSegmentsEndAtSentenceBoundary() {
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(25, 0);
+        Document document = Document.from("첫 문장입니다. 두 번째 문장입니다. 세 번째 문장입니다. 네 번째 문장입니다.");
+
+        List<TextSegment> segments = splitter.split(document);
+
+        assertThat(segments).allSatisfy(segment -> assertThat(endsAtSentenceBoundary(segment.text())).isTrue());
+    }
+
+    @Test
+    @DisplayName("최대 크기를 넘는 단일 초장문 문장은 폴백 분할기로 나눈다")
+    void longSingleSentenceUsesFallbackSplitter() {
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(40, 0);
+        String longSentence = "가나다라마바사 ".repeat(20) + "처리를 완료합니다.";
+        Document document = Document.from(longSentence);
+
+        List<TextSegment> segments = splitter.split(document);
+
+        assertThat(segments).hasSizeGreaterThan(1);
+        assertThat(segments).allSatisfy(segment -> assertThat(segment.text()).hasSizeLessThanOrEqualTo(40));
+    }
+
+    @Test
+    @DisplayName("원문 metadata 를 보존하고 index 를 0부터 순서대로 부여한다")
+    void preserveMetadataAndAssignIndex() {
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(25, 0);
+        Metadata metadata = Metadata.from("id", "doc-1");
+        metadata.put("file_name", "sample.md");
+        Document document = Document.from("첫 문장입니다. 두 번째 문장입니다. 세 번째 문장입니다.", metadata);
+
+        List<TextSegment> segments = splitter.split(document);
+
+        for (int i = 0; i < segments.size(); i++) {
+            Metadata segmentMetadata = segments.get(i).metadata();
+            assertThat(segmentMetadata.getString("id")).isEqualTo("doc-1");
+            assertThat(segmentMetadata.getString("file_name")).isEqualTo("sample.md");
+            assertThat(segmentMetadata.getString("index")).isEqualTo(String.valueOf(i));
+        }
+    }
+
+    @Test
+    @DisplayName("같은 입력은 항상 같은 결과를 반환한다")
+    void splitIsDeterministic() {
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(25, 5);
+        Metadata metadata = Metadata.from("id", "doc-1");
+        Document document = Document.from("첫 문장입니다. 두 번째 문장입니다. 세 번째 문장입니다.", metadata);
+
+        List<TextSegment> first = splitter.split(document);
+        List<TextSegment> second = splitter.split(document);
+
+        assertThat(first).extracting(TextSegment::text).isEqualTo(second.stream().map(TextSegment::text).toList());
+        assertThat(first).extracting(segment -> segment.metadata().toMap())
+                .isEqualTo(second.stream().map(segment -> segment.metadata().toMap()).toList());
+    }
+
+    @Test
+    @DisplayName("빈 문서는 빈 세그먼트 목록을 반환한다")
+    void returnEmptyListForBlankDocument() {
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(25, 0);
+
+        assertThat(splitter.split(documentWithText(null))).isEmpty();
+        assertThat(splitter.split(documentWithText(" \n\t "))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("큰 chunkSize 에서는 마크다운 원문 substring 을 그대로 보존한다")
+    void preserveOriginalMarkdownBytesWithLargeChunkSize() {
+        String text = markdownFixture();
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(5000, 0);
+
+        List<TextSegment> segments = splitter.split(Document.from(text));
+
+        assertThat(segments).isNotEmpty();
+        assertOrderedSubstrings(text, segments);
+        assertThat(segments).extracting(TextSegment::text)
+                .anySatisfy(segmentText -> {
+                    assertThat(segmentText).contains("\n| 항목 | 기본값 |");
+                    assertThat(segmentText).contains("""
+                            ```java
+                            // 주석. 끝
+                            int value = 1;
+                            ```""");
+                    assertThat(segmentText).contains("\"즉시 조치한다.\"라고");
+                });
+    }
+
+    @Test
+    @DisplayName("작은 chunkSize 에서도 폴백 없는 청크는 원문 substring 으로 만든다")
+    void preserveOriginalMarkdownSubstringsWithSmallChunkSize() {
+        String text = markdownFixture();
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(300, 0);
+
+        List<TextSegment> segments = splitter.split(Document.from(text));
+
+        assertThat(segments).hasSizeGreaterThan(1);
+        assertOrderedSubstrings(text, segments);
+        assertThat(segments).allSatisfy(segment -> assertThat(segment.text()).hasSizeLessThanOrEqualTo(300));
+    }
+
+    private boolean endsAtSentenceBoundary(String text) {
+        if (text.endsWith(".") || text.endsWith("!") || text.endsWith("?")
+                || text.endsWith("。") || text.endsWith("！") || text.endsWith("？")) {
+            return true;
+        }
+
+        char last = text.charAt(text.length() - 1);
+        return last == '다' || last == '요' || last == '까' || last == '죠' || last == '음'
+                || last == '임' || last == '함' || last == '네' || last == '오' || last == '쇼';
+    }
+
+    private Document documentWithText(String text) {
+        return new Document() {
+            @Override
+            public String text() {
+                return text;
+            }
+
+            @Override
+            public Metadata metadata() {
+                return new Metadata();
+            }
+        };
+    }
+
+    private void assertOrderedSubstrings(String source, List<TextSegment> segments) {
+        int previousIndex = 0;
+        for (TextSegment segment : segments) {
+            String segmentText = segment.text();
+            assertThat(source).contains(segmentText);
+            int foundIndex = source.indexOf(segmentText, previousIndex);
+            assertThat(foundIndex).isGreaterThanOrEqualTo(previousIndex);
+            previousIndex = foundIndex;
+        }
+    }
+
+    private String markdownFixture() {
+        return """
+                # 처리 기준
+
+                담당자는 "즉시 조치한다."라고 말했다. 이 규정은 제3조제1항. 다음 조항을 따른다.
+
+                | 항목 | 기본값 |
+                | --- | --- |
+                | chunk | 500 |
+                | overlap | 50 |
+                | parser | markdown |
+
+                ```java
+                // 주석. 끝
+                int value = 1;
+                ```
+
+                날짜는 2026. 7. 30. 기준입니다. 담당자는 A. B. 홍길동입니다. 마지막 문장입니다.
+                추가 설명은 표와 코드펜스 뒤에서도 원문 순서를 유지하는지 확인한다. 또 다른 문장은 작은 chunkSize 에서 다음 청크로 이동한다.""";
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -139,7 +139,7 @@ class EgovKoreanSentenceSplitterTest {
 
         char last = text.charAt(text.length() - 1);
         return last == '다' || last == '요' || last == '까' || last == '죠' || last == '음'
-                || last == '임' || last == '함' || last == '네' || last == '오' || last == '쇼';
+                || last == '임' || last == '함' || last == '네' || last == '오';
     }
 
     private Document documentWithText(String text) {

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/eval/EgovKoreanSentenceChunkingQualityTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/eval/EgovKoreanSentenceChunkingQualityTest.java
@@ -1,0 +1,178 @@
+package com.example.chat.eval;
+
+import com.example.chat.config.etl.transformers.EgovKoreanSentenceSplitter;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.segment.TextSegment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 행정문서 반례에서 한국어 문장 경계 splitter가 원문 구조와 인용 조사 경계를 보존하는지 확인한다.
+ *
+ * <p>recursive 수치는 비교를 위한 관측값이며 단언 대상이 아니다.</p>
+ */
+class EgovKoreanSentenceChunkingQualityTest {
+
+    private static final Logger log = LoggerFactory.getLogger(EgovKoreanSentenceChunkingQualityTest.class);
+
+    private static final int CHUNK_SIZE = 300;
+    private static final String PIPE_TABLE = """
+            | 항목 | 기본값 | 설명 |
+            | --- | --- | --- |
+            | 보관기간 | 30일 | 신청 로그를 보존합니다. |
+            | 재시도 | 3회 | 장애 시 다시 수행합니다. |
+            """;
+    private static final String CODE_FENCE = """
+            ```java
+            // 주석. 끝
+            String ticket = "No. 5";
+            ```
+            """;
+    private static final String COUNTEREXAMPLE_DOCUMENT = """
+            # 민원 처리 기준
+
+            담당자는 "즉시 조치한다."라고 말했다. 접수자는 2026. 7. 30. 이전 신청 내역을 확인합니다.
+            이 규정은 제3조제1항. 다음 조항을 따른다. A. B. 홍길동 검토관은 비율 3.14와 No. 5, etc. 표기를 보존합니다.
+
+            ## 처리 옵션
+
+            """
+            + PIPE_TABLE
+            + """
+
+            """
+            + CODE_FENCE
+            + """
+
+            1. 신청서 제출
+            2. 담당 부서 검토
+
+            인용문은 "자료를 보완한다."라며 끝나지 않고 다음 설명과 함께 유지됩니다.
+            본문은 표와 코드펜스 뒤에서도 행정 문서의 원문 개행을 그대로 포함해야 합니다.
+            제목 다음 문단은 고아 제목을 과대 해석하지 않도록 실제 마지막 비공백 줄만 측정합니다.
+            처리 결과 통지는 신청인의 연락처와 전자문서 수신 동의 여부를 함께 확인한 뒤 발송합니다.
+            담당 부서는 보완 요청 사유, 제출 기한, 미제출 시 처리 기준을 같은 문서 안에 명확히 적습니다.
+            감사 기록은 업무 담당자, 승인자, 변경 일시를 포함하며 추후 이의신청 검토 자료로 활용합니다.
+            """;
+
+    @Test
+    @DisplayName("행정문서 반례에서 원문 substring, 표 개행, 코드펜스, 인용 조사 경계를 보존한다")
+    void preservesOriginalMarkdownStructuresInCounterexample() {
+        List<TextSegment> recursiveSegments = split(recursiveSplitter());
+        List<TextSegment> koreanSegments = split(koreanSplitter());
+
+        ComparisonMetrics recursive = measure("recursive", recursiveSegments);
+        ComparisonMetrics korean = measure("korean", koreanSegments);
+
+        log.info("[반례] chunkSize={} strategy={} 청크수={} 평균길이={} 충전율={} 제목고아율={} 원문일치율={}",
+                CHUNK_SIZE, recursive.strategy(), recursive.chunkCount(), formatInteger(recursive.averageChunkLength()),
+                format(recursive.fillRatio()), format(recursive.headingOnlyTailRatio()),
+                format(recursive.originalSubstringRatio()));
+        log.info("[반례] chunkSize={} strategy={} 청크수={} 평균길이={} 충전율={} 제목고아율={} 원문일치율={}",
+                CHUNK_SIZE, korean.strategy(), korean.chunkCount(), formatInteger(korean.averageChunkLength()),
+                format(korean.fillRatio()), format(korean.headingOnlyTailRatio()),
+                format(korean.originalSubstringRatio()));
+
+        assertThat(recursiveSegments)
+                .allMatch(segment -> segment.text().length() <= CHUNK_SIZE);
+
+        assertThat(koreanSegments)
+                .hasSizeGreaterThanOrEqualTo(3)
+                .allMatch(segment -> segment.text().length() <= CHUNK_SIZE)
+                .allMatch(segment -> COUNTEREXAMPLE_DOCUMENT.contains(segment.text()))
+                .anyMatch(segment -> segment.text().contains(PIPE_TABLE))
+                .anyMatch(segment -> segment.text().contains(CODE_FENCE))
+                .noneMatch(this::startsWithQuotationParticle);
+    }
+
+    private List<TextSegment> split(DocumentSplitter splitter) {
+        Metadata metadata = new Metadata();
+        metadata.put("id", "counterexample.md");
+        metadata.put("source", "counterexample.md");
+        metadata.put("file_name", "counterexample.md");
+        return splitter.split(Document.from(COUNTEREXAMPLE_DOCUMENT, metadata));
+    }
+
+    private ComparisonMetrics measure(String strategy, List<TextSegment> segments) {
+        double averageChunkLength = averageChunkLength(segments);
+        return new ComparisonMetrics(strategy, segments.size(), averageChunkLength, averageChunkLength / CHUNK_SIZE,
+                headingOnlyTailRatio(segments), originalSubstringRatio(segments));
+    }
+
+    private double averageChunkLength(List<TextSegment> segments) {
+        return segments.stream()
+                .mapToInt(segment -> segment.text().length())
+                .average()
+                .orElse(0.0);
+    }
+
+    private double headingOnlyTailRatio(List<TextSegment> segments) {
+        long headingTailCount = segments.stream()
+                .map(TextSegment::text)
+                .filter(this::hasHeadingAsLastNonBlankLine)
+                .count();
+        return (double) headingTailCount / segments.size();
+    }
+
+    private boolean hasHeadingAsLastNonBlankLine(String text) {
+        String[] lines = text.split("\\R");
+        for (int i = lines.length - 1; i >= 0; i--) {
+            String line = lines[i].trim();
+            if (!line.isEmpty()) {
+                return line.startsWith("#");
+            }
+        }
+        return false;
+    }
+
+    private double originalSubstringRatio(List<TextSegment> segments) {
+        long originalSubstringCount = segments.stream()
+                .filter(segment -> COUNTEREXAMPLE_DOCUMENT.contains(segment.text()))
+                .count();
+        return (double) originalSubstringCount / segments.size();
+    }
+
+    private boolean startsWithQuotationParticle(TextSegment segment) {
+        String text = segment.text().stripLeading();
+        return text.startsWith("라고") || text.startsWith("라며");
+    }
+
+    private DocumentSplitter recursiveSplitter() {
+        return DocumentSplitters.recursive(CHUNK_SIZE, overlapSize());
+    }
+
+    private DocumentSplitter koreanSplitter() {
+        return new EgovKoreanSentenceSplitter(CHUNK_SIZE, overlapSize());
+    }
+
+    private int overlapSize() {
+        return Math.max(CHUNK_SIZE / 10, 50);
+    }
+
+    private String format(double value) {
+        return String.format(Locale.ROOT, "%.3f", value);
+    }
+
+    private String formatInteger(double value) {
+        return String.format(Locale.ROOT, "%.0f", value);
+    }
+
+    private record ComparisonMetrics(
+            String strategy,
+            int chunkCount,
+            double averageChunkLength,
+            double fillRatio,
+            double headingOnlyTailRatio,
+            double originalSubstringRatio) {
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/eval/EgovKoreanSentenceChunkingRecallComparisonTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/eval/EgovKoreanSentenceChunkingRecallComparisonTest.java
@@ -1,0 +1,246 @@
+package com.example.chat.eval;
+
+import com.example.chat.config.EgovHybridContentRetriever;
+import com.example.chat.config.etl.transformers.EgovKoreanSentenceSplitter;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.splitter.DocumentSplitters;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 한국어 문장 경계 인지 splitter와 기존 recursive splitter의 청크 충전율, 원문 보존율,
+ * 제목 고아율, lexical recall@3를 비교한다.
+ *
+ * <p>이 테스트는 문장 경계 전략이 recall을 개선한다고 주장하지 않는다. 고정 corpus와 QA 시드에서
+ * recall 회귀를 방어하고, 원문 offset 기반 청킹이 원문 substring을 보존하는지 확인한다.</p>
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class EgovKoreanSentenceChunkingRecallComparisonTest {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(EgovKoreanSentenceChunkingRecallComparisonTest.class);
+
+    private static final double LEXICAL_THRESHOLD = 0.30;
+    private static final int[] CHUNK_SIZES = {4000, 1000};
+    private static final List<CorpusDocument> CORPUS = List.of(
+            new CorpusDocument("doc-reactive-redis.md", "reactive-redis.md",
+                    EgovRetrievalRecallPoCTest.REDIS_DOCUMENT),
+            new CorpusDocument("doc-pgvector.md", "pgvector.md",
+                    EgovRetrievalRecallPoCTest.PGVECTOR_DOCUMENT),
+            new CorpusDocument("doc-crypto.md", "crypto.md",
+                    EgovRetrievalRecallPoCTest.CRYPTO_DOCUMENT),
+            new CorpusDocument("doc-batch.md", "batch.md",
+                    EgovRetrievalRecallPoCTest.BATCH_DOCUMENT),
+            new CorpusDocument("doc-cache-storage.md", "cache-storage.md",
+                    EgovRetrievalRecallPoCTest.CACHE_DISTRACTOR_DOCUMENT));
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static DataSource dataSource;
+    static JdbcTemplate jdbc;
+    static DataSourceTransactionManager txManager;
+
+    @BeforeAll
+    static void setUp() {
+        DriverManagerDataSource ds = new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+        ds.setDriverClassName("org.postgresql.Driver");
+        dataSource = ds;
+        jdbc = new JdbcTemplate(ds);
+        txManager = new DataSourceTransactionManager(ds);
+
+        jdbc.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+    }
+
+    @Test
+    @DisplayName("한국어 문장 경계 청킹과 기존 recursive 청킹의 충전율, 원문 보존율, 제목 고아율, recall@3를 비교한다")
+    void comparesKoreanSentenceChunkingRecallAndQualityMetrics() {
+        for (int chunkSize : CHUNK_SIZES) {
+            ComparisonResult recursive = evaluate(chunkSize, "recursive", recursiveSplitter(chunkSize));
+            ComparisonResult korean = evaluate(chunkSize, "korean", koreanSplitter(chunkSize));
+
+            assertThat(korean.averageRecallAtThree())
+                    .isGreaterThanOrEqualTo(recursive.averageRecallAtThree() - 0.1);
+            assertThat(korean.fillRatio())
+                    .isGreaterThanOrEqualTo(recursive.fillRatio());
+            assertThat(korean.originalSubstringRatio())
+                    .isEqualTo(1.0);
+        }
+    }
+
+    private ComparisonResult evaluate(int chunkSize, String strategy, DocumentSplitter splitter) {
+        String tableName = tableName(chunkSize, strategy);
+        jdbc.execute("DROP TABLE IF EXISTS " + tableName);
+        jdbc.execute("CREATE TABLE " + tableName + " (embedding_id serial primary key, text text, metadata jsonb)");
+        jdbc.execute("CREATE INDEX idx_" + tableName + "_trgm ON " + tableName + " USING gin (text gin_trgm_ops)");
+
+        List<TextSegment> segments = splitCorpus(splitter);
+        for (TextSegment segment : segments) {
+            assertThat(segment.text()).hasSizeLessThanOrEqualTo(chunkSize);
+            insert(tableName, segment);
+        }
+
+        double averageRecallAtThree = averageRecallAtThree(tableName);
+        double averageChunkLength = averageChunkLength(segments);
+        double fillRatio = averageChunkLength / chunkSize;
+        double headingOnlyTailRatio = headingOnlyTailRatio(segments);
+        double originalSubstringRatio = originalSubstringRatio(segments);
+
+        log.info("[비교] chunkSize={} strategy={} 청크수={} 평균길이={} 충전율={} 제목고아율={} 원문일치율={} 평균recall@3={}",
+                chunkSize, strategy, segments.size(), formatInteger(averageChunkLength), format(fillRatio),
+                format(headingOnlyTailRatio), format(originalSubstringRatio), format(averageRecallAtThree));
+
+        return new ComparisonResult(chunkSize, strategy, segments.size(), averageChunkLength, fillRatio,
+                headingOnlyTailRatio, originalSubstringRatio, averageRecallAtThree);
+    }
+
+    private List<TextSegment> splitCorpus(DocumentSplitter splitter) {
+        List<TextSegment> segments = new ArrayList<>();
+        for (CorpusDocument corpusDocument : CORPUS) {
+            Metadata metadata = new Metadata();
+            metadata.put("id", corpusDocument.id());
+            metadata.put("source", corpusDocument.fileName());
+            metadata.put("file_name", corpusDocument.fileName());
+
+            Document document = Document.from(corpusDocument.text(), metadata);
+            segments.addAll(splitter.split(document));
+        }
+        return List.copyOf(segments);
+    }
+
+    private void insert(String tableName, TextSegment segment) {
+        String id = segment.metadata().getString("id");
+        String fileName = segment.metadata().getString("file_name");
+        String metadata = "{\"id\": \"" + id + "\", \"source\": \"" + fileName
+                + "\", \"file_name\": \"" + fileName + "\"}";
+        jdbc.update("INSERT INTO " + tableName + "(text, metadata) VALUES (?, ?::jsonb)", segment.text(), metadata);
+    }
+
+    private double averageRecallAtThree(String tableName) {
+        EgovHybridContentRetriever retriever = retriever(tableName);
+        double recallSum = 0.0;
+
+        for (EgovRetrievalRecallPoCTest.SeedQuestion seed : EgovRetrievalRecallPoCTest.QA_SEEDS) {
+            List<String> retrievedDocIds = retriever.retrieve(Query.from(seed.question())).stream()
+                    .map(Content::textSegment)
+                    .map(segment -> segment.metadata().getString("id"))
+                    .distinct()
+                    .toList();
+            assertThat(retrievedDocIds).hasSizeLessThanOrEqualTo(EgovRetrievalRecallPoCTest.TOP_K);
+            recallSum += EgovRetrievalRecallPoCTest.recallAtK(
+                    retrievedDocIds, List.of(seed.goldDocId()), EgovRetrievalRecallPoCTest.TOP_K);
+        }
+
+        return recallSum / EgovRetrievalRecallPoCTest.QA_SEEDS.size();
+    }
+
+    private EgovHybridContentRetriever retriever(String tableName) {
+        ContentRetriever emptyDense = q -> List.of();
+        return new EgovHybridContentRetriever(emptyDense, jdbc, txManager, tableName,
+                1.0, 1.0, LEXICAL_THRESHOLD, EgovRetrievalRecallPoCTest.TOP_K);
+    }
+
+    private double averageChunkLength(List<TextSegment> segments) {
+        return segments.stream()
+                .mapToInt(segment -> segment.text().length())
+                .average()
+                .orElse(0.0);
+    }
+
+    private double headingOnlyTailRatio(List<TextSegment> segments) {
+        long headingTailCount = segments.stream()
+                .map(TextSegment::text)
+                .filter(this::hasHeadingAsLastNonBlankLine)
+                .count();
+        return (double) headingTailCount / segments.size();
+    }
+
+    private boolean hasHeadingAsLastNonBlankLine(String text) {
+        String[] lines = text.split("\\R");
+        for (int i = lines.length - 1; i >= 0; i--) {
+            String line = lines[i].trim();
+            if (!line.isEmpty()) {
+                return line.startsWith("#");
+            }
+        }
+        return false;
+    }
+
+    private double originalSubstringRatio(List<TextSegment> segments) {
+        long originalSubstringCount = segments.stream()
+                .filter(segment -> originalText(segment).contains(segment.text()))
+                .count();
+        return (double) originalSubstringCount / segments.size();
+    }
+
+    private String originalText(TextSegment segment) {
+        String id = segment.metadata().getString("id");
+        return CORPUS.stream()
+                .filter(corpusDocument -> corpusDocument.id().equals(id))
+                .map(CorpusDocument::text)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown corpus id: " + id));
+    }
+
+    private DocumentSplitter recursiveSplitter(int chunkSize) {
+        return DocumentSplitters.recursive(chunkSize, overlapSize(chunkSize));
+    }
+
+    private DocumentSplitter koreanSplitter(int chunkSize) {
+        return new EgovKoreanSentenceSplitter(chunkSize, overlapSize(chunkSize));
+    }
+
+    private int overlapSize(int chunkSize) {
+        return Math.max(chunkSize / 10, 50);
+    }
+
+    private String tableName(int chunkSize, String strategy) {
+        return "chunk_recall_" + strategy + "_" + chunkSize;
+    }
+
+    private String format(double value) {
+        return String.format(Locale.ROOT, "%.3f", value);
+    }
+
+    private String formatInteger(double value) {
+        return String.format(Locale.ROOT, "%.0f", value);
+    }
+
+    private record CorpusDocument(String id, String fileName, String text) {
+    }
+
+    private record ComparisonResult(
+            int chunkSize,
+            String strategy,
+            int chunkCount,
+            double averageChunkLength,
+            double fillRatio,
+            double headingOnlyTailRatio,
+            double originalSubstringRatio,
+            double averageRecallAtThree) {
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/eval/EgovRetrievalRecallPoCTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/eval/EgovRetrievalRecallPoCTest.java
@@ -34,9 +34,9 @@ class EgovRetrievalRecallPoCTest {
     private static final Logger log = LoggerFactory.getLogger(EgovRetrievalRecallPoCTest.class);
 
     private static final String TABLE = "document_embeddings";
-    private static final int TOP_K = 3;
+    static final int TOP_K = 3;
 
-    private static final String REDIS_DOCUMENT = (
+    static final String REDIS_DOCUMENT = (
             "# 리액티브 레디스 접근 모듈\n"
             + "ReactiveRedisTemplate은 논블로킹 방식으로 캐시 항목을 조회하고 저장하며 키 만료 시간을 관리합니다. "
             + "리액티브 세션 저장소는 요청 스레드를 점유하지 않고 비동기 결과를 발행합니다. "
@@ -58,7 +58,7 @@ class EgovRetrievalRecallPoCTest {
             + "명령 실행 순서가 중요한 업무는 병렬 연산을 제한하고 구독 체인에서 순차 결합 연산자를 사용합니다. "
             + "구독 취소 신호가 전달되면 남은 네트워크 작업과 버퍼를 해제하여 불필요한 자원 사용을 막습니다. "
             + "부하 시험은 생산 환경과 비슷한 키 분포와 값 크기를 사용하여 병목 지점을 사전에 확인합니다. ").repeat(8);
-    private static final String PGVECTOR_DOCUMENT = (
+    static final String PGVECTOR_DOCUMENT = (
             "# PostgreSQL 임베딩 검색 모듈\n"
             + "pgvector 확장은 문서 임베딩을 벡터 열에 저장하고 코사인 거리 기준으로 유사한 청크를 검색합니다. "
             + "질의 임베딩과 저장 벡터의 차원은 같아야 하며 모델 교체 시 전체 색인의 호환성을 점검합니다. "
@@ -69,7 +69,7 @@ class EgovRetrievalRecallPoCTest {
             + "업무 분류와 접근 권한 조건은 메타데이터 열에 저장하고 벡터 후보 집합과 함께 안전하게 제한합니다. "
             + "삭제와 갱신이 반복되는 테이블은 진공 작업과 재색인 주기를 정해 인덱스 팽창을 관리합니다. "
             + "검색 품질 시험은 고정 질의 집합으로 정확도와 지연 시간을 함께 기록하여 설정 변경을 비교합니다. ").repeat(8);
-    private static final String CRYPTO_DOCUMENT = (
+    static final String CRYPTO_DOCUMENT = (
             "# 표준프레임워크 데이터 암호화\n"
             + "ARIA 대칭키 암복호화 서비스는 환경 설정의 민감한 값을 보호하고 허가된 애플리케이션만 복호화합니다. "
             + "PBE 방식은 비밀번호와 솔트를 이용해 키를 유도하며 반복 횟수와 알고리즘 식별자를 설정으로 관리합니다. "
@@ -80,7 +80,7 @@ class EgovRetrievalRecallPoCTest {
             + "초기화 벡터와 난수 값은 안전한 생성기를 사용하고 동일 키에서 값을 재사용하지 않도록 검사합니다. "
             + "암복호화 API는 입력 길이와 문자 인코딩을 검증하고 오류 메시지에 민감 정보가 포함되지 않게 합니다. "
             + "보안 점검에서는 허용 알고리즘 목록과 키 접근 권한을 확인하고 폐기된 키의 사용을 차단합니다. ").repeat(8);
-    private static final String BATCH_DOCUMENT = (
+    static final String BATCH_DOCUMENT = (
             "# 대용량 배치 실행 모듈\n"
             + "배치 작업은 청크 단위 커밋으로 읽기, 처리, 쓰기 구간을 나누고 성공한 실행 위치를 체크포인트에 보존합니다. "
             + "작업 실패 후 재시작하면 완료된 구간을 건너뛰고 마지막 저장 지점부터 남은 데이터를 다시 수행합니다. "
@@ -91,7 +91,7 @@ class EgovRetrievalRecallPoCTest {
             + "단계 리스너는 실행 전후 통계를 남기되 업무 데이터 변경은 처리기와 기록기에서 일관되게 수행합니다. "
             + "재실행 가능한 작업은 외부 시스템 호출에도 업무 키를 전달하여 중복 반영을 방지합니다. "
             + "스케줄러는 이전 실행의 종료 상태를 확인하고 장시간 작업이 겹치지 않도록 동시 실행을 제한합니다. ").repeat(8);
-    private static final String CACHE_DISTRACTOR_DOCUMENT = (
+    static final String CACHE_DISTRACTOR_DOCUMENT = (
             "# 로컬 파일 캐싱과 객체 저장소\n"
             + "애플리케이션의 캐시 저장소는 원격 객체 파일을 로컬 디스크에 보관하여 반복 다운로드 비용을 줄입니다. "
             + "비동기 조회 작업은 파일 경로와 수정 시각을 검사한 뒤 작업 큐에서 원본 스토리지 접근을 수행합니다. "
@@ -103,7 +103,7 @@ class EgovRetrievalRecallPoCTest {
             + "파일 권한은 애플리케이션 계정으로 제한하고 심볼릭 링크를 통한 허용 경로 이탈을 검사합니다. "
             + "임시 파일은 다운로드 완료 후 원자적으로 이름을 변경하고 비정상 종료 시 남은 항목을 주기적으로 정리합니다. ").repeat(8);
 
-    private static final List<SeedQuestion> QA_SEEDS = List.of(
+    static final List<SeedQuestion> QA_SEEDS = List.of(
             new SeedQuestion("논블로킹 캐시 저장소에서 비동기 조회를 구성하는 방법", "doc-reactive-redis.md"),
             new SeedQuestion("Lettuce 연결의 대량 스트림 부하 제어 방식", "doc-reactive-redis.md"),
             new SeedQuestion("임베딩 문서를 코사인 기준으로 유사 검색하는 인덱스 구성", "doc-pgvector.md"),
@@ -182,12 +182,12 @@ class EgovRetrievalRecallPoCTest {
         assertThat(recallAtK(List.of("N1", "N2", "N3", "GOLD"), List.of("GOLD"), 3)).isZero();
     }
 
-    private static double recallAtK(List<String> retrieved, List<String> relevant, int k) {
+    static double recallAtK(List<String> retrieved, List<String> relevant, int k) {
         List<String> topK = retrieved.stream().limit(k).toList();
         long hit = relevant.stream().filter(topK::contains).count();
         return (double) hit / relevant.size();
     }
 
-    private record SeedQuestion(String question, String goldDocId) {
+    record SeedQuestion(String question, String goldDocId) {
     }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
@@ -187,6 +187,27 @@ class EgovKoreanSentenceSupportTest {
     }
 
     @Test
+    @DisplayName("영어 문장 끝 마침표는 경계로 보지 않아 뒤따르는 한국어 문장과 한 구간으로 남는다")
+    void keepEnglishSentenceWithFollowingKoreanSentence() {
+        String text = "Spring Boot provides auto-configuration. 이를 통해 개발자는 설정을 최소화할 수 있습니다.";
+
+        assertThat(EgovKoreanSentenceSupport.splitSentences(text)).containsExactly(text);
+        assertThat(EgovKoreanSentenceSupport.splitSentences("Spring Boot provides auto-configuration. It reduces boilerplate."))
+                .containsExactly("Spring Boot provides auto-configuration. It reduces boilerplate.");
+    }
+
+    @Test
+    @DisplayName("영어 문장이 섞여도 빈 줄 문단 경계는 그대로 적용한다")
+    void splitEnglishMixedTextAtBlankLineBoundary() {
+        String text = "Spring Boot provides auto-configuration.\n\n이를 통해 개발자는 설정을 최소화할 수 있습니다.";
+
+        assertThat(EgovKoreanSentenceSupport.splitSentences(text)).containsExactly(
+                "Spring Boot provides auto-configuration.",
+                "이를 통해 개발자는 설정을 최소화할 수 있습니다."
+        );
+    }
+
+    @Test
     @DisplayName("null 또는 공백 입력은 빈 목록을 반환한다")
     void returnEmptyListForBlankInput() {
         assertThat(EgovKoreanSentenceSupport.splitSentences(null)).isEmpty();
@@ -207,7 +228,8 @@ class EgovKoreanSentenceSupportTest {
                 "첫 줄입니다\n이어지는 줄입니다.\n\n새 문단입니다.",
                 "# 제목\n본문입니다.",
                 "담당자는 \"즉시 조치한다.\"라고 말했다.",
-                "앞 문장입니다.\n```java\n// 주석. 끝\nint value = 1;\n```\n뒤 문장입니다."
+                "앞 문장입니다.\n```java\n// 주석. 끝\nint value = 1;\n```\n뒤 문장입니다.",
+                "Spring Boot provides auto-configuration. 이를 통해 개발자는 설정을 최소화할 수 있습니다."
         );
 
         for (String text : cases) {

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
@@ -25,6 +25,22 @@ class EgovKoreanSentenceSupportTest {
     }
 
     @Test
+    @DisplayName("날짜 표기·라틴 이니셜은 문장 파편으로 자르지 않는다")
+    void keepDateAndLatinInitialInSameSentence() {
+        assertThat(EgovKoreanSentenceSupport.splitSentences("회의는 2026. 7. 30. 개최한다. 참석자는 다음과 같다."))
+                .containsExactly("회의는 2026. 7. 30. 개최한다.", "참석자는 다음과 같다.");
+        assertThat(EgovKoreanSentenceSupport.splitSentences("담당자는 A. B. 홍길동입니다. 확인 바랍니다."))
+                .containsExactly("담당자는 A. B. 홍길동입니다.", "확인 바랍니다.");
+    }
+
+    @Test
+    @DisplayName("종결어미로 끝난 문장은 다음 문장이 종결어미와 같은 글자로 시작해도 분리한다")
+    void splitSentenceBeforeWordStartingWithEndingSyllable() {
+        assertThat(EgovKoreanSentenceSupport.splitSentences("보고서를 제출한다. 하고자 하는 업무는 별도로 정한다."))
+                .containsExactly("보고서를 제출한다.", "하고자 하는 업무는 별도로 정한다.");
+    }
+
+    @Test
     @DisplayName("소수점과 버전 표기는 문장 경계로 보지 않는다")
     void keepDecimalAndVersionInSameSentence() {
         String text = "값은 3.14입니다. 버전은 1.0.1입니다.";
@@ -60,18 +76,15 @@ class EgovKoreanSentenceSupportTest {
 
         List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
 
+        // 종결어미가 아닌 글자·숫자 뒤 마침표는 경계로 보지 않는다. 두 문장이 한 구간에 남아도
+        // 청크는 원문 offset을 잘라내므로 내용이 훼손되지 않는다.
         assertThat(sentences).containsExactly(
                 "1. 항목입니다.",
                 "- 2. 하위 항목입니다.",
                 "제1. 서수 항목입니다.",
-                "이 규정은 제3조제1항.",
-                "다음 조항을 따른다.",
-                "적용 범위는 제2조.",
-                "세부는 별표 참조.",
-                "총 금액은 100.",
-                "이는 부가세 별도다.",
-                "제2항.",
-                "설명입니다."
+                "이 규정은 제3조제1항. 다음 조항을 따른다.",
+                "적용 범위는 제2조. 세부는 별표 참조. 총 금액은 100. 이는 부가세 별도다.",
+                "제2항. 설명입니다."
         );
     }
 

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
@@ -1,0 +1,209 @@
+package com.example.chat.util;
+
+import com.example.chat.util.EgovKoreanSentenceSupport.SentenceSpan;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link EgovKoreanSentenceSupport} 단위 테스트.
+ */
+class EgovKoreanSentenceSupportTest {
+
+    @Test
+    @DisplayName("종결부호로 한국어 문장을 분리한다")
+    void splitKoreanSentencesByTerminators() {
+        String text = "안녕하세요. 반갑습니다! 무엇일까요?";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("안녕하세요.", "반갑습니다!", "무엇일까요?");
+    }
+
+    @Test
+    @DisplayName("소수점과 버전 표기는 문장 경계로 보지 않는다")
+    void keepDecimalAndVersionInSameSentence() {
+        String text = "값은 3.14입니다. 버전은 1.0.1입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("값은 3.14입니다.", "버전은 1.0.1입니다.");
+    }
+
+    @Test
+    @DisplayName("라틴 약어 뒤 마침표는 문장 경계로 보지 않는다")
+    void keepAbbreviationsInSameSentence() {
+        String text = "번호는 No. 1입니다. 기타 etc. 항목입니다. 예: e.g. 형식입니다. 지역은 U.S. 기준입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly(
+                "번호는 No. 1입니다.",
+                "기타 etc. 항목입니다.",
+                "예: e.g. 형식입니다.",
+                "지역은 U.S. 기준입니다."
+        );
+    }
+
+    @Test
+    @DisplayName("줄 시작 목록 번호와 제+숫자 표기만 문장 경계로 보지 않는다")
+    void keepNumberedListMarkersInSameSentence() {
+        String text = """
+                1. 항목입니다.
+                  - 2. 하위 항목입니다.
+                제1. 서수 항목입니다.
+                이 규정은 제3조제1항. 다음 조항을 따른다. 적용 범위는 제2조. 세부는 별표 참조. 총 금액은 100. 이는 부가세 별도다. 제2항. 설명입니다.""";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly(
+                "1. 항목입니다.",
+                "- 2. 하위 항목입니다.",
+                "제1. 서수 항목입니다.",
+                "이 규정은 제3조제1항.",
+                "다음 조항을 따른다.",
+                "적용 범위는 제2조.",
+                "세부는 별표 참조.",
+                "총 금액은 100.",
+                "이는 부가세 별도다.",
+                "제2항.",
+                "설명입니다."
+        );
+    }
+
+    @Test
+    @DisplayName("연속 마침표는 하나의 경계만 만들고 빈 문장을 만들지 않는다")
+    void keepTerminatorRunTogether() {
+        String text = "끝났다... 다음";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("끝났다...", "다음");
+        assertThat(sentences).doesNotContain("");
+    }
+
+    @Test
+    @DisplayName("공백 없는 한국어 종결어미 뒤 문장을 분리한다")
+    void splitNoSpaceAfterKoreanEnding() {
+        String text = "처리를 완료합니다.다음 문장입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("처리를 완료합니다.", "다음 문장입니다.");
+    }
+
+    @Test
+    @DisplayName("빈 줄은 경계이고 하드랩 단일 개행은 경계가 아니다")
+    void splitBlankLineButKeepHardWrappedLine() {
+        String text = "첫 줄입니다\n이어지는 줄입니다.\n\n새 문단입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("첫 줄입니다\n이어지는 줄입니다.", "새 문단입니다.");
+    }
+
+    @Test
+    @DisplayName("마크다운 제목 줄은 본문과 분리한다")
+    void splitMarkdownHeadingLine() {
+        String text = "# 제목\n본문입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("# 제목", "본문입니다.");
+    }
+
+    @Test
+    @DisplayName("문장 구간은 오름차순이고 구간 사이에는 공백만 남는다")
+    void splitSentenceSpansKeepOrderedWhitespaceOnlyGaps() {
+        String text = "  # 제목\n본문입니다.\n\n담당자는 \"즉시 조치한다.\"라고 말했다.\n```java\n// 주석. 끝\n```\n마지막입니다.  ";
+
+        List<SentenceSpan> spans = EgovKoreanSentenceSupport.splitSentenceSpans(text);
+        List<String> spanTexts = new ArrayList<>();
+
+        assertThat(spans).isNotEmpty();
+        assertThat(text.substring(0, spans.get(0).start()).trim()).isEmpty();
+        for (int i = 0; i < spans.size(); i++) {
+            SentenceSpan span = spans.get(i);
+            assertThat(span.start()).isLessThan(span.end());
+            spanTexts.add(text.substring(span.start(), span.end()));
+            if (i + 1 < spans.size()) {
+                SentenceSpan next = spans.get(i + 1);
+                assertThat(span.end()).isLessThanOrEqualTo(next.start());
+                assertThat(text.substring(span.end(), next.start()).trim()).isEmpty();
+            }
+        }
+        assertThat(text.substring(spans.get(spans.size() - 1).end()).trim()).isEmpty();
+        assertThat(EgovKoreanSentenceSupport.splitSentences(text)).isEqualTo(spanTexts);
+    }
+
+    @Test
+    @DisplayName("인용문 뒤 조사는 같은 문장으로 유지하고 실제 다음 문장은 분리한다")
+    void keepQuoteParticlesWithQuotedSentence() {
+        String text = "담당자는 \"즉시 조치한다.\"라고 말했다. 다음 담당자는 \"교체한다.\" 라며 보고했다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly(
+                "담당자는 \"즉시 조치한다.\"라고 말했다.",
+                "다음 담당자는 \"교체한다.\" 라며 보고했다."
+        );
+    }
+
+    @Test
+    @DisplayName("코드펜스 내부 문장부호는 분리하지 않고 앞뒤 산문만 분리한다")
+    void keepCodeFenceBlockAsSingleSpan() {
+        String text = """
+                앞 문장입니다.
+                ```java
+                // 주석. 끝
+                int value = 1;
+                ```
+                뒤 문장입니다.""";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly(
+                "앞 문장입니다.",
+                "```java\n// 주석. 끝\nint value = 1;\n```",
+                "뒤 문장입니다."
+        );
+    }
+
+    @Test
+    @DisplayName("null 또는 공백 입력은 빈 목록을 반환한다")
+    void returnEmptyListForBlankInput() {
+        assertThat(EgovKoreanSentenceSupport.splitSentences(null)).isEmpty();
+        assertThat(EgovKoreanSentenceSupport.splitSentences(" \n\t ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("분리한 문장은 공백 제거 기준으로 원문을 무손실 재구성한다")
+    void splitSentencesAreLosslessIgnoringWhitespace() {
+        List<String> cases = List.of(
+                "안녕하세요. 반갑습니다! 무엇일까요?",
+                "값은 3.14입니다. 버전은 1.0.1입니다.",
+                "번호는 No. 1입니다. 기타 etc. 항목입니다. 예: e.g. 형식입니다. 지역은 U.S. 기준입니다.",
+                "1. 항목입니다.\n  - 2. 하위 항목입니다.\n제1. 서수 항목입니다.",
+                "이 규정은 제3조제1항. 다음 조항을 따른다. 적용 범위는 제2조. 세부는 별표 참조. 총 금액은 100. 이는 부가세 별도다.",
+                "끝났다... 다음",
+                "처리를 완료합니다.다음 문장입니다.",
+                "첫 줄입니다\n이어지는 줄입니다.\n\n새 문단입니다.",
+                "# 제목\n본문입니다.",
+                "담당자는 \"즉시 조치한다.\"라고 말했다.",
+                "앞 문장입니다.\n```java\n// 주석. 끝\nint value = 1;\n```\n뒤 문장입니다."
+        );
+
+        for (String text : cases) {
+            String rebuilt = String.join("", EgovKoreanSentenceSupport.splitSentences(text));
+            assertThat(removeWhitespace(rebuilt)).isEqualTo(removeWhitespace(text));
+        }
+    }
+
+    private String removeWhitespace(String text) {
+        return text.replaceAll("\\s+", "");
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/EgovETLPipelineConfig.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/EgovETLPipelineConfig.java
@@ -2,6 +2,7 @@ package com.example.chat.config.etl;
 
 import org.springframework.ai.ollama.OllamaChatModel;
 import org.springframework.ai.vectorstore.redis.RedisVectorStore;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,7 @@ import com.example.chat.config.etl.readers.EgovMarkdownReader;
 import com.example.chat.config.etl.readers.EgovPdfReader;
 import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
 import com.example.chat.config.etl.transformers.EgovContentFormatTransformer;
+import com.example.chat.config.etl.transformers.EgovKoreanSentenceSplitter;
 import com.example.chat.config.etl.transformers.EgovPiiMaskingTransformer;
 import com.example.chat.config.etl.writers.EgovVectorStoreWriter;
 
@@ -75,9 +77,10 @@ public class EgovETLPipelineConfig {
     }
 
     @Bean
-    public EgovEnhancedDocumentTransformer egovEnhancedDocumentTransformer(OllamaChatModel ollamaChatModel) {
+    public EgovEnhancedDocumentTransformer egovEnhancedDocumentTransformer(OllamaChatModel ollamaChatModel,
+            ObjectProvider<EgovKoreanSentenceSplitter> koreanSentenceSplitterProvider) {
         log.info("EgovEnhancedDocumentTransformer 빈 생성");
-        return new EgovEnhancedDocumentTransformer(ollamaChatModel);
+        return new EgovEnhancedDocumentTransformer(ollamaChatModel, koreanSentenceSplitterProvider);
     }
 
     @Bean

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/EgovKoreanChunkingConfig.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/EgovKoreanChunkingConfig.java
@@ -1,0 +1,30 @@
+package com.example.chat.config.etl;
+
+import com.example.chat.config.etl.transformers.EgovKoreanSentenceSplitter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 한국어 문장경계 인지 청킹 설정.
+ */
+@Slf4j
+@Configuration
+public class EgovKoreanChunkingConfig {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.ai.document.chunking.korean-sentence", name = "enabled", havingValue = "true")
+    public EgovKoreanSentenceSplitter koreanSentenceTextSplitter(
+            @Value("${spring.ai.document.chunk-size:4000}") int chunkSize,
+            @Value("${spring.ai.document.min-chunk-size-chars:350}") int minChunkSizeChars,
+            @Value("${spring.ai.document.min-chunk-length-to-embed:50}") int minChunkLengthToEmbed,
+            @Value("${spring.ai.document.max-num-chunks:500}") int maxNumChunks) {
+
+        log.info("한국어 문장경계 청킹 초기화 - chunkSize: {}, minChunkSizeChars: {}, minChunkLengthToEmbed: {}, maxNumChunks: {}, keepSeparator: {}",
+                chunkSize, minChunkSizeChars, minChunkLengthToEmbed, maxNumChunks, true);
+        return new EgovKoreanSentenceSplitter(
+                chunkSize, minChunkSizeChars, minChunkLengthToEmbed, maxNumChunks, true);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovEnhancedDocumentTransformer.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovEnhancedDocumentTransformer.java
@@ -8,7 +8,9 @@ import org.springframework.ai.model.transformer.SummaryMetadataEnricher;
 import org.springframework.ai.model.transformer.SummaryMetadataEnricher.SummaryType;
 import org.springframework.ai.model.transformer.KeywordMetadataEnricher;
 import org.springframework.ai.ollama.OllamaChatModel;
+import org.springframework.ai.transformer.splitter.TextSplitter;
 import org.springframework.ai.transformer.splitter.TokenTextSplitter;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class EgovEnhancedDocumentTransformer implements DocumentTransformer {
 
     private final OllamaChatModel ollamaChatModel;
+    private final ObjectProvider<EgovKoreanSentenceSplitter> koreanSentenceSplitterProvider;
     private final SummaryMetadataEnricher summaryEnricher;
     private KeywordMetadataEnricher keywordEnricher;
     
@@ -54,8 +57,10 @@ public class EgovEnhancedDocumentTransformer implements DocumentTransformer {
     @Value("${spring.ai.document.keyword-count}")
     private int keywordCount;
 
-    public EgovEnhancedDocumentTransformer(OllamaChatModel ollamaChatModel) {
+    public EgovEnhancedDocumentTransformer(OllamaChatModel ollamaChatModel,
+            ObjectProvider<EgovKoreanSentenceSplitter> koreanSentenceSplitterProvider) {
         this.ollamaChatModel = ollamaChatModel;
+        this.koreanSentenceSplitterProvider = koreanSentenceSplitterProvider;
         
         // 요약 생성기 초기화 (사용 여부는 설정에 따라 결정)
         this.summaryEnricher = new SummaryMetadataEnricher(
@@ -86,14 +91,21 @@ public class EgovEnhancedDocumentTransformer implements DocumentTransformer {
         log.info("TokenTextSplitter 설정 - chunkSize: {}, minChunkSizeChars: {}, minChunkLengthToEmbed: {}, maxNumChunks: {}", 
                 chunkSize, minChunkSizeChars, minChunkLengthToEmbed, maxNumChunks);
         
-        // 동적으로 TokenTextSplitter 생성
-        TokenTextSplitter textSplitter = new TokenTextSplitter(
-            chunkSize,           // chunkSize: 설정에서 가져온 청크 크기
-            minChunkSizeChars,   // minChunkSizeChars: 설정에서 가져온 최소 청크 크기
-            minChunkLengthToEmbed, // minChunkLengthToEmbed: 임베딩할 최소 청크 길이
-            maxNumChunks,        // maxNumChunks: 설정에서 가져온 최대 청크 수
-            true                 // keepSeparator: 구분자 유지 여부
-        );
+        TextSplitter textSplitter;
+        EgovKoreanSentenceSplitter koreanSentenceSplitter = koreanSentenceSplitterProvider.getIfAvailable();
+        if (koreanSentenceSplitter != null) {
+            textSplitter = koreanSentenceSplitter;
+            log.info("문서 분할기 선택 - {}", EgovKoreanSentenceSplitter.class.getSimpleName());
+        } else {
+            // 동적으로 TokenTextSplitter 생성
+            textSplitter = new TokenTextSplitter(
+                chunkSize,           // chunkSize: 설정에서 가져온 청크 크기
+                minChunkSizeChars,   // minChunkSizeChars: 설정에서 가져온 최소 청크 크기
+                minChunkLengthToEmbed, // minChunkLengthToEmbed: 임베딩할 최소 청크 길이
+                maxNumChunks,        // maxNumChunks: 설정에서 가져온 최대 청크 수
+                true                 // keepSeparator: 구분자 유지 여부
+            );
+        }
         
         List<Document> splitDocs = textSplitter.apply(documents);
         log.info("문서 분할 완료: {}개 청크 생성 (청크 크기: {} 토큰)", splitDocs.size(), chunkSize);
@@ -138,4 +150,4 @@ public class EgovEnhancedDocumentTransformer implements DocumentTransformer {
             return docsWithKeywords;
         }
     }
-} 
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -18,7 +18,8 @@ import org.springframework.ai.transformer.splitter.TokenTextSplitter;
  * {@link TokenTextSplitter} 와 동일한 CL100K_BASE 토크나이저로 청크 크기를 판정한다.
  * 청크는 원문 부분문자열이며 개행·표 구조가 보존된다.
  * 단일 문장이 청크 한도를 넘으면 원문 offset 창으로 잘라 나눠 모델 입력 한도를 지키면서도
- * 청크가 원문 부분문자열로 남게 한다. 기존 {@link TokenTextSplitter} 와의 정합을 위해
+ * 청크가 원문 부분문자열로 남게 한다. 보충면 문자 하나가 한도를 넘는 극단 설정(청크 크기 1~2)에서는
+ * 어떤 창도 한도에 맞지 않으므로 코드포인트 하나를 그대로 내보내 분할이 끝나도록 한다. 기존 {@link TokenTextSplitter} 와의 정합을 위해
  * 오버랩은 두지 않는다.</p>
  */
 public class EgovKoreanSentenceSplitter extends TokenTextSplitter {

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -17,8 +17,8 @@ import org.springframework.ai.transformer.splitter.TokenTextSplitter;
  * <p>{@link EgovKoreanSentenceSupport} 로 문장 경계를 먼저 나눈 뒤, Spring AI
  * {@link TokenTextSplitter} 와 동일한 CL100K_BASE 토크나이저로 청크 크기를 판정한다.
  * 청크는 원문 부분문자열이며 개행·표 구조가 보존된다.
- * 단일 문장이 청크 한도를 넘으면 {@code super.splitText(...)} 로 기존 분할기 동작에
- * 위임하여 모델 입력 한도를 보장한다. 기존 {@link TokenTextSplitter} 와의 정합을 위해
+ * 단일 문장이 청크 한도를 넘으면 원문 offset 창으로 잘라 나눠 모델 입력 한도를 지키면서도
+ * 청크가 원문 부분문자열로 남게 한다. 기존 {@link TokenTextSplitter} 와의 정합을 위해
  * 오버랩은 두지 않는다.</p>
  */
 public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
@@ -60,7 +60,7 @@ public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
                 if (chunks.size() >= maxNumChunks) {
                     break;
                 }
-                addFallbackChunks(chunks, sentence);
+                addOversizedSpanChunks(chunks, text, span);
                 if (chunks.size() >= maxNumChunks) {
                     break;
                 }
@@ -93,13 +93,47 @@ public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
         return List.copyOf(chunks);
     }
 
-    private void addFallbackChunks(List<String> chunks, String sentence) {
-        for (String fallbackChunk : super.splitText(sentence)) {
-            addChunk(chunks, fallbackChunk);
-            if (chunks.size() >= maxNumChunks) {
+    // 한 문장이 토큰 한도를 넘으면 원문 offset 창으로 잘라 나눈다. 토큰 한도에 맞는 가장 긴 창을
+    // 이진 탐색으로 찾고 가능하면 공백 위치로 물러나 자른다. 어느 경우에도 청크는 원문 부분문자열로 남는다.
+    private void addOversizedSpanChunks(List<String> chunks, String text, SentenceSpan span) {
+        int cursor = span.start();
+        while (cursor < span.end()) {
+            int cut = longestCutWithinTokenLimit(text, cursor, span.end());
+            if (cut < span.end()) {
+                int candidate = cut;
+                while (candidate > cursor && !Character.isWhitespace(text.charAt(candidate))) {
+                    candidate--;
+                }
+                if (candidate > cursor) {
+                    cut = candidate;
+                }
+            }
+
+            addChunk(chunks, text.substring(cursor, cut).strip());
+            if (chunks.size() >= maxNumChunks || cut >= span.end()) {
                 return;
             }
+            cursor = cut;
+            while (cursor < span.end() && Character.isWhitespace(text.charAt(cursor))) {
+                cursor++;
+            }
         }
+    }
+
+    private int longestCutWithinTokenLimit(String text, int start, int end) {
+        int low = start + 1;
+        int high = end;
+        int best = low;
+        while (low <= high) {
+            int mid = low + (high - low) / 2;
+            if (countTokens(text.substring(start, mid)) <= chunkSize) {
+                best = mid;
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return best;
     }
 
     private void addSpanChunk(List<String> chunks, String text, List<SentenceSpan> spans,

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -109,6 +109,8 @@ public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
                 }
             }
 
+            cut = alignToCodePointBoundary(text, cursor, cut);
+
             addChunk(chunks, text.substring(cursor, cut).strip());
             if (chunks.size() >= maxNumChunks || cut >= span.end()) {
                 return;
@@ -120,14 +122,25 @@ public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
         }
     }
 
+    // 서로게이트 페어 중간에서 자르면 짝 잃은 문자가 남으므로 코드포인트 경계로 물러난다.
+    private static int alignToCodePointBoundary(String text, int start, int cut) {
+        if (cut > start && cut < text.length() && Character.isLowSurrogate(text.charAt(cut))
+                && Character.isHighSurrogate(text.charAt(cut - 1))) {
+            return cut - 1;
+        }
+        return cut;
+    }
+
     private int longestCutWithinTokenLimit(String text, int start, int end) {
         int low = start + 1;
         int high = end;
         int best = low;
         while (low <= high) {
             int mid = low + (high - low) / 2;
-            if (countTokens(text.substring(start, mid)) <= chunkSize) {
-                best = mid;
+            // 토큰 계산기는 짝 잃은 서로게이트를 거부하므로 후보 위치를 먼저 코드포인트 경계로 맞춘다.
+            int candidate = alignToCodePointBoundary(text, start, mid);
+            if (candidate > start && countTokens(text.substring(start, candidate)) <= chunkSize) {
+                best = candidate;
                 low = mid + 1;
             } else {
                 high = mid - 1;

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -110,6 +110,10 @@ public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
             }
 
             cut = alignToCodePointBoundary(text, cursor, cut);
+            if (cut <= cursor) {
+                // 토큰 한도에 맞는 창이 없거나 보정으로 창이 비면 한 코드포인트만큼 나아가 진행을 보장한다.
+                cut = nextCodePointIndex(text, cursor);
+            }
 
             addChunk(chunks, text.substring(cursor, cut).strip());
             if (chunks.size() >= maxNumChunks || cut >= span.end()) {
@@ -120,6 +124,10 @@ public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
                 cursor++;
             }
         }
+    }
+
+    private static int nextCodePointIndex(String text, int index) {
+        return index + Character.charCount(text.codePointAt(index));
     }
 
     // 서로게이트 페어 중간에서 자르면 짝 잃은 문자가 남으므로 코드포인트 경계로 물러난다.
@@ -134,7 +142,7 @@ public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
     private int longestCutWithinTokenLimit(String text, int start, int end) {
         int low = start + 1;
         int high = end;
-        int best = low;
+        int best = start;
         while (low <= high) {
             int mid = low + (high - low) / 2;
             // 토큰 계산기는 짝 잃은 서로게이트를 거부하므로 후보 위치를 먼저 코드포인트 경계로 맞춘다.

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitter.java
@@ -1,0 +1,124 @@
+package com.example.chat.config.etl.transformers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.example.chat.util.EgovKoreanSentenceSupport;
+import com.example.chat.util.EgovKoreanSentenceSupport.SentenceSpan;
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingType;
+
+import org.springframework.ai.transformer.splitter.TokenTextSplitter;
+
+/**
+ * 한국어 문장 경계를 우선 보존하는 Spring AI 문서 분할기.
+ *
+ * <p>{@link EgovKoreanSentenceSupport} 로 문장 경계를 먼저 나눈 뒤, Spring AI
+ * {@link TokenTextSplitter} 와 동일한 CL100K_BASE 토크나이저로 청크 크기를 판정한다.
+ * 청크는 원문 부분문자열이며 개행·표 구조가 보존된다.
+ * 단일 문장이 청크 한도를 넘으면 {@code super.splitText(...)} 로 기존 분할기 동작에
+ * 위임하여 모델 입력 한도를 보장한다. 기존 {@link TokenTextSplitter} 와의 정합을 위해
+ * 오버랩은 두지 않는다.</p>
+ */
+public class EgovKoreanSentenceSplitter extends TokenTextSplitter {
+
+    private final Encoding encoding;
+    private final int chunkSize;
+    private final int minChunkLengthToEmbed;
+    private final int maxNumChunks;
+
+    public EgovKoreanSentenceSplitter(int chunkSize, int minChunkSizeChars,
+            int minChunkLengthToEmbed, int maxNumChunks, boolean keepSeparator) {
+        super(chunkSize, minChunkSizeChars, minChunkLengthToEmbed, maxNumChunks, keepSeparator);
+        this.encoding = Encodings.newLazyEncodingRegistry().getEncoding(EncodingType.CL100K_BASE);
+        this.chunkSize = chunkSize;
+        this.minChunkLengthToEmbed = minChunkLengthToEmbed;
+        this.maxNumChunks = maxNumChunks;
+    }
+
+    @Override
+    protected List<String> splitText(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+
+        List<SentenceSpan> spans = EgovKoreanSentenceSupport.splitSentenceSpans(text);
+        List<String> chunks = new ArrayList<>();
+        int bufferStart = -1;
+        int bufferEnd = -1;
+
+        for (int i = 0; i < spans.size(); i++) {
+            SentenceSpan span = spans.get(i);
+            String sentence = text.substring(span.start(), span.end());
+            if (countTokens(sentence) > chunkSize) {
+                if (bufferStart >= 0) {
+                    addSpanChunk(chunks, text, spans, bufferStart, bufferEnd);
+                    bufferStart = -1;
+                    bufferEnd = -1;
+                }
+                if (chunks.size() >= maxNumChunks) {
+                    break;
+                }
+                addFallbackChunks(chunks, sentence);
+                if (chunks.size() >= maxNumChunks) {
+                    break;
+                }
+                continue;
+            }
+
+            if (bufferStart < 0) {
+                bufferStart = i;
+                bufferEnd = i;
+                continue;
+            }
+
+            String candidate = text.substring(spans.get(bufferStart).start(), span.end());
+            if (countTokens(candidate) <= chunkSize) {
+                bufferEnd = i;
+                continue;
+            }
+
+            addSpanChunk(chunks, text, spans, bufferStart, bufferEnd);
+            if (chunks.size() >= maxNumChunks) {
+                break;
+            }
+            bufferStart = i;
+            bufferEnd = i;
+        }
+
+        if (chunks.size() < maxNumChunks && bufferStart >= 0) {
+            addSpanChunk(chunks, text, spans, bufferStart, bufferEnd);
+        }
+        return List.copyOf(chunks);
+    }
+
+    private void addFallbackChunks(List<String> chunks, String sentence) {
+        for (String fallbackChunk : super.splitText(sentence)) {
+            addChunk(chunks, fallbackChunk);
+            if (chunks.size() >= maxNumChunks) {
+                return;
+            }
+        }
+    }
+
+    private void addSpanChunk(List<String> chunks, String text, List<SentenceSpan> spans,
+            int startIndex, int endIndex) {
+        addChunk(chunks, text.substring(spans.get(startIndex).start(), spans.get(endIndex).end()));
+    }
+
+    private void addChunk(List<String> chunks, String chunk) {
+        if (chunks.size() >= maxNumChunks || chunk == null) {
+            return;
+        }
+
+        String trimmed = chunk.trim();
+        if (trimmed.length() > minChunkLengthToEmbed) {
+            chunks.add(trimmed);
+        }
+    }
+
+    private int countTokens(String text) {
+        return encoding.countTokens(text);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
@@ -2,32 +2,20 @@ package com.example.chat.util;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 
 /**
  * 한국어 문장 경계를 결정론적으로 분리하는 유틸리티.
  *
- * <p>종결부호({@code . ! ? 。 ！ ？})와 닫는 인용/괄호를 함께 문장 끝으로 보고,
- * 소수점·목록 번호·라틴 약어는 문장 경계에서 제외한다. 한국어 종결어미 뒤의 종결부호는
- * 다음 문장과 공백이 없어도 경계로 인정하며, 빈 줄과 일부 마크다운 블록 시작 줄은 문단/블록
- * 경계로 처리한다. LLM·외부 사전 없이 결정론적으로 동작한다.</p>
+ * <p>경계 판정은 보수적이다. 빈 줄과 마크다운 블록 시작 줄을 문단·블록 경계로 보고,
+ * 마침표는 한국어 종결어미 뒤에 오고 다음이 공백·개행·문서 끝일 때만 문장 끝으로 본다.
+ * 그 밖의 마침표(날짜 표기·소수점·라틴 약어·목록 번호·법령 조항 등)는 경계로 보지 않는다.
+ * 물음표·느낌표는 표기 모호성이 없어 공백·개행·문서 끝이 이어지면 경계로 본다.</p>
+ *
+ * <p>경계를 놓치면 두 문장이 한 구간으로 남을 뿐이고, 청크는 원문 offset을 그대로 잘라내므로
+ * 내용이 훼손되지 않는다. 반대로 경계를 잘못 만들면 문장이 중간에서 끊어지므로, 확신이 없는
+ * 마침표는 자르지 않는다. LLM·외부 사전 없이 결정론적으로 동작한다.</p>
  */
 public final class EgovKoreanSentenceSupport {
-
-    private static final Set<String> ABBREVIATIONS = Set.of(
-            "no", "etc", "eg", "ie", "vs", "cf", "fig", "tbl", "ex",
-            "mr", "mrs", "ms", "dr", "prof", "inc", "ltd", "co", "corp",
-            "dept", "approx", "pp", "vol", "sec",
-            "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "sept",
-            "oct", "nov", "dec",
-            "a.m", "a.m.", "p.m", "p.m.", "e.g", "e.g.", "i.e", "i.e.",
-            "u.s", "u.s."
-    );
-    private static final List<String> QUOTE_PARTICLES = List.of(
-            "이라면서", "이라며", "이라는", "이라고", "라면서", "라고요",
-            "라고", "라며", "라는", "라던", "하고"
-    );
 
     private EgovKoreanSentenceSupport() {
     }
@@ -54,10 +42,11 @@ public final class EgovKoreanSentenceSupport {
         int index = 0;
 
         while (index < text.length()) {
-            if (isCodeFenceLineStart(text, index)) {
+            CodeFence fence = codeFenceAt(text, index);
+            if (fence != null) {
                 // 코드펜스 내부의 마침표는 코드 조각일 수 있으므로 블록 전체를 하나의 구간으로 고정한다.
                 addSentenceSpan(spans, text, sentenceStart, index);
-                int fenceEnd = consumeCodeFenceBlock(text, index);
+                int fenceEnd = consumeCodeFenceBlock(text, index, fence);
                 addSentenceSpan(spans, text, index, fenceEnd);
                 sentenceStart = fenceEnd;
                 index = fenceEnd;
@@ -124,49 +113,36 @@ public final class EgovKoreanSentenceSupport {
             runEnd++;
         }
 
+        // 종결부호 후보 런 전체를 한 번에 소비해 "..."나 "?!"에서 빈 문장이 생기지 않게 한다.
+        // 닫는 인용/괄호는 앞 문장의 일부이므로 종결부호 뒤에 붙은 경우 함께 포함한다.
         int boundaryEnd = runEnd;
         while (boundaryEnd < text.length() && isClosingQuoteOrBracket(text.charAt(boundaryEnd))) {
             boundaryEnd++;
         }
+        boolean consumedClosingQuote = boundaryEnd > runEnd;
 
-        char terminator = text.charAt(terminatorStart);
         char previous = previousChar(text, terminatorStart);
         char next = nextChar(text, boundaryEnd);
+        boolean followedByBreak = next == '\0' || Character.isWhitespace(next);
+        boolean boundary;
 
-        // 종결부호 후보 런 전체를 한 번에 소비해 "..."나 "?!"에서 빈 문장이 생기지 않게 한다.
-        // 닫는 인용/괄호는 앞 문장의 일부이므로 종결부호 뒤에 붙은 경우 함께 포함한다.
-        boolean boundary = false;
-
-        // 기본 경계는 다음 문자가 공백이거나 문자열 끝인 경우로 제한해 URL·확장자·소수 오인을 줄인다.
-        if (next == '\0' || Character.isWhitespace(next)) {
-            boundary = true;
+        if (text.charAt(terminatorStart) == '.') {
+            // 마침표는 날짜 표기·소수점·약어·목록 번호와 구분되지 않으므로 한국어 종결어미 뒤에서만 경계로 본다.
+            boundary = isKoreanSentenceEnding(previous) && followedByBreak;
+        } else {
+            // 물음표·느낌표는 다른 표기로 쓰이지 않아 뒤에 공백·개행·문서 끝이 오면 경계로 본다.
+            boundary = followedByBreak;
         }
 
-        if (terminator == '.') {
-            // 숫자 사이의 마침표는 소수점 또는 버전 표기일 가능성이 높아 경계로 보지 않는다.
-            if (Character.isDigit(previous) && Character.isDigit(next)) {
-                boundary = false;
-            }
-
-            // 줄 시작의 숫자열과 제+숫자 뒤 마침표만 목록 번호·서수 표기로 보고 문장 경계에서 제외한다.
-            if (isNumberedListMarker(text, terminatorStart)) {
-                boundary = false;
-            }
-
-            // 라틴 약어 뒤 마침표는 문장 내부 표기이므로 대소문자와 내부 마침표를 정규화해 제외한다.
-            if (isAbbreviation(text, terminatorStart)) {
-                boundary = false;
-            }
-        }
-
-        // 한국어 종결어미 뒤 마침표는 공백 없이 다음 한글 문장이 이어져도 경계로 인정한다.
-        if (!boundary && isKoreanSentenceEnding(previous) && isSafeNoSpaceNext(next)) {
-            boundary = true;
-        }
-
-        // 닫는 인용 뒤 조사(라고/라며 등)는 앞 인용문을 받는 문장 성분이므로 경계로 자르지 않는다.
-        if (boundary && isFollowedByQuoteParticle(text, boundaryEnd)) {
+        // 인용문을 닫은 뒤 같은 줄에 한국어가 이어지면 인용을 받는 문장 성분(라고 말했다)이므로 자르지 않는다.
+        if (boundary && consumedClosingQuote && continuesWithHangulOnSameLine(text, boundaryEnd)) {
             boundary = false;
+        }
+
+        // 공백 없이 다음 문장이 붙는 표기도 종결어미 뒤라면 경계로 인정한다.
+        // 닫는 인용을 소비한 경우는 위와 같은 이유로 제외한다.
+        if (!boundary && !consumedClosingQuote && isKoreanSentenceEnding(previous) && isSafeNoSpaceNext(next)) {
+            boundary = true;
         }
 
         return new SentenceBoundary(boundary, boundaryEnd);
@@ -244,37 +220,41 @@ public final class EgovKoreanSentenceSupport {
         return numberEnd < text.length() && (text.charAt(numberEnd) == '.' || text.charAt(numberEnd) == ')');
     }
 
-    private static boolean isCodeFenceLineStart(String text, int start) {
+    // 코드펜스 여는 줄이면 마커 문자와 길이를 돌려준다. 백틱과 물결표를 모두 인식한다.
+    private static CodeFence codeFenceAt(String text, int start) {
         if (!isAtLineStart(text, start)) {
-            return false;
+            return null;
         }
-        return codeFenceMarkerIndex(text, start) >= 0;
+
+        int index = skipHorizontalWhitespace(text, start);
+        if (index >= text.length()) {
+            return null;
+        }
+
+        char marker = text.charAt(index);
+        if (marker != '`' && marker != '~') {
+            return null;
+        }
+
+        int length = 0;
+        while (index + length < text.length() && text.charAt(index + length) == marker) {
+            length++;
+        }
+        return length >= 3 ? new CodeFence(marker, length) : null;
     }
 
-    private static int consumeCodeFenceBlock(String text, int fenceLineStart) {
-        int nextLineStart = nextLineStart(text, fenceLineStart);
-        int search = nextLineStart;
+    private static int consumeCodeFenceBlock(String text, int fenceLineStart, CodeFence opening) {
+        int search = nextLineStart(text, fenceLineStart);
         while (search < text.length()) {
-            if (isCodeFenceLineStart(text, search)) {
+            CodeFence closing = codeFenceAt(text, search);
+            // 닫는 펜스는 여는 펜스와 같은 문자이고 길이가 같거나 길어야 한다(네 겹 백틱 블록의 조기 종료 방지).
+            if (closing != null && closing.marker() == opening.marker() && closing.length() >= opening.length()) {
                 // 닫는 펜스 줄 끝까지만 포함하고 뒤 개행은 문장 사이 공백으로 남긴다.
                 return lineEnd(text, search);
             }
             search = nextLineStart(text, search);
         }
         return text.length();
-    }
-
-    private static int codeFenceMarkerIndex(String text, int lineStart) {
-        int index = lineStart;
-        while (index < text.length()) {
-            char ch = text.charAt(index);
-            if (ch == ' ' || ch == '\t') {
-                index++;
-                continue;
-            }
-            break;
-        }
-        return startsWith(text, index, "```") ? index : -1;
     }
 
     private static int lineEnd(String text, int index) {
@@ -308,85 +288,6 @@ public final class EgovKoreanSentenceSupport {
         return index == 0 || isLineBreak(text.charAt(index - 1));
     }
 
-    private static boolean isNumberedListMarker(String text, int dotIndex) {
-        char afterDot = nextChar(text, dotIndex + 1);
-        if (afterDot != '\0' && !Character.isWhitespace(afterDot)) {
-            return false;
-        }
-
-        int markerStart = listMarkerStart(text, dotIndex);
-        if (markerStart < 0) {
-            return false;
-        }
-
-        if (isKoreanOrdinalMarker(text, markerStart, dotIndex)) {
-            return true;
-        }
-
-        if (!Character.isDigit(text.charAt(markerStart))) {
-            return false;
-        }
-
-        for (int i = markerStart; i < dotIndex; i++) {
-            if (!Character.isDigit(text.charAt(i))) {
-                return false;
-            }
-        }
-        return markerStart < dotIndex;
-    }
-
-    private static int listMarkerStart(String text, int dotIndex) {
-        int index = lineStart(text, dotIndex);
-        index = skipHorizontalWhitespace(text, index);
-
-        while (index < dotIndex && isMarkdownListQuoteMarker(text.charAt(index))) {
-            int afterMarker = index + 1;
-            if (afterMarker >= dotIndex || !isHorizontalWhitespace(text.charAt(afterMarker))) {
-                break;
-            }
-            // 줄 시작 불릿/인용 접두어 뒤 공백은 목록번호의 시각적 들여쓰기라서 같은 패턴으로 본다.
-            index = skipHorizontalWhitespace(text, afterMarker);
-        }
-
-        return index < dotIndex ? index : -1;
-    }
-
-    private static boolean isKoreanOrdinalMarker(String text, int markerStart, int dotIndex) {
-        if (text.charAt(markerStart) != '제' || markerStart + 1 >= dotIndex) {
-            return false;
-        }
-
-        for (int i = markerStart + 1; i < dotIndex; i++) {
-            if (!Character.isDigit(text.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static boolean isMarkdownListQuoteMarker(char ch) {
-        return ch == '-' || ch == '*' || ch == '>';
-    }
-
-    private static boolean isAbbreviation(String text, int dotIndex) {
-        int start = dotIndex - 1;
-        while (start >= 0) {
-            char ch = text.charAt(start);
-            if (isLatinLetter(ch) || ch == '.') {
-                start--;
-                continue;
-            }
-            break;
-        }
-
-        String token = text.substring(start + 1, dotIndex).toLowerCase(Locale.ROOT);
-        if (token.isEmpty()) {
-            return false;
-        }
-
-        return ABBREVIATIONS.contains(token) || ABBREVIATIONS.contains(token + ".");
-    }
-
     private static boolean isKoreanSentenceEnding(char ch) {
         return ch == '다' || ch == '요' || ch == '까' || ch == '죠' || ch == '음'
                 || ch == '임' || ch == '함' || ch == '네' || ch == '오' || ch == '쇼';
@@ -403,26 +304,13 @@ public final class EgovKoreanSentenceSupport {
         return ch == '"' || ch == '\'' || ch == '「' || ch == '『' || ch == '(' || ch == '[' || ch == '《';
     }
 
+    private static boolean continuesWithHangulOnSameLine(String text, int start) {
+        int index = skipHorizontalWhitespace(text, start);
+        return index < text.length() && isHangulSyllable(text.charAt(index));
+    }
+
     private static boolean isHangulSyllable(char ch) {
         return ch >= '가' && ch <= '힣';
-    }
-
-    private static boolean isLatinLetter(char ch) {
-        return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
-    }
-
-    private static boolean isFollowedByQuoteParticle(String text, int start) {
-        int index = start;
-        while (index < text.length() && isHorizontalWhitespace(text.charAt(index))) {
-            index++;
-        }
-
-        for (String particle : QUOTE_PARTICLES) {
-            if (startsWith(text, index, particle)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static int skipHorizontalWhitespace(String text, int start) {
@@ -437,17 +325,15 @@ public final class EgovKoreanSentenceSupport {
         return ch == ' ' || ch == '\t';
     }
 
-    private static boolean startsWith(String text, int start, String prefix) {
-        return start >= 0 && start + prefix.length() <= text.length()
-                && text.regionMatches(start, prefix, 0, prefix.length());
-    }
-
     private static char previousChar(String text, int index) {
         return index > 0 ? text.charAt(index - 1) : '\0';
     }
 
     private static char nextChar(String text, int index) {
         return index < text.length() ? text.charAt(index) : '\0';
+    }
+
+    private record CodeFence(char marker, int length) {
     }
 
     private record SentenceBoundary(boolean boundary, int endIndex) {

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
@@ -1,0 +1,458 @@
+package com.example.chat.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * 한국어 문장 경계를 결정론적으로 분리하는 유틸리티.
+ *
+ * <p>종결부호({@code . ! ? 。 ！ ？})와 닫는 인용/괄호를 함께 문장 끝으로 보고,
+ * 소수점·목록 번호·라틴 약어는 문장 경계에서 제외한다. 한국어 종결어미 뒤의 종결부호는
+ * 다음 문장과 공백이 없어도 경계로 인정하며, 빈 줄과 일부 마크다운 블록 시작 줄은 문단/블록
+ * 경계로 처리한다. LLM·외부 사전 없이 결정론적으로 동작한다.</p>
+ */
+public final class EgovKoreanSentenceSupport {
+
+    private static final Set<String> ABBREVIATIONS = Set.of(
+            "no", "etc", "eg", "ie", "vs", "cf", "fig", "tbl", "ex",
+            "mr", "mrs", "ms", "dr", "prof", "inc", "ltd", "co", "corp",
+            "dept", "approx", "pp", "vol", "sec",
+            "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "sept",
+            "oct", "nov", "dec",
+            "a.m", "a.m.", "p.m", "p.m.", "e.g", "e.g.", "i.e", "i.e.",
+            "u.s", "u.s."
+    );
+    private static final List<String> QUOTE_PARTICLES = List.of(
+            "이라면서", "이라며", "이라는", "이라고", "라면서", "라고요",
+            "라고", "라며", "라는", "라던", "하고"
+    );
+
+    private EgovKoreanSentenceSupport() {
+    }
+
+    /**
+     * 원문 내 문장 구간. {@code start} 포함, {@code end} 제외이며 앞뒤 공백은 제외한다.
+     */
+    public record SentenceSpan(int start, int end) {
+    }
+
+    /**
+     * 입력 텍스트의 한국어 문장 구간을 원문 offset 기준으로 분리한다.
+     *
+     * @param text 분리할 텍스트
+     * @return 오름차순·비중첩 문장 구간 목록
+     */
+    public static List<SentenceSpan> splitSentenceSpans(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+
+        List<SentenceSpan> spans = new ArrayList<>();
+        int sentenceStart = 0;
+        int index = 0;
+
+        while (index < text.length()) {
+            if (isCodeFenceLineStart(text, index)) {
+                // 코드펜스 내부의 마침표는 코드 조각일 수 있으므로 블록 전체를 하나의 구간으로 고정한다.
+                addSentenceSpan(spans, text, sentenceStart, index);
+                int fenceEnd = consumeCodeFenceBlock(text, index);
+                addSentenceSpan(spans, text, index, fenceEnd);
+                sentenceStart = fenceEnd;
+                index = fenceEnd;
+                continue;
+            }
+
+            char current = text.charAt(index);
+
+            if (isLineBreak(current)) {
+                LineBreakRun lineBreakRun = consumeLineBreakRun(text, index);
+                if (lineBreakRun.count() >= 2) {
+                    // 빈 줄은 문단이 바뀐 신호이므로 종결부호가 없어도 강제 경계로 본다.
+                    addSentenceSpan(spans, text, sentenceStart, index);
+                    sentenceStart = lineBreakRun.endIndex();
+                } else if (isMarkdownBlockStart(text, lineStart(text, index))
+                        || isMarkdownBlockStart(text, lineBreakRun.endIndex())) {
+                    // 단일 개행은 보통 하드랩이지만, 다음 줄이 마크다운 블록이면 문단 섞임을 막기 위해 경계로 본다.
+                    addSentenceSpan(spans, text, sentenceStart, index);
+                    sentenceStart = lineBreakRun.endIndex();
+                }
+                index = lineBreakRun.endIndex();
+                continue;
+            }
+
+            if (isTerminator(current)) {
+                SentenceBoundary boundary = evaluateTerminatorBoundary(text, index);
+                if (boundary.boundary()) {
+                    addSentenceSpan(spans, text, sentenceStart, boundary.endIndex());
+                    sentenceStart = boundary.endIndex();
+                }
+                index = boundary.endIndex();
+                continue;
+            }
+
+            index++;
+        }
+
+        addSentenceSpan(spans, text, sentenceStart, text.length());
+        return List.copyOf(spans);
+    }
+
+    /**
+     * 입력 텍스트를 한국어 문장 경계 기준으로 분리한다.
+     *
+     * @param text 분리할 텍스트
+     * @return 앞뒤 공백이 제거된 문장 목록
+     */
+    public static List<String> splitSentences(String text) {
+        List<SentenceSpan> spans = splitSentenceSpans(text);
+        if (spans.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> sentences = new ArrayList<>(spans.size());
+        for (SentenceSpan span : spans) {
+            sentences.add(text.substring(span.start(), span.end()));
+        }
+        return List.copyOf(sentences);
+    }
+
+    private static SentenceBoundary evaluateTerminatorBoundary(String text, int terminatorStart) {
+        int runEnd = terminatorStart + 1;
+        while (runEnd < text.length() && isTerminator(text.charAt(runEnd))) {
+            runEnd++;
+        }
+
+        int boundaryEnd = runEnd;
+        while (boundaryEnd < text.length() && isClosingQuoteOrBracket(text.charAt(boundaryEnd))) {
+            boundaryEnd++;
+        }
+
+        char terminator = text.charAt(terminatorStart);
+        char previous = previousChar(text, terminatorStart);
+        char next = nextChar(text, boundaryEnd);
+
+        // 종결부호 후보 런 전체를 한 번에 소비해 "..."나 "?!"에서 빈 문장이 생기지 않게 한다.
+        // 닫는 인용/괄호는 앞 문장의 일부이므로 종결부호 뒤에 붙은 경우 함께 포함한다.
+        boolean boundary = false;
+
+        // 기본 경계는 다음 문자가 공백이거나 문자열 끝인 경우로 제한해 URL·확장자·소수 오인을 줄인다.
+        if (next == '\0' || Character.isWhitespace(next)) {
+            boundary = true;
+        }
+
+        if (terminator == '.') {
+            // 숫자 사이의 마침표는 소수점 또는 버전 표기일 가능성이 높아 경계로 보지 않는다.
+            if (Character.isDigit(previous) && Character.isDigit(next)) {
+                boundary = false;
+            }
+
+            // 줄 시작의 숫자열과 제+숫자 뒤 마침표만 목록 번호·서수 표기로 보고 문장 경계에서 제외한다.
+            if (isNumberedListMarker(text, terminatorStart)) {
+                boundary = false;
+            }
+
+            // 라틴 약어 뒤 마침표는 문장 내부 표기이므로 대소문자와 내부 마침표를 정규화해 제외한다.
+            if (isAbbreviation(text, terminatorStart)) {
+                boundary = false;
+            }
+        }
+
+        // 한국어 종결어미 뒤 마침표는 공백 없이 다음 한글 문장이 이어져도 경계로 인정한다.
+        if (!boundary && isKoreanSentenceEnding(previous) && isSafeNoSpaceNext(next)) {
+            boundary = true;
+        }
+
+        // 닫는 인용 뒤 조사(라고/라며 등)는 앞 인용문을 받는 문장 성분이므로 경계로 자르지 않는다.
+        if (boundary && isFollowedByQuoteParticle(text, boundaryEnd)) {
+            boundary = false;
+        }
+
+        return new SentenceBoundary(boundary, boundaryEnd);
+    }
+
+    private static void addSentenceSpan(List<SentenceSpan> spans, String text, int start, int end) {
+        int trimmedStart = start;
+        int trimmedEnd = end;
+        while (trimmedStart < trimmedEnd && Character.isWhitespace(text.charAt(trimmedStart))) {
+            trimmedStart++;
+        }
+        while (trimmedEnd > trimmedStart && Character.isWhitespace(text.charAt(trimmedEnd - 1))) {
+            trimmedEnd--;
+        }
+        if (trimmedStart < trimmedEnd) {
+            spans.add(new SentenceSpan(trimmedStart, trimmedEnd));
+        }
+    }
+
+    private static boolean isTerminator(char ch) {
+        return ch == '.' || ch == '!' || ch == '?' || ch == '。' || ch == '！' || ch == '？';
+    }
+
+    private static boolean isClosingQuoteOrBracket(char ch) {
+        return ch == '"' || ch == '\'' || ch == '」' || ch == '』' || ch == ')' || ch == ']' || ch == '》';
+    }
+
+    private static boolean isLineBreak(char ch) {
+        return ch == '\n' || ch == '\r';
+    }
+
+    private static LineBreakRun consumeLineBreakRun(String text, int start) {
+        int index = start;
+        int count = 0;
+        while (index < text.length() && isLineBreak(text.charAt(index))) {
+            if (text.charAt(index) == '\r' && index + 1 < text.length() && text.charAt(index + 1) == '\n') {
+                index += 2;
+            } else {
+                index++;
+            }
+            count++;
+        }
+        return new LineBreakRun(count, index);
+    }
+
+    private static boolean isMarkdownBlockStart(String text, int start) {
+        int index = start;
+        while (index < text.length()) {
+            char ch = text.charAt(index);
+            if (ch == ' ' || ch == '\t') {
+                index++;
+                continue;
+            }
+            break;
+        }
+
+        if (index >= text.length()) {
+            return false;
+        }
+
+        char ch = text.charAt(index);
+        if (ch == '#' || ch == '-' || ch == '*' || ch == '>' || ch == '|') {
+            return true;
+        }
+
+        if (!Character.isDigit(ch)) {
+            return false;
+        }
+
+        int numberEnd = index + 1;
+        while (numberEnd < text.length() && Character.isDigit(text.charAt(numberEnd))) {
+            numberEnd++;
+        }
+
+        return numberEnd < text.length() && (text.charAt(numberEnd) == '.' || text.charAt(numberEnd) == ')');
+    }
+
+    private static boolean isCodeFenceLineStart(String text, int start) {
+        if (!isAtLineStart(text, start)) {
+            return false;
+        }
+        return codeFenceMarkerIndex(text, start) >= 0;
+    }
+
+    private static int consumeCodeFenceBlock(String text, int fenceLineStart) {
+        int nextLineStart = nextLineStart(text, fenceLineStart);
+        int search = nextLineStart;
+        while (search < text.length()) {
+            if (isCodeFenceLineStart(text, search)) {
+                // 닫는 펜스 줄 끝까지만 포함하고 뒤 개행은 문장 사이 공백으로 남긴다.
+                return lineEnd(text, search);
+            }
+            search = nextLineStart(text, search);
+        }
+        return text.length();
+    }
+
+    private static int codeFenceMarkerIndex(String text, int lineStart) {
+        int index = lineStart;
+        while (index < text.length()) {
+            char ch = text.charAt(index);
+            if (ch == ' ' || ch == '\t') {
+                index++;
+                continue;
+            }
+            break;
+        }
+        return startsWith(text, index, "```") ? index : -1;
+    }
+
+    private static int lineEnd(String text, int index) {
+        int lineEnd = index;
+        while (lineEnd < text.length() && !isLineBreak(text.charAt(lineEnd))) {
+            lineEnd++;
+        }
+        return lineEnd;
+    }
+
+    private static int nextLineStart(String text, int index) {
+        int lineEnd = lineEnd(text, index);
+        if (lineEnd >= text.length()) {
+            return text.length();
+        }
+        if (text.charAt(lineEnd) == '\r' && lineEnd + 1 < text.length() && text.charAt(lineEnd + 1) == '\n') {
+            return lineEnd + 2;
+        }
+        return lineEnd + 1;
+    }
+
+    private static int lineStart(String text, int index) {
+        int lineStart = index;
+        while (lineStart > 0 && !isLineBreak(text.charAt(lineStart - 1))) {
+            lineStart--;
+        }
+        return lineStart;
+    }
+
+    private static boolean isAtLineStart(String text, int index) {
+        return index == 0 || isLineBreak(text.charAt(index - 1));
+    }
+
+    private static boolean isNumberedListMarker(String text, int dotIndex) {
+        char afterDot = nextChar(text, dotIndex + 1);
+        if (afterDot != '\0' && !Character.isWhitespace(afterDot)) {
+            return false;
+        }
+
+        int markerStart = listMarkerStart(text, dotIndex);
+        if (markerStart < 0) {
+            return false;
+        }
+
+        if (isKoreanOrdinalMarker(text, markerStart, dotIndex)) {
+            return true;
+        }
+
+        if (!Character.isDigit(text.charAt(markerStart))) {
+            return false;
+        }
+
+        for (int i = markerStart; i < dotIndex; i++) {
+            if (!Character.isDigit(text.charAt(i))) {
+                return false;
+            }
+        }
+        return markerStart < dotIndex;
+    }
+
+    private static int listMarkerStart(String text, int dotIndex) {
+        int index = lineStart(text, dotIndex);
+        index = skipHorizontalWhitespace(text, index);
+
+        while (index < dotIndex && isMarkdownListQuoteMarker(text.charAt(index))) {
+            int afterMarker = index + 1;
+            if (afterMarker >= dotIndex || !isHorizontalWhitespace(text.charAt(afterMarker))) {
+                break;
+            }
+            // 줄 시작 불릿/인용 접두어 뒤 공백은 목록번호의 시각적 들여쓰기라서 같은 패턴으로 본다.
+            index = skipHorizontalWhitespace(text, afterMarker);
+        }
+
+        return index < dotIndex ? index : -1;
+    }
+
+    private static boolean isKoreanOrdinalMarker(String text, int markerStart, int dotIndex) {
+        if (text.charAt(markerStart) != '제' || markerStart + 1 >= dotIndex) {
+            return false;
+        }
+
+        for (int i = markerStart + 1; i < dotIndex; i++) {
+            if (!Character.isDigit(text.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isMarkdownListQuoteMarker(char ch) {
+        return ch == '-' || ch == '*' || ch == '>';
+    }
+
+    private static boolean isAbbreviation(String text, int dotIndex) {
+        int start = dotIndex - 1;
+        while (start >= 0) {
+            char ch = text.charAt(start);
+            if (isLatinLetter(ch) || ch == '.') {
+                start--;
+                continue;
+            }
+            break;
+        }
+
+        String token = text.substring(start + 1, dotIndex).toLowerCase(Locale.ROOT);
+        if (token.isEmpty()) {
+            return false;
+        }
+
+        return ABBREVIATIONS.contains(token) || ABBREVIATIONS.contains(token + ".");
+    }
+
+    private static boolean isKoreanSentenceEnding(char ch) {
+        return ch == '다' || ch == '요' || ch == '까' || ch == '죠' || ch == '음'
+                || ch == '임' || ch == '함' || ch == '네' || ch == '오' || ch == '쇼';
+    }
+
+    private static boolean isSafeNoSpaceNext(char ch) {
+        if (ch == '\0' || isLineBreak(ch) || isOpeningQuoteOrBracket(ch)) {
+            return true;
+        }
+        return isHangulSyllable(ch);
+    }
+
+    private static boolean isOpeningQuoteOrBracket(char ch) {
+        return ch == '"' || ch == '\'' || ch == '「' || ch == '『' || ch == '(' || ch == '[' || ch == '《';
+    }
+
+    private static boolean isHangulSyllable(char ch) {
+        return ch >= '가' && ch <= '힣';
+    }
+
+    private static boolean isLatinLetter(char ch) {
+        return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
+    }
+
+    private static boolean isFollowedByQuoteParticle(String text, int start) {
+        int index = start;
+        while (index < text.length() && isHorizontalWhitespace(text.charAt(index))) {
+            index++;
+        }
+
+        for (String particle : QUOTE_PARTICLES) {
+            if (startsWith(text, index, particle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int skipHorizontalWhitespace(String text, int start) {
+        int index = start;
+        while (index < text.length() && isHorizontalWhitespace(text.charAt(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private static boolean isHorizontalWhitespace(char ch) {
+        return ch == ' ' || ch == '\t';
+    }
+
+    private static boolean startsWith(String text, int start, String prefix) {
+        return start >= 0 && start + prefix.length() <= text.length()
+                && text.regionMatches(start, prefix, 0, prefix.length());
+    }
+
+    private static char previousChar(String text, int index) {
+        return index > 0 ? text.charAt(index - 1) : '\0';
+    }
+
+    private static char nextChar(String text, int index) {
+        return index < text.length() ? text.charAt(index) : '\0';
+    }
+
+    private record SentenceBoundary(boolean boundary, int endIndex) {
+    }
+
+    private record LineBreakRun(int count, int endIndex) {
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
@@ -131,7 +131,8 @@ public final class EgovKoreanSentenceSupport {
             boundary = isKoreanSentenceEnding(previous) && followedByBreak;
         } else {
             // 물음표·느낌표는 다른 표기로 쓰이지 않아 뒤에 공백·개행·문서 끝이 오면 경계로 본다.
-            boundary = followedByBreak;
+            // 다만 같은 줄에서 아직 닫히지 않은 마크다운 링크·이미지 안이면 토큰 중간이므로 제외한다.
+            boundary = followedByBreak && !isInsideUnclosedInlineMarkup(text, terminatorStart);
         }
 
         // 인용문을 닫은 뒤 같은 줄에 한국어가 이어지면 인용을 받는 문장 성분(라고 말했다)이므로 자르지 않는다.
@@ -146,6 +147,32 @@ public final class EgovKoreanSentenceSupport {
         }
 
         return new SentenceBoundary(boundary, boundaryEnd);
+    }
+
+    // 닫는 펜스에는 정보문자열이 올 수 없다(CommonMark). 마커 뒤에 수평공백만 있는 줄만 닫는 펜스로 본다.
+    private static boolean isBlankAfterFenceMarker(String text, int lineStart, CodeFence fence) {
+        int index = skipHorizontalWhitespace(text, lineStart) + fence.length();
+        index = skipHorizontalWhitespace(text, index);
+        return index >= text.length() || isLineBreak(text.charAt(index));
+    }
+
+    // 같은 줄 앞쪽에 닫히지 않은 [ 또는 ( 가 있으면 마크다운 링크·이미지 표기 안이다.
+    private static boolean isInsideUnclosedInlineMarkup(String text, int index) {
+        int bracket = 0;
+        int paren = 0;
+        for (int i = lineStart(text, index); i < index; i++) {
+            char ch = text.charAt(i);
+            if (ch == '[') {
+                bracket++;
+            } else if (ch == ']' && bracket > 0) {
+                bracket--;
+            } else if (ch == '(') {
+                paren++;
+            } else if (ch == ')' && paren > 0) {
+                paren--;
+            }
+        }
+        return bracket > 0 || paren > 0;
     }
 
     private static void addSentenceSpan(List<SentenceSpan> spans, String text, int start, int end) {
@@ -248,7 +275,8 @@ public final class EgovKoreanSentenceSupport {
         while (search < text.length()) {
             CodeFence closing = codeFenceAt(text, search);
             // 닫는 펜스는 여는 펜스와 같은 문자이고 길이가 같거나 길어야 한다(네 겹 백틱 블록의 조기 종료 방지).
-            if (closing != null && closing.marker() == opening.marker() && closing.length() >= opening.length()) {
+            if (closing != null && closing.marker() == opening.marker() && closing.length() >= opening.length()
+                    && isBlankAfterFenceMarker(text, search, closing)) {
                 // 닫는 펜스 줄 끝까지만 포함하고 뒤 개행은 문장 사이 공백으로 남긴다.
                 return lineEnd(text, search);
             }

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/util/EgovKoreanSentenceSupport.java
@@ -14,6 +14,10 @@ import java.util.List;
  * <p>경계를 놓치면 두 문장이 한 구간으로 남을 뿐이고, 청크는 원문 offset을 그대로 잘라내므로
  * 내용이 훼손되지 않는다. 반대로 경계를 잘못 만들면 문장이 중간에서 끊어지므로, 확신이 없는
  * 마침표는 자르지 않는다. LLM·외부 사전 없이 결정론적으로 동작한다.</p>
+ *
+ * <p>마침표 경계 판정은 한국어 종결어미 뒤에서만 동작하므로 영어 문장 끝 마침표는 경계로 보지 않는다.
+ * 영어 문장과 뒤따르는 한국어 문장은 한 구간으로 남고, 영어 비중이 높은 문서는 구간이 길어질 수 있다.
+ * 이는 약어·소수점 오분리를 피하기 위한 의도된 제약이며, 이런 문서에는 기존 splitter가 더 적합하다.</p>
  */
 public final class EgovKoreanSentenceSupport {
 
@@ -318,7 +322,7 @@ public final class EgovKoreanSentenceSupport {
 
     private static boolean isKoreanSentenceEnding(char ch) {
         return ch == '다' || ch == '요' || ch == '까' || ch == '죠' || ch == '음'
-                || ch == '임' || ch == '함' || ch == '네' || ch == '오' || ch == '쇼';
+                || ch == '임' || ch == '함' || ch == '네' || ch == '오';
     }
 
     private static boolean isSafeNoSpaceNext(char ch) {

--- a/spring-ai-rag-redis-stack/src/main/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/main/resources/application.yml
@@ -66,6 +66,7 @@ spring:
       chunking:
         korean-sentence:
           # 활성화 여부. false(기본)이면 기존 TokenTextSplitter 방식만 사용 (기존 동작 유지)
+          # 한국어가 위주인 문서에서 효과적이며, 영어 비중이 높은 문서에는 적합하지 않을 수 있음
           enabled: false
 
       # 최소 청크 크기 (문자 단위)

--- a/spring-ai-rag-redis-stack/src/main/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/main/resources/application.yml
@@ -62,6 +62,12 @@ spring:
       # 청크 크기 설정 (토큰 단위)
       chunk-size: 4000
 
+      # 한국어 문장경계 인지 청킹 설정
+      chunking:
+        korean-sentence:
+          # 활성화 여부. false(기본)이면 기존 TokenTextSplitter 방식만 사용 (기존 동작 유지)
+          enabled: false
+
       # 최소 청크 크기 (문자 단위)
       min-chunk-size-chars: 350
 

--- a/spring-ai-rag-redis-stack/src/main/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/main/resources/application.yml
@@ -67,6 +67,8 @@ spring:
         korean-sentence:
           # 활성화 여부. false(기본)이면 기존 TokenTextSplitter 방식만 사용 (기존 동작 유지)
           # 한국어가 위주인 문서에서 효과적이며, 영어 비중이 높은 문서에는 적합하지 않을 수 있음
+          # 빈 줄(연속 개행) 기준 문단 경계까지 쓰려면 위 normalization.normalize-newlines 를 false 로 둔다.
+          # true(기본)이면 연속 개행이 1개로 축약되어 빈 줄 경계는 동작하지 않고, 마크다운 블록·코드펜스 경계만 적용된다.
           enabled: false
 
       # 최소 청크 크기 (문자 단위)

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/EgovKoreanChunkingToggleTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/EgovKoreanChunkingToggleTest.java
@@ -1,0 +1,102 @@
+package com.example.chat.config.etl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.example.chat.config.etl.transformers.EgovEnhancedDocumentTransformer;
+import com.example.chat.config.etl.transformers.EgovKoreanSentenceSplitter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.ollama.OllamaChatModel;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.ai.transformer.splitter.TokenTextSplitter;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * 한국어 문장경계 인지 청킹 토글 동작을 검증한다.
+ */
+class EgovKoreanChunkingToggleTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(EgovKoreanChunkingConfig.class);
+
+    @Test
+    @DisplayName("토글 off(기본): 한국어 문장경계 splitter 빈 미등록")
+    void koreanSentenceSplitterAbsentWhenDisabled() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean("koreanSentenceTextSplitter");
+            assertThat(context).doesNotHaveBean(EgovKoreanSentenceSplitter.class);
+        });
+    }
+
+    @Test
+    @DisplayName("토글 on: 한국어 문장경계 splitter 빈 등록")
+    void koreanSentenceSplitterPresentWhenEnabled() {
+        runner.withPropertyValues("spring.ai.document.chunking.korean-sentence.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasBean("koreanSentenceTextSplitter");
+            assertThat(context).hasSingleBean(EgovKoreanSentenceSplitter.class);
+            assertThat(context).getBean("koreanSentenceTextSplitter").isInstanceOf(EgovKoreanSentenceSplitter.class);
+        });
+    }
+
+    @Test
+    @DisplayName("한국어 splitter 빈 부재 시 기존 TokenTextSplitter 경로로 폴백한다")
+    void enhancedTransformerFallsBackToTokenTextSplitterWhenBeanAbsent() {
+        EgovEnhancedDocumentTransformer transformer = new EgovEnhancedDocumentTransformer(
+                ollamaChatModel(), emptyKoreanSentenceSplitterProvider());
+        setDocumentOptions(transformer, 30, 10, 0, 100);
+        ReflectionTestUtils.setField(transformer, "enableSummary", false);
+        ReflectionTestUtils.setField(transformer, "summaryMinChunks", 2);
+        ReflectionTestUtils.setField(transformer, "enableKeywords", false);
+        ReflectionTestUtils.setField(transformer, "keywordCount", 5);
+
+        Document document = new Document(
+                "전자정부 표준프레임워크 문서입니다. 기존 TokenTextSplitter 경로를 검증합니다. 폴백 결과가 같아야 합니다.");
+        List<Document> documents = List.of(document);
+        TokenTextSplitter tokenTextSplitter = new TokenTextSplitter(30, 10, 0, 100, true);
+
+        List<String> expected = tokenTextSplitter.apply(documents).stream()
+                .map(Document::getText)
+                .collect(Collectors.toList());
+        List<String> actual = transformer.apply(documents).stream()
+                .map(Document::getText)
+                .collect(Collectors.toList());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private ObjectProvider<EgovKoreanSentenceSplitter> emptyKoreanSentenceSplitterProvider() {
+        return new ObjectProvider<>() {
+            @Override
+            public EgovKoreanSentenceSplitter getObject() {
+                return null;
+            }
+
+            @Override
+            public EgovKoreanSentenceSplitter getIfAvailable() {
+                return null;
+            }
+        };
+    }
+
+    private OllamaChatModel ollamaChatModel() {
+        return OllamaChatModel.builder()
+                .ollamaApi(OllamaApi.builder().baseUrl("http://localhost:1").build())
+                .build();
+    }
+
+    private void setDocumentOptions(EgovEnhancedDocumentTransformer transformer, int chunkSize,
+            int minChunkSizeChars, int minChunkLengthToEmbed, int maxNumChunks) {
+        ReflectionTestUtils.setField(transformer, "chunkSize", chunkSize);
+        ReflectionTestUtils.setField(transformer, "minChunkSizeChars", minChunkSizeChars);
+        ReflectionTestUtils.setField(transformer, "minChunkLengthToEmbed", minChunkLengthToEmbed);
+        ReflectionTestUtils.setField(transformer, "maxNumChunks", maxNumChunks);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -1,0 +1,196 @@
+package com.example.chat.config.etl.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+/**
+ * {@link EgovKoreanSentenceSplitter} 단위 테스트.
+ */
+class EgovKoreanSentenceSplitterTest {
+
+    private static final Encoding ENCODING = Encodings.newLazyEncodingRegistry()
+            .getEncoding(EncodingType.CL100K_BASE);
+    private static final Pattern SENTENCE_ENDING = Pattern.compile(
+            ".*([.!?。！？][\"'」』)\\]》]?|다|요|니다|습니다|한다|된다)$");
+
+    @Test
+    @DisplayName("청크의 토큰 수가 chunkSize 이하다")
+    void chunksDoNotExceedTokenLimit() {
+        int chunkSize = 30;
+        EgovKoreanSentenceSplitter splitter = splitter(chunkSize);
+        String text = "첫 문장입니다. 둘째 문장입니다. 셋째 문장입니다. 넷째 문장입니다. 다섯째 문장입니다.";
+
+        List<String> chunks = splitter.splitText(text);
+
+        assertThat(chunks).isNotEmpty();
+        assertThat(chunks).allSatisfy(chunk -> assertThat(countTokens(chunk)).isLessThanOrEqualTo(chunkSize));
+    }
+
+    @Test
+    @DisplayName("문장 중간에서 청크가 끝나지 않는다")
+    void chunksEndAtSentenceBoundary() {
+        EgovKoreanSentenceSplitter splitter = splitter(30);
+        String text = "첫 번째 문장입니다. 두 번째 문장입니다! 세 번째 문장입니다? 마지막 문장입니다.";
+
+        List<String> chunks = splitter.splitText(text);
+
+        assertThat(chunks).isNotEmpty();
+        assertThat(chunks).allSatisfy(chunk -> assertThat(SENTENCE_ENDING.matcher(chunk).matches()).isTrue());
+    }
+
+    @Test
+    @DisplayName("초장문 단일 문장은 기존 TokenTextSplitter 폴백으로 분할한다")
+    void longSingleSentenceFallsBackToSuperSplitter() {
+        int chunkSize = 30;
+        EgovKoreanSentenceSplitter splitter = splitter(chunkSize);
+        String text = "전자정부표준프레임워크문서청킹검증".repeat(80);
+
+        List<String> chunks = splitter.splitText(text);
+
+        assertThat(chunks).hasSizeGreaterThan(1);
+        assertThat(chunks).allSatisfy(chunk -> assertThat(countTokens(chunk)).isLessThanOrEqualTo(chunkSize));
+    }
+
+    @Test
+    @DisplayName("apply 경로에서 Document metadata를 보존한다")
+    void applyPreservesDocumentMetadata() {
+        EgovKoreanSentenceSplitter splitter = splitter(30);
+        Document document = new Document("문서 첫 문장입니다. 문서 두 번째 문장입니다.",
+                Map.of("id", "doc-1", "file_name", "guide.md"));
+
+        List<Document> chunks = splitter.apply(List.of(document));
+
+        assertThat(chunks).isNotEmpty();
+        assertThat(chunks).allSatisfy(chunk -> assertThat(chunk.getMetadata())
+                .containsEntry("id", "doc-1")
+                .containsEntry("file_name", "guide.md"));
+    }
+
+    @Test
+    @DisplayName("같은 입력은 항상 같은 결과를 반환한다")
+    void deterministicForSameInput() {
+        EgovKoreanSentenceSplitter splitter = splitter(30);
+        String text = "결정론을 검증합니다. 같은 입력은 같은 청크가 됩니다. 순서도 유지됩니다.";
+
+        List<String> first = splitter.splitText(text);
+        List<String> second = splitter.splitText(text);
+
+        assertThat(second).isEqualTo(first);
+    }
+
+    @Test
+    @DisplayName("빈 텍스트 입력은 빈 결과를 반환한다")
+    void blankTextReturnsEmptyResult() {
+        EgovKoreanSentenceSplitter splitter = splitter(30);
+
+        assertThat(splitter.splitText(null)).isEmpty();
+        assertThat(splitter.splitText(" \n\t ")).isEmpty();
+        assertThat(splitter.apply(List.of(new Document(" \n\t ")))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("minChunkLengthToEmbed 미만 청크는 버린다")
+    void discardsChunksBelowMinimumLengthToEmbed() {
+        EgovKoreanSentenceSplitter splitter = new EgovKoreanSentenceSplitter(30, 10, 50, 100, true);
+
+        List<String> chunks = splitter.splitText("짧습니다. 작습니다.");
+
+        assertThat(chunks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("큰 chunkSize 에서는 마크다운 원문 byte 구조를 그대로 보존한다")
+    void preservesOriginalMarkdownBytesWithLargeChunkSize() {
+        String text = markdownFixture();
+        EgovKoreanSentenceSplitter splitter = splitter(5000);
+
+        List<String> chunks = splitter.splitText(text);
+
+        assertThat(chunks).isNotEmpty();
+        assertOriginalSubstrings(text, chunks);
+        assertThat(chunks)
+                .anySatisfy(chunk -> {
+                    assertThat(chunk).contains("# 처리 기준");
+                    assertThat(chunk).contains("## 상세 기준");
+                    assertThat(chunk).contains("\n\n");
+                    assertThat(chunk).contains("\n| 항목 | 기본값 |");
+                    assertThat(chunk).contains("""
+                            ```java
+                            // 주석. 끝
+                            int value = 1;
+                            ```""");
+                    assertThat(chunk).contains("\"즉시 조치한다.\"라고 말했다.");
+                });
+        assertThat(chunks).allSatisfy(chunk -> {
+            assertThat(chunk).doesNotStartWith("라고");
+            assertThat(chunk).doesNotStartWith("라며");
+        });
+    }
+
+    @Test
+    @DisplayName("작은 chunkSize 에서도 폴백 없는 청크는 원문 substring 으로 만든다")
+    void preservesOriginalSubstringsWithSmallChunkSize() {
+        String text = markdownFixture();
+        EgovKoreanSentenceSplitter splitter = splitter(90);
+
+        List<String> chunks = splitter.splitText(text);
+
+        assertThat(chunks).hasSizeGreaterThan(1);
+        assertOriginalSubstrings(text, chunks);
+        assertThat(chunks).allSatisfy(chunk -> {
+            assertThat(chunk).doesNotStartWith("라고");
+            assertThat(chunk).doesNotStartWith("라며");
+        });
+    }
+
+    private EgovKoreanSentenceSplitter splitter(int chunkSize) {
+        return new EgovKoreanSentenceSplitter(chunkSize, 10, 0, 100, true);
+    }
+
+    private static int countTokens(String text) {
+        return ENCODING.countTokens(text);
+    }
+
+    private void assertOriginalSubstrings(String source, List<String> chunks) {
+        for (String chunk : chunks) {
+            assertThat(source).contains(chunk);
+        }
+    }
+
+    private String markdownFixture() {
+        return """
+                # 처리 기준
+
+                ## 상세 기준
+
+                담당자는 "즉시 조치한다."라고 말했다. 이 규정은 제3조제1항. 다음 조항을 따른다.
+
+                1. 신청서 제출
+                2. 접수 확인
+
+                | 항목 | 기본값 |
+                | --- | --- |
+                | chunk | 500 |
+                | overlap | 50 |
+                | parser | markdown |
+
+                ```java
+                // 주석. 끝
+                int value = 1;
+                ```
+
+                날짜는 2026. 7. 30. 기준입니다. 담당자는 A. B. 홍길동입니다.
+                수치는 3.14이고 No. 1 양식을 따른다. 마지막 문장입니다.""";
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -1,7 +1,9 @@
 package com.example.chat.config.etl.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -248,5 +250,22 @@ class EgovKoreanSentenceSplitterTest {
             }
         }
         return false;
+    }
+
+    @Test
+    @DisplayName("보충면 문자와 작은 청크 크기 조합에서도 유한 시간에 끝난다")
+    void terminatesForSupplementaryCharactersWithTinyChunkSize() {
+        String text = "\uD840\uDC0B\uD842\uDF9F".repeat(120);
+
+        for (int chunkSize : new int[] {1, 2, 3, 20}) {
+            assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+                List<String> chunks = splitter(chunkSize).split(List.of(new Document(text))).stream()
+                        .map(Document::getText)
+                        .toList();
+                assertThat(chunks).isNotEmpty();
+                assertThat(chunks).hasSizeLessThanOrEqualTo(text.length());
+                assertThat(chunks).allSatisfy(chunk -> assertThat(text).contains(chunk));
+            });
+        }
     }
 }

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -268,4 +268,25 @@ class EgovKoreanSentenceSplitterTest {
             });
         }
     }
+
+    @Test
+    @DisplayName("청크 크기가 보충면 문자 하나보다 작으면 코드포인트 하나를 그대로 내보낸다")
+    void emitsSingleCodePointWhenChunkSizeIsSmallerThanOneCharacter() {
+        String text = "\uD840\uDC0B\uD842\uDF9F".repeat(20);
+
+        for (int chunkSize : new int[] {1, 2}) {
+            List<String> chunks = splitter(chunkSize).split(List.of(new Document(text))).stream()
+                    .map(Document::getText)
+                    .toList();
+
+            assertThat(chunks).isNotEmpty();
+            // 보충면 문자 하나는 UTF-16 두 글자, CL100K 기준 세 토큰이므로 한도를 지킬 창이 없다.
+            // 분할이 끝나도록 코드포인트 하나를 내보내고, 그 결과 토큰 수가 한도를 넘는다.
+            assertThat(chunks).allSatisfy(chunk -> {
+                assertThat(text).contains(chunk);
+                assertThat(chunk.codePointCount(0, chunk.length())).isEqualTo(1);
+                assertThat(countTokens(chunk)).isGreaterThan(chunkSize);
+            });
+        }
+    }
 }

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -193,4 +193,27 @@ class EgovKoreanSentenceSplitterTest {
                 날짜는 2026. 7. 30. 기준입니다. 담당자는 A. B. 홍길동입니다.
                 수치는 3.14이고 No. 1 양식을 따른다. 마지막 문장입니다.""";
     }
+
+    @Test
+    @DisplayName("토큰 한도를 넘는 구간도 원문 부분문자열로 잘라 나눈다")
+    void keepsOriginalSubstringForOversizedSpan() {
+        StringBuilder code = new StringBuilder("```java\n");
+        for (int i = 0; i < 60; i++) {
+            code.append("    public void method").append(i).append("() {\n")
+                    .append("        int value = ").append(i).append("; // 주석\n    }\n");
+        }
+        code.append("```\n");
+        String text = code.toString();
+        int chunkSize = 60;
+
+        List<String> chunks = splitter(chunkSize).split(List.of(new Document(text))).stream()
+                .map(Document::getText)
+                .toList();
+
+        assertThat(chunks).isNotEmpty();
+        assertThat(chunks).allSatisfy(chunk -> {
+            assertThat(text).contains(chunk);
+            assertThat(countTokens(chunk)).isLessThanOrEqualTo(chunkSize);
+        });
+    }
 }

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovKoreanSentenceSplitterTest.java
@@ -216,4 +216,37 @@ class EgovKoreanSentenceSplitterTest {
             assertThat(countTokens(chunk)).isLessThanOrEqualTo(chunkSize);
         });
     }
+
+    @Test
+    @DisplayName("보충면 문자를 코드포인트 경계에서 잘라 짝 잃은 문자를 남기지 않는다")
+    void doesNotSplitSurrogatePairs() {
+        String text = "\uD840\uDC0B\uD842\uDF9F".repeat(120);
+        int chunkSize = 40;
+
+        List<String> chunks = splitter(chunkSize).split(List.of(new Document(text))).stream()
+                .map(Document::getText)
+                .toList();
+
+        assertThat(chunks).isNotEmpty();
+        assertThat(chunks).allSatisfy(chunk -> {
+            assertThat(text).contains(chunk);
+            assertThat(hasUnpairedSurrogate(chunk)).isFalse();
+            assertThat(countTokens(chunk)).isLessThanOrEqualTo(chunkSize);
+        });
+    }
+
+    private static boolean hasUnpairedSurrogate(String text) {
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (Character.isHighSurrogate(ch)) {
+                if (i + 1 >= text.length() || !Character.isLowSurrogate(text.charAt(i + 1))) {
+                    return true;
+                }
+                i++;
+            } else if (Character.isLowSurrogate(ch)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
@@ -187,6 +187,27 @@ class EgovKoreanSentenceSupportTest {
     }
 
     @Test
+    @DisplayName("영어 문장 끝 마침표는 경계로 보지 않아 뒤따르는 한국어 문장과 한 구간으로 남는다")
+    void keepEnglishSentenceWithFollowingKoreanSentence() {
+        String text = "Spring Boot provides auto-configuration. 이를 통해 개발자는 설정을 최소화할 수 있습니다.";
+
+        assertThat(EgovKoreanSentenceSupport.splitSentences(text)).containsExactly(text);
+        assertThat(EgovKoreanSentenceSupport.splitSentences("Spring Boot provides auto-configuration. It reduces boilerplate."))
+                .containsExactly("Spring Boot provides auto-configuration. It reduces boilerplate.");
+    }
+
+    @Test
+    @DisplayName("영어 문장이 섞여도 빈 줄 문단 경계는 그대로 적용한다")
+    void splitEnglishMixedTextAtBlankLineBoundary() {
+        String text = "Spring Boot provides auto-configuration.\n\n이를 통해 개발자는 설정을 최소화할 수 있습니다.";
+
+        assertThat(EgovKoreanSentenceSupport.splitSentences(text)).containsExactly(
+                "Spring Boot provides auto-configuration.",
+                "이를 통해 개발자는 설정을 최소화할 수 있습니다."
+        );
+    }
+
+    @Test
     @DisplayName("null 또는 공백 입력은 빈 목록을 반환한다")
     void returnEmptyListForBlankInput() {
         assertThat(EgovKoreanSentenceSupport.splitSentences(null)).isEmpty();
@@ -207,7 +228,8 @@ class EgovKoreanSentenceSupportTest {
                 "첫 줄입니다\n이어지는 줄입니다.\n\n새 문단입니다.",
                 "# 제목\n본문입니다.",
                 "담당자는 \"즉시 조치한다.\"라고 말했다.",
-                "앞 문장입니다.\n```java\n// 주석. 끝\nint value = 1;\n```\n뒤 문장입니다."
+                "앞 문장입니다.\n```java\n// 주석. 끝\nint value = 1;\n```\n뒤 문장입니다.",
+                "Spring Boot provides auto-configuration. 이를 통해 개발자는 설정을 최소화할 수 있습니다."
         );
 
         for (String text : cases) {

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
@@ -25,6 +25,22 @@ class EgovKoreanSentenceSupportTest {
     }
 
     @Test
+    @DisplayName("날짜 표기·라틴 이니셜은 문장 파편으로 자르지 않는다")
+    void keepDateAndLatinInitialInSameSentence() {
+        assertThat(EgovKoreanSentenceSupport.splitSentences("회의는 2026. 7. 30. 개최한다. 참석자는 다음과 같다."))
+                .containsExactly("회의는 2026. 7. 30. 개최한다.", "참석자는 다음과 같다.");
+        assertThat(EgovKoreanSentenceSupport.splitSentences("담당자는 A. B. 홍길동입니다. 확인 바랍니다."))
+                .containsExactly("담당자는 A. B. 홍길동입니다.", "확인 바랍니다.");
+    }
+
+    @Test
+    @DisplayName("종결어미로 끝난 문장은 다음 문장이 종결어미와 같은 글자로 시작해도 분리한다")
+    void splitSentenceBeforeWordStartingWithEndingSyllable() {
+        assertThat(EgovKoreanSentenceSupport.splitSentences("보고서를 제출한다. 하고자 하는 업무는 별도로 정한다."))
+                .containsExactly("보고서를 제출한다.", "하고자 하는 업무는 별도로 정한다.");
+    }
+
+    @Test
     @DisplayName("소수점과 버전 표기는 문장 경계로 보지 않는다")
     void keepDecimalAndVersionInSameSentence() {
         String text = "값은 3.14입니다. 버전은 1.0.1입니다.";
@@ -60,18 +76,15 @@ class EgovKoreanSentenceSupportTest {
 
         List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
 
+        // 종결어미가 아닌 글자·숫자 뒤 마침표는 경계로 보지 않는다. 두 문장이 한 구간에 남아도
+        // 청크는 원문 offset을 잘라내므로 내용이 훼손되지 않는다.
         assertThat(sentences).containsExactly(
                 "1. 항목입니다.",
                 "- 2. 하위 항목입니다.",
                 "제1. 서수 항목입니다.",
-                "이 규정은 제3조제1항.",
-                "다음 조항을 따른다.",
-                "적용 범위는 제2조.",
-                "세부는 별표 참조.",
-                "총 금액은 100.",
-                "이는 부가세 별도다.",
-                "제2항.",
-                "설명입니다."
+                "이 규정은 제3조제1항. 다음 조항을 따른다.",
+                "적용 범위는 제2조. 세부는 별표 참조. 총 금액은 100. 이는 부가세 별도다.",
+                "제2항. 설명입니다."
         );
     }
 

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/util/EgovKoreanSentenceSupportTest.java
@@ -1,0 +1,209 @@
+package com.example.chat.util;
+
+import com.example.chat.util.EgovKoreanSentenceSupport.SentenceSpan;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link EgovKoreanSentenceSupport} 단위 테스트.
+ */
+class EgovKoreanSentenceSupportTest {
+
+    @Test
+    @DisplayName("종결부호로 한국어 문장을 분리한다")
+    void splitKoreanSentencesByTerminators() {
+        String text = "안녕하세요. 반갑습니다! 무엇일까요?";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("안녕하세요.", "반갑습니다!", "무엇일까요?");
+    }
+
+    @Test
+    @DisplayName("소수점과 버전 표기는 문장 경계로 보지 않는다")
+    void keepDecimalAndVersionInSameSentence() {
+        String text = "값은 3.14입니다. 버전은 1.0.1입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("값은 3.14입니다.", "버전은 1.0.1입니다.");
+    }
+
+    @Test
+    @DisplayName("라틴 약어 뒤 마침표는 문장 경계로 보지 않는다")
+    void keepAbbreviationsInSameSentence() {
+        String text = "번호는 No. 1입니다. 기타 etc. 항목입니다. 예: e.g. 형식입니다. 지역은 U.S. 기준입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly(
+                "번호는 No. 1입니다.",
+                "기타 etc. 항목입니다.",
+                "예: e.g. 형식입니다.",
+                "지역은 U.S. 기준입니다."
+        );
+    }
+
+    @Test
+    @DisplayName("줄 시작 목록 번호와 제+숫자 표기만 문장 경계로 보지 않는다")
+    void keepNumberedListMarkersInSameSentence() {
+        String text = """
+                1. 항목입니다.
+                  - 2. 하위 항목입니다.
+                제1. 서수 항목입니다.
+                이 규정은 제3조제1항. 다음 조항을 따른다. 적용 범위는 제2조. 세부는 별표 참조. 총 금액은 100. 이는 부가세 별도다. 제2항. 설명입니다.""";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly(
+                "1. 항목입니다.",
+                "- 2. 하위 항목입니다.",
+                "제1. 서수 항목입니다.",
+                "이 규정은 제3조제1항.",
+                "다음 조항을 따른다.",
+                "적용 범위는 제2조.",
+                "세부는 별표 참조.",
+                "총 금액은 100.",
+                "이는 부가세 별도다.",
+                "제2항.",
+                "설명입니다."
+        );
+    }
+
+    @Test
+    @DisplayName("연속 마침표는 하나의 경계만 만들고 빈 문장을 만들지 않는다")
+    void keepTerminatorRunTogether() {
+        String text = "끝났다... 다음";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("끝났다...", "다음");
+        assertThat(sentences).doesNotContain("");
+    }
+
+    @Test
+    @DisplayName("공백 없는 한국어 종결어미 뒤 문장을 분리한다")
+    void splitNoSpaceAfterKoreanEnding() {
+        String text = "처리를 완료합니다.다음 문장입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("처리를 완료합니다.", "다음 문장입니다.");
+    }
+
+    @Test
+    @DisplayName("빈 줄은 경계이고 하드랩 단일 개행은 경계가 아니다")
+    void splitBlankLineButKeepHardWrappedLine() {
+        String text = "첫 줄입니다\n이어지는 줄입니다.\n\n새 문단입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("첫 줄입니다\n이어지는 줄입니다.", "새 문단입니다.");
+    }
+
+    @Test
+    @DisplayName("마크다운 제목 줄은 본문과 분리한다")
+    void splitMarkdownHeadingLine() {
+        String text = "# 제목\n본문입니다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly("# 제목", "본문입니다.");
+    }
+
+    @Test
+    @DisplayName("문장 구간은 오름차순이고 구간 사이에는 공백만 남는다")
+    void splitSentenceSpansKeepOrderedWhitespaceOnlyGaps() {
+        String text = "  # 제목\n본문입니다.\n\n담당자는 \"즉시 조치한다.\"라고 말했다.\n```java\n// 주석. 끝\n```\n마지막입니다.  ";
+
+        List<SentenceSpan> spans = EgovKoreanSentenceSupport.splitSentenceSpans(text);
+        List<String> spanTexts = new ArrayList<>();
+
+        assertThat(spans).isNotEmpty();
+        assertThat(text.substring(0, spans.get(0).start()).trim()).isEmpty();
+        for (int i = 0; i < spans.size(); i++) {
+            SentenceSpan span = spans.get(i);
+            assertThat(span.start()).isLessThan(span.end());
+            spanTexts.add(text.substring(span.start(), span.end()));
+            if (i + 1 < spans.size()) {
+                SentenceSpan next = spans.get(i + 1);
+                assertThat(span.end()).isLessThanOrEqualTo(next.start());
+                assertThat(text.substring(span.end(), next.start()).trim()).isEmpty();
+            }
+        }
+        assertThat(text.substring(spans.get(spans.size() - 1).end()).trim()).isEmpty();
+        assertThat(EgovKoreanSentenceSupport.splitSentences(text)).isEqualTo(spanTexts);
+    }
+
+    @Test
+    @DisplayName("인용문 뒤 조사는 같은 문장으로 유지하고 실제 다음 문장은 분리한다")
+    void keepQuoteParticlesWithQuotedSentence() {
+        String text = "담당자는 \"즉시 조치한다.\"라고 말했다. 다음 담당자는 \"교체한다.\" 라며 보고했다.";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly(
+                "담당자는 \"즉시 조치한다.\"라고 말했다.",
+                "다음 담당자는 \"교체한다.\" 라며 보고했다."
+        );
+    }
+
+    @Test
+    @DisplayName("코드펜스 내부 문장부호는 분리하지 않고 앞뒤 산문만 분리한다")
+    void keepCodeFenceBlockAsSingleSpan() {
+        String text = """
+                앞 문장입니다.
+                ```java
+                // 주석. 끝
+                int value = 1;
+                ```
+                뒤 문장입니다.""";
+
+        List<String> sentences = EgovKoreanSentenceSupport.splitSentences(text);
+
+        assertThat(sentences).containsExactly(
+                "앞 문장입니다.",
+                "```java\n// 주석. 끝\nint value = 1;\n```",
+                "뒤 문장입니다."
+        );
+    }
+
+    @Test
+    @DisplayName("null 또는 공백 입력은 빈 목록을 반환한다")
+    void returnEmptyListForBlankInput() {
+        assertThat(EgovKoreanSentenceSupport.splitSentences(null)).isEmpty();
+        assertThat(EgovKoreanSentenceSupport.splitSentences(" \n\t ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("분리한 문장은 공백 제거 기준으로 원문을 무손실 재구성한다")
+    void splitSentencesAreLosslessIgnoringWhitespace() {
+        List<String> cases = List.of(
+                "안녕하세요. 반갑습니다! 무엇일까요?",
+                "값은 3.14입니다. 버전은 1.0.1입니다.",
+                "번호는 No. 1입니다. 기타 etc. 항목입니다. 예: e.g. 형식입니다. 지역은 U.S. 기준입니다.",
+                "1. 항목입니다.\n  - 2. 하위 항목입니다.\n제1. 서수 항목입니다.",
+                "이 규정은 제3조제1항. 다음 조항을 따른다. 적용 범위는 제2조. 세부는 별표 참조. 총 금액은 100. 이는 부가세 별도다.",
+                "끝났다... 다음",
+                "처리를 완료합니다.다음 문장입니다.",
+                "첫 줄입니다\n이어지는 줄입니다.\n\n새 문단입니다.",
+                "# 제목\n본문입니다.",
+                "담당자는 \"즉시 조치한다.\"라고 말했다.",
+                "앞 문장입니다.\n```java\n// 주석. 끝\nint value = 1;\n```\n뒤 문장입니다."
+        );
+
+        for (String text : cases) {
+            String rebuilt = String.join("", EgovKoreanSentenceSupport.splitSentences(text));
+            assertThat(removeWhitespace(rebuilt)).isEqualTo(removeWhitespace(text));
+        }
+    }
+
+    private String removeWhitespace(String text) {
+        return text.replaceAll("\\s+", "");
+    }
+}


### PR DESCRIPTION
## 변경 이유

Issue #71에서 제안한 한국어 문장경계 인지 청킹을 구현했습니다. 두 모듈의 현재 분할은 spring-ai가 `TokenTextSplitter`, langchain4j가 `DocumentSplitters.recursive`로 토큰·문자 길이만 보고 자르기 때문에 문장 중간에서 청크가 끊어집니다. 두 방식은 청크를 재조립하는 과정에서 원문의 공백을 개행으로 바꾸므로 검색으로 받은 청크를 원문에서 그대로 찾을 수 없습니다.

Issue #71 코멘트로 주신 지시 두 건을 반영했습니다. 첫째, 두 모듈이 독립 Maven 프로젝트라 공용 유틸을 뽑을 수 없으므로 `EgovInjectionGuard`(#62)와 같이 각 모듈에 같은 내용으로 독립 구현했습니다. 두 파일은 md5가 동일하고 모듈 간 import는 없습니다. 둘째, 머지된 `EgovRetrievalRecallPoCTest`를 재사용해 기존 splitter와 비교한 결과를 아래 "측정 결과와 한계"에 실었습니다.

기본값은 OFF입니다. 프로퍼티를 켜지 않으면 기존 분할 경로가 그대로 동작하므로 회귀 여지를 남기지 않았습니다.

## 변경 내용

두 모듈에 한국어 문장경계 인지 splitter를 추가했습니다. 모듈별 파일은 다음과 같습니다.

langchain4j-ai-rag-postgre
- 신설 `util/EgovKoreanSentenceSupport.java` — 문장 경계 검출 유틸. 종결어미와 종결부호를 보고 경계를 판정합니다. 자르는 위치는 코드포인트 경계로 맞춥니다.
- 신설 `config/etl/transformers/EgovKoreanSentenceSplitter.java` — langchain4j `DocumentSplitter` 구현. 원문 offset을 잘라 청크를 만들고 한도는 문자 수로 판정합니다.
- 신설 `config/etl/EgovKoreanChunkingConfig.java` — `document.chunking.korean-sentence.enabled=true`일 때만 빈을 등록하는 `@ConditionalOnProperty` 게이트. 오버랩 기본값을 여기서 계산합니다.
- 수정 `config/etl/transformers/EgovEnhancedDocumentTransformer.java` — 생성자에 `ObjectProvider<EgovKoreanSentenceSplitter>`를 받아 빈이 있으면 쓰고 없으면 기존 `DocumentSplitters.recursive`를 그대로 씁니다.
- 수정 `src/main/resources/application.yml` — `document.chunking.korean-sentence.enabled: false`와 오버랩 옵션 주석을 추가했습니다.
- 수정 `eval/EgovRetrievalRecallPoCTest.java` — 비교 테스트가 코퍼스·QA 시드·recall 계산을 재사용하도록 선언 9곳의 `private`를 떼어 패키지 전용으로 넓혔습니다. 로직과 코퍼스는 손대지 않았습니다.

spring-ai-rag-redis-stack
- 신설 `util/EgovKoreanSentenceSupport.java`·`config/etl/transformers/EgovKoreanSentenceSplitter.java`·`config/etl/EgovKoreanChunkingConfig.java` — langchain4j 쪽과 같은 구성입니다. 유틸은 내용이 같습니다. 분할기는 기존 `TokenTextSplitter`를 상속해 한도를 같은 토큰 수로 판정합니다. 게이트 프로퍼티는 `spring.ai.document.chunking.korean-sentence.enabled`입니다.
- 수정 `config/etl/EgovETLPipelineConfig.java`·`config/etl/transformers/EgovEnhancedDocumentTransformer.java` — 같은 `ObjectProvider` 폴백 배선을 넣었습니다. transformer의 파일 끝 개행 누락도 함께 고쳤습니다.
- 수정 `src/main/resources/application.yml` — 게이트 프로퍼티를 `false`로 추가했습니다.

테스트는 두 모듈에 splitter·유틸·토글 테스트를 각각 추가했습니다. langchain4j 모듈에는 청킹 품질 비교와 recall 비교 테스트를 더했습니다.

## 측정 결과와 한계

머지된 `EgovRetrievalRecallPoCTest`의 고정 코퍼스·QA 시드셋·recall 계산을 그대로 재사용해(가시성만 패키지 전용으로 넓혔고 로직·코퍼스는 무변경) 동일 문서를 기존 `DocumentSplitters.recursive`와 문장경계 방식으로 각각 색인하고 같은 lexical 채널로 비교했습니다. 결정론적 연산이므로 아래 수치는 시행 평균이 아니라 질의집합(8개) 평균입니다.

| 청크 크기 | 분할 방식 | 청크 수 | 평균 길이 | 충전율 | 원문 일치율 | 평균 recall@3 |
|---|---|---|---|---|---|---|
| 4000(기본) | recursive | 12 | 2,310자 | 0.578 | 0.417 | 0.800 |
| 4000(기본) | 문장경계 | 11 | 2,478자 | 0.620 | 1.000 | 0.800 |
| 1000 | recursive | 48 | 589자 | 0.589 | 0.104 | 0.800 |
| 1000 | 문장경계 | 29 | 914자 | 0.914 | 1.000 | 0.800 |

**recall@3은 네 조합 모두 0.800으로 같습니다. 이 변경은 검색 정확도를 개선하지 않습니다.** 측정으로 확인한 이득은 두 가지입니다.

첫째, 청크가 원문의 부분문자열로 유지됩니다. 기존 방식은 청크를 재조립하면서 원문의 공백을 개행으로 바꾸므로 원문과 문자열이 달라집니다(내용이 사라지지는 않습니다). 문장경계 방식은 원문 offset을 잘라내므로 표의 개행, 코드펜스의 들여쓰기, 인용부호 앞뒤 공백이 그대로 남습니다. 답변 근거로 청크를 인용할 때 원문과 대조하기 쉽습니다. 문장 하나가 청크 한도를 넘는 경우에도 기존 분할기에 넘기지 않고 원문 offset 창으로 잘라 이 성질을 지킵니다.

둘째, 청크 크기가 작을수록 청크 구성이 촘촘해집니다. 1000자에서 충전율 0.589 → 0.914, 청크 수 48 → 29로 임베딩 호출과 색인 행이 줄어듭니다. 앱 기본값 4000자에서는 12 → 11로 차이가 작습니다.

PoC 코퍼스는 동일 본문을 8회 반복한 합성 문서라 recall 수치로 방식 간 우열을 가릴 수 없습니다. 청크 수·충전율·원문 일치율은 분할기 규칙과 무관한 통계라 코퍼스 구조에 덜 민감합니다.

## 경계 판정의 한계

마침표는 날짜(`2026. 7. 30.`)·소수점·라틴 약어·목록 번호·법령 조항과 구분되지 않으므로 한국어 종결어미 뒤에 오고 다음이 공백·개행·문서 끝일 때만 문장 끝으로 봅니다. 그래서 `이 규정은 제3조제1항. 다음 조항을 따른다.`처럼 종결어미가 아닌 자리에서 끝나는 문장은 다음 문장과 한 구간에 남습니다. 인용을 닫은 뒤 같은 줄에 한국어가 이어지면 인용을 받는 문장 성분으로 보아 자르지 않으므로, `그는 "완료한다." 다음 절차를 진행한다.`처럼 실제로 새 문장이 오는 경우에도 병합됩니다. 물음표·느낌표는 같은 줄에서 닫히지 않은 대괄호·괄호 안에 있으면 마크다운 링크·이미지 표기 중간으로 보아 자르지 않는데, 이 판정은 일반 괄호에도 적용되므로 `(문의 사항이 있습니까? 담당자에게 연락하세요)` 같은 문장도 한 구간에 남습니다.

경계를 놓치면 두 문장이 한 구간에 남을 뿐이고 청크는 원문 부분문자열이므로 내용이 훼손되지 않습니다. 반대로 잘못 자르면 문장이 중간에서 끊어지므로 확신이 없는 마침표는 자르지 않는 쪽을 택했습니다.

## 설정과 적용 범위

기본값 `enabled: false`입니다. 프로퍼티를 설정하지 않으면 빈이 등록되지 않고 기존 `DocumentSplitters.recursive`(langchain4j) / `TokenTextSplitter`(Spring AI) 경로가 그대로 동작합니다. Spring AI 모듈은 폴백 시 출력이 기존 `TokenTextSplitter` 결과와 같음을, langchain4j 모듈은 기존 `DocumentSplitters.recursive` 결과와 같음을 각각 테스트로 검증했습니다.

langchain4j 모듈의 오버랩은 기본값이 기존 recursive와 같은 청크 크기의 10%(최소 50자)이며 청크 크기의 절반을 넘을 수 없습니다. 오버랩이 절반을 넘으면 분할 창이 조금씩만 나아가 청크 수가 문서 길이에 비례해 늘어나므로 생성자에서 거부합니다. 청크를 자르는 위치와 오버랩 재개 위치는 서로게이트 페어 중간을 피해 코드포인트 경계로 맞춥니다. 보충면 문자 하나가 한도를 넘는 극단 설정(청크 크기 1~2)에서는 한도에 맞는 창이 없으므로 코드포인트 하나를 그대로 내보내 분할이 끝나게 합니다.

두 모듈은 독립 Maven 프로젝트라 공용 유틸을 뽑을 수 없어 경계 검출 유틸을 각 모듈에 같은 내용으로 구현했습니다(`EgovInjectionGuard` #62와 같은 방식). Spring AI 쪽 분할기는 기존 `TokenTextSplitter`를 상속해 청크 크기를 같은 CL100K_BASE 토큰 수로 판정하고 오버랩을 두지 않습니다. langchain4j 쪽은 문자 수 기준입니다.

## 테스트 방법

두 모듈 모두 `mvn test`로 확인했습니다.

```
langchain4j-ai-rag-postgre: Tests run 119, Failures 0, Errors 0, Skipped 0
spring-ai-rag-redis-stack : Tests run 134, Failures 0, Errors 0, Skipped 0
```

Docker가 있는 환경에서 실행하면 비교 테스트가 Testcontainers로 실제 PostgreSQL을 띄워 위 표의 수치를 산출합니다.

무한루프는 검증 실패가 아니라 빌드 정지로 나타나므로 회귀 테스트에 타임아웃을 걸었습니다. 청크 크기 1·2·3과 보충면 문자 조합, 오버랩 상한을 넘긴 설정이 대상입니다.

관련 Issue: #71

