### PR TITLE
fix: 문서 정규화가 개행을 소실시키고 줄바꿈 치환에 문자 n을 삽입하는 문제 수정

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovContentFormatTransformer.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovContentFormatTransformer.java
@@ -63,12 +63,13 @@ public class EgovContentFormatTransformer implements DocumentTransformer {
 
         // 공백 정규화
         if (normalizeWhitespace) {
-            normalizedContent = normalizedContent.replaceAll("\\s+", " ");
+            normalizedContent = normalizedContent.replaceAll("[^\\S\\r\\n]+", " ");
         }
 
-        // 줄바꿈 정규화
+        // 줄바꿈 정규화 (CRLF -> LF 통일 후 빈 줄 제거)
         if (normalizeNewlines) {
-            normalizedContent = normalizedContent.replaceAll("\\n{2,}", "\\n");
+            normalizedContent = normalizedContent.replaceAll("\\r\\n?", "\n");
+            normalizedContent = normalizedContent.replaceAll("\n{2,}", "\n");
         }
 
         // 코드 블록 제거

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovContentFormatTransformerTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovContentFormatTransformerTest.java
@@ -1,0 +1,108 @@
+package com.example.chat.config.etl.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.Metadata;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * {@link EgovContentFormatTransformer}의 내용 정규화 동작을 검증한다.
+ *
+ * <p>Spring 컨텍스트 없이 @Value 필드를 직접 주입해 결정적으로 동작한다.
+ */
+class EgovContentFormatTransformerTest {
+
+    /** @Value 설정을 직접 주입한 표준 인스턴스. */
+    private EgovContentFormatTransformer transformer(boolean enabled, boolean normalizeWhitespace,
+            boolean normalizeNewlines) {
+        EgovContentFormatTransformer transformer = new EgovContentFormatTransformer();
+        ReflectionTestUtils.setField(transformer, "normalizationEnabled", enabled);
+        ReflectionTestUtils.setField(transformer, "removeHtmlTags", false);
+        ReflectionTestUtils.setField(transformer, "normalizeWhitespace", normalizeWhitespace);
+        ReflectionTestUtils.setField(transformer, "normalizeNewlines", normalizeNewlines);
+        ReflectionTestUtils.setField(transformer, "removeCodeBlocks", false);
+        ReflectionTestUtils.setField(transformer, "cleanSpecialChars", false);
+        return transformer;
+    }
+
+    @Test
+    @DisplayName("줄바꿈 정규화는 빈 줄을 단일 개행으로 축약하고 문자 n을 삽입하지 않는다")
+    void normalizeNewlinesDoesNotInsertLiteralN() {
+        EgovContentFormatTransformer transformer = transformer(true, false, true);
+        Document doc = Document.from("1문단 첫 줄\n\n2문단 첫 줄\n\n\n3문단");
+
+        Document result = transformer.transform(doc);
+
+        assertThat(result.text()).isEqualTo("1문단 첫 줄\n2문단 첫 줄\n3문단");
+        assertThat(result.text()).doesNotContain("줄n2문단");
+    }
+
+    @Test
+    @DisplayName("공백 정규화는 연속 스페이스와 탭만 축약하고 개행은 보존한다")
+    void normalizeWhitespacePreservesNewlines() {
+        EgovContentFormatTransformer transformer = transformer(true, true, false);
+        Document doc = Document.from("가  나\t\t다\n라   마\t바");
+
+        Document result = transformer.transform(doc);
+
+        assertThat(result.text()).isEqualTo("가 나 다\n라 마 바");
+    }
+
+    @Test
+    @DisplayName("기본 정규화 설정은 문단 구조를 보존하고 문단 내 연속 공백을 축약한다")
+    void defaultNormalizationPreservesParagraphStructure() {
+        EgovContentFormatTransformer transformer = transformer(true, true, true);
+        Document doc = Document.from("1문단  첫 줄\n\n2문단\t\t첫 줄\n\n\n3문단   첫 줄");
+
+        Document result = transformer.transform(doc);
+
+        assertThat(result.text()).isEqualTo("1문단 첫 줄\n2문단 첫 줄\n3문단 첫 줄");
+    }
+
+    @Test
+    @DisplayName("CRLF 입력도 LF 기준으로 줄바꿈 정규화한다")
+    void normalizeCrLfToLf() {
+        EgovContentFormatTransformer transformer = transformer(true, false, true);
+        Document doc = Document.from("가\r\n\r\n나");
+
+        Document result = transformer.transform(doc);
+
+        assertThat(result.text()).isEqualTo("가\n나");
+    }
+
+    @Test
+    @DisplayName("비활성화 시 원본 문서를 동일 인스턴스로 반환한다")
+    void disabledReturnsSameDocument() {
+        EgovContentFormatTransformer transformer = transformer(false, true, true);
+        Document doc = Document.from("가  나\n\n다");
+
+        Document result = transformer.transform(doc);
+        List<Document> allResult = transformer.transformAll(List.of(doc));
+
+        assertThat(result).isSameAs(doc);
+        assertThat(allResult).containsExactly(doc);
+    }
+
+    @Test
+    @DisplayName("정규화로 내용이 바뀌면 기존 메타데이터와 정규화 정보를 보존한다")
+    void changedContentKeepsMetadataAndAddsNormalizationMetadata() {
+        EgovContentFormatTransformer transformer = transformer(true, true, false);
+        Metadata metadata = new Metadata();
+        metadata.put("source", "manual");
+        Document doc = Document.from("가  나", metadata);
+
+        Document result = transformer.transform(doc);
+
+        assertThat(result).isNotSameAs(doc);
+        assertThat(result.text()).isEqualTo("가 나");
+        assertThat(result.metadata().getString("source")).isEqualTo("manual");
+        assertThat(result.metadata().getString("original_length")).isEqualTo("4");
+        assertThat(result.metadata().getString("normalized_length")).isEqualTo("3");
+        assertThat(result.metadata().getString("normalization_applied")).isEqualTo("true");
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovContentFormatTransformer.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/transformers/EgovContentFormatTransformer.java
@@ -105,12 +105,13 @@ public class EgovContentFormatTransformer implements DocumentTransformer {
         
         // 공백 정규화
         if (normalizeWhitespace) {
-            normalizedContent = normalizedContent.replaceAll("\\s+", " ");
+            normalizedContent = normalizedContent.replaceAll("[^\\S\\r\\n]+", " ");
         }
         
-        // 줄바꿈 정규화
+        // 줄바꿈 정규화 (CRLF -> LF 통일 후 빈 줄 제거)
         if (normalizeNewlines) {
-            normalizedContent = normalizedContent.replaceAll("\\n{2,}", "\\n");
+            normalizedContent = normalizedContent.replaceAll("\\r\\n?", "\n");
+            normalizedContent = normalizedContent.replaceAll("\n{2,}", "\n");
         }
         
         // 코드 블록 제거

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovContentFormatTransformerTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/transformers/EgovContentFormatTransformerTest.java
@@ -1,0 +1,106 @@
+package com.example.chat.config.etl.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * {@link EgovContentFormatTransformer}의 내용 정규화 동작을 검증한다.
+ *
+ * <p>Spring 컨텍스트 없이 @Value 필드를 직접 주입해 결정적으로 동작한다.
+ */
+class EgovContentFormatTransformerTest {
+
+    /** @Value 설정을 직접 주입한 표준 인스턴스. */
+    private EgovContentFormatTransformer transformer(boolean enabled, boolean normalizeWhitespace,
+            boolean normalizeNewlines) {
+        EgovContentFormatTransformer transformer = new EgovContentFormatTransformer();
+        ReflectionTestUtils.setField(transformer, "normalizationEnabled", enabled);
+        ReflectionTestUtils.setField(transformer, "removeHtmlTags", false);
+        ReflectionTestUtils.setField(transformer, "normalizeWhitespace", normalizeWhitespace);
+        ReflectionTestUtils.setField(transformer, "normalizeNewlines", normalizeNewlines);
+        ReflectionTestUtils.setField(transformer, "removeCodeBlocks", false);
+        ReflectionTestUtils.setField(transformer, "cleanSpecialChars", false);
+        return transformer;
+    }
+
+    @Test
+    @DisplayName("줄바꿈 정규화는 빈 줄을 단일 개행으로 축약하고 문자 n을 삽입하지 않는다")
+    void normalizeNewlinesDoesNotInsertLiteralN() {
+        EgovContentFormatTransformer transformer = transformer(true, false, true);
+        Document doc = new Document("1문단 첫 줄\n\n2문단 첫 줄\n\n\n3문단");
+
+        List<Document> result = transformer.apply(List.of(doc));
+
+        assertThat(result.get(0).getText()).isEqualTo("1문단 첫 줄\n2문단 첫 줄\n3문단");
+        assertThat(result.get(0).getText()).doesNotContain("줄n2문단");
+    }
+
+    @Test
+    @DisplayName("공백 정규화는 연속 스페이스와 탭만 축약하고 개행은 보존한다")
+    void normalizeWhitespacePreservesNewlines() {
+        EgovContentFormatTransformer transformer = transformer(true, true, false);
+        Document doc = new Document("가  나\t\t다\n라   마\t바");
+
+        List<Document> result = transformer.apply(List.of(doc));
+
+        assertThat(result.get(0).getText()).isEqualTo("가 나 다\n라 마 바");
+    }
+
+    @Test
+    @DisplayName("기본 정규화 설정은 문단 구조를 보존하고 문단 내 연속 공백을 축약한다")
+    void defaultNormalizationPreservesParagraphStructure() {
+        EgovContentFormatTransformer transformer = transformer(true, true, true);
+        Document doc = new Document("1문단  첫 줄\n\n2문단\t\t첫 줄\n\n\n3문단   첫 줄");
+
+        List<Document> result = transformer.apply(List.of(doc));
+
+        assertThat(result.get(0).getText()).isEqualTo("1문단 첫 줄\n2문단 첫 줄\n3문단 첫 줄");
+    }
+
+    @Test
+    @DisplayName("CRLF 입력도 LF 기준으로 줄바꿈 정규화한다")
+    void normalizeCrLfToLf() {
+        EgovContentFormatTransformer transformer = transformer(true, false, true);
+        Document doc = new Document("가\r\n\r\n나");
+
+        List<Document> result = transformer.apply(List.of(doc));
+
+        assertThat(result.get(0).getText()).isEqualTo("가\n나");
+    }
+
+    @Test
+    @DisplayName("비활성화 시 원본 문서를 동일 인스턴스로 반환한다")
+    void disabledReturnsSameDocument() {
+        EgovContentFormatTransformer transformer = transformer(false, true, true);
+        Document doc = new Document("가  나\n\n다");
+
+        List<Document> result = transformer.apply(List.of(doc));
+
+        assertThat(result).containsExactly(doc);
+        assertThat(result.get(0)).isSameAs(doc);
+    }
+
+    @Test
+    @DisplayName("정규화로 내용이 바뀌면 기존 메타데이터와 정규화 정보를 보존한다")
+    void changedContentKeepsMetadataAndAddsNormalizationMetadata() {
+        EgovContentFormatTransformer transformer = transformer(true, true, false);
+        Document doc = new Document("가  나", new HashMap<>(Map.of("source", "manual")));
+
+        List<Document> result = transformer.apply(List.of(doc));
+
+        assertThat(result.get(0)).isNotSameAs(doc);
+        assertThat(result.get(0).getText()).isEqualTo("가 나");
+        assertThat(result.get(0).getMetadata()).containsEntry("source", "manual");
+        assertThat(result.get(0).getMetadata()).containsEntry("original_length", 4);
+        assertThat(result.get(0).getMetadata()).containsEntry("normalized_length", 3);
+        assertThat(result.get(0).getMetadata()).containsEntry("custom_normalization_applied", true);
+    }
+}


### PR DESCRIPTION
## 변경 이유

`EgovContentFormatTransformer.normalizeContent()`의 정규화 두 단계에 각각 결함이 있습니다. 두 모듈에 같은 코드가 있어 함께 고쳤습니다.

**1. 줄바꿈 정규화가 개행 대신 문자 `n`을 넣습니다.**

```java
normalizedContent = normalizedContent.replaceAll("\\n{2,}", "\\n");
```

`replaceAll`의 치환 문자열에서 `\\n`은 역슬래시 이스케이프로 해석돼 결과가 개행이 아니라 문자 `n`입니다. 치환 문자열에 개행을 넣으려면 `"\n"`이어야 합니다. `normalize-whitespace: false`, `normalize-newlines: true` 설정에서 `1문단\n\n2문단`은 `1문단n2문단`이 됩니다. 문단 경계가 사라지는 데 그치지 않고 본문에 없던 글자가 삽입되므로, 임베딩 대상 텍스트와 검색 결과로 노출되는 원문이 모두 오염됩니다.

**2. 공백 정규화가 개행까지 지워 줄바꿈 정규화를 무력화합니다.**

```java
normalizedContent = normalizedContent.replaceAll("\\s+", " ");
```

`\s`는 `\n`을 포함하므로 이 단계에서 문서의 개행이 전부 공백 하나로 바뀝니다. 두 모듈 모두 `normalize-whitespace` 기본값이 `true`이고 이 단계가 줄바꿈 정규화보다 먼저 실행되므로(langchain4j 63~72행, spring-ai 105~114행), 뒤따르는 `normalize-newlines`는 지울 대상이 남아 있지 않습니다. 설정으로 분리해 둔 두 단계가 실제로는 앞 단계 하나로 끝납니다.

개행 소실은 정규화 이후 단계에도 영향을 줍니다. 두 모듈 다 정규화가 문서 분할보다 먼저 실행되므로(`EgovDocumentServiceImpl` langchain4j 130행 → 135행, spring-ai 139행 → 147행), 분할기는 개행이 하나도 없는 한 줄짜리 텍스트를 받습니다. 문단 단위로 자르도록 되어 있는 분할 기준이 실제로는 동작하지 않습니다.

## 변경 내용

- 공백 정규화 정규식을 `\s+`에서 `[^\S\r\n]+`로 바꿔 스페이스와 탭만 축약하고 개행은 보존합니다.
- 줄바꿈 정규화를 `\r\n?` → `\n`으로 줄 끝 문자를 통일한 뒤 `\n{2,}` → `\n`으로 빈 줄을 축약하도록 고쳤습니다. 치환 문자열도 실제 개행으로 바로잡았습니다. CRLF 문서에서는 `\n{2,}`가 `\r\n\r\n`에 걸리지 않아 빈 줄이 그대로 남던 문제도 함께 해소됩니다.
- 두 모듈에 `EgovContentFormatTransformerTest`를 각각 추가했습니다. Spring 컨텍스트 없이 `ReflectionTestUtils`로 `@Value` 필드를 주입해 설정 조합별로 결정적으로 검증합니다. 문자 `n` 삽입 여부, 개행 보존, 기본 설정에서의 문단 구조 유지, CRLF 입력, 비활성화 시 원본 인스턴스 반환, 메타데이터 보존 6건입니다.

## 테스트 방법

```
cd langchain4j-ai-rag-postgre && mvn -B test
cd spring-ai-rag-redis-stack && mvn -B test
```

두 모듈 모두 전체 테스트가 통과합니다(실패·오류 0건).

회귀 여부는 본문 수정만 되돌리고 테스트만 적용해 확인했습니다. 이 상태에서 신규 테스트 중 4건이 실패합니다.

- `normalizeNewlinesDoesNotInsertLiteralN` — 기대 `1문단 첫 줄\n2문단 첫 줄\n3문단`, 실제 `1문단 첫 줄n2문단 첫 줄n3문단`
- `normalizeWhitespacePreservesNewlines` — 기대 `가 나 다\n라 마 바`, 실제 `가 나 다 라 마 바`
- `defaultNormalizationPreservesParagraphStructure`, `normalizeCrLfToLf`도 같은 원인으로 실패

## 영향 범위

- 수정 파일은 두 모듈의 `EgovContentFormatTransformer.java`(각 본문 4줄)와 신규 테스트 2개입니다.
- `normalize-whitespace: true`인 기본 설정에서 정규화 결과에 개행이 남습니다. 분할기가 문단 경계를 인식하게 되므로 기존 대비 청크 경계가 달라질 수 있습니다. 지금까지 개행이 모두 사라진 텍스트가 분할기에 전달되던 것을 설정 의도대로 되돌리는 변경입니다.
- 설정 키, 공개 API 시그니처, 의존성 변경은 없습니다.
