### PR TITLE
fix: 재색인 시 같은 문서의 이전 벡터가 삭제되지 않고 누적되는 문제 수정

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/writers/EgovVectorStoreWriter.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/writers/EgovVectorStoreWriter.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
+import static dev.langchain4j.store.embedding.filter.MetadataFilterBuilder.metadataKey;
+
 /**
  * 벡터 저장소 Writer
  * 문서를 임베딩하여 PGVector에 저장
@@ -20,6 +22,8 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class EgovVectorStoreWriter {
+
+    private static final int DELETE_BATCH_SIZE = 200;
 
     private final EmbeddingStore<TextSegment> embeddingStore;
     private final EmbeddingModel embeddingModel;
@@ -43,18 +47,32 @@ public class EgovVectorStoreWriter {
         }
 
         try {
-            // 문서를 TextSegment로 변환하고 임베딩 생성
+            // 문서를 TextSegment로 변환하고 배치 임베딩 생성
             List<TextSegment> segments = new ArrayList<>();
-            List<Embedding> embeddings = new ArrayList<>();
 
             for (Document doc : documents) {
-                // TextSegment 생성 (메타데이터 포함)
-                TextSegment segment = TextSegment.from(doc.text(), doc.metadata());
-                segments.add(segment);
+                segments.add(TextSegment.from(doc.text(), doc.metadata()));
+            }
 
-                // 임베딩 생성
-                Embedding embedding = embeddingModel.embed(doc.text()).content();
-                embeddings.add(embedding);
+            List<Embedding> embeddings = embeddingModel.embedAll(segments).content();
+
+            // 같은 문서 id의 기존 벡터를 먼저 삭제하여 재색인 시 stale 청크 누적을 방지
+            List<String> documentIds = segments.stream()
+                    .map(segment -> segment.metadata().getString("id"))
+                    .filter(id -> id != null && !id.isBlank())
+                    .distinct()
+                    .toList();
+
+            if (documentIds.isEmpty()) {
+                log.warn("삭제 대상 문서 id가 없어 기존 벡터 삭제를 건너뜁니다. 저장은 계속 진행합니다.");
+            } else {
+                log.info("기존 벡터 삭제 시작: 대상 문서 id {}건, 입력 문서 {}개", documentIds.size(), documents.size());
+                for (int from = 0; from < documentIds.size(); from += DELETE_BATCH_SIZE) {
+                    int to = Math.min(from + DELETE_BATCH_SIZE, documentIds.size());
+                    List<String> idBatch = documentIds.subList(from, to);
+                    embeddingStore.removeAll(metadataKey("id").isIn(idBatch));
+                }
+                log.info("기존 벡터 삭제 완료: 대상 문서 id {}건, 입력 문서 {}개", documentIds.size(), documents.size());
             }
 
             // 벡터 저장소에 저장

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterPgVectorDbTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterPgVectorDbTest.java
@@ -1,0 +1,133 @@
+package com.example.chat.config.etl.writers;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * PgVector 실제 엔진에서 metadata id 기반 삭제가 동작하는지 검증한다.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class EgovVectorStoreWriterPgVectorDbTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>(DockerImageName.parse("pgvector/pgvector:pg17")
+                    .asCompatibleSubstituteFor("postgres"));
+
+    @Test
+    @DisplayName("재색인 시 PgVector의 기존 id 청크가 실제 삭제된다")
+    void reindexingDeletesStaleRowsInPgVector() {
+        String table = "test_embeddings_reindex";
+        DeterministicEmbeddingModel embeddingModel = new DeterministicEmbeddingModel();
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(pgVectorStore(table), embeddingModel);
+
+        writer.write(List.of(
+                document("doc-a", "a.txt", "pg doc-a v1 첫 번째 청크"),
+                document("doc-a", "a.txt", "pg doc-a v1 두 번째 청크")));
+        writer.write(List.of(
+                document("doc-a", "a.txt", "pg doc-a v2 첫 번째 청크"),
+                document("doc-a", "a.txt", "pg doc-a v2 두 번째 청크")));
+
+        JdbcTemplate jdbc = jdbcTemplate();
+        assertThat(countRows(jdbc, table)).isEqualTo(2);
+        assertThat(texts(jdbc, table)).containsExactlyInAnyOrder("pg doc-a v2 첫 번째 청크", "pg doc-a v2 두 번째 청크");
+    }
+
+    @Test
+    @DisplayName("source가 같은 다른 id 청크는 PgVector에서 삭제되지 않는다")
+    void reindexingOneIdKeepsOtherIdWithSameSourceInPgVector() {
+        String table = "test_embeddings_pdf_page";
+        DeterministicEmbeddingModel embeddingModel = new DeterministicEmbeddingModel();
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(pgVectorStore(table), embeddingModel);
+
+        writer.write(List.of(document("pdf-x_1", "x.pdf", "pg x.pdf 1페이지 원문")));
+        writer.write(List.of(document("pdf-x_2", "x.pdf", "pg x.pdf 2페이지 원문")));
+        writer.write(List.of(document("pdf-x_2", "x.pdf", "pg x.pdf 2페이지 수정본")));
+
+        JdbcTemplate jdbc = jdbcTemplate();
+        assertThat(countRows(jdbc, table)).isEqualTo(2);
+        assertThat(texts(jdbc, table)).contains("pg x.pdf 1페이지 원문", "pg x.pdf 2페이지 수정본");
+        assertThat(texts(jdbc, table)).doesNotContain("pg x.pdf 2페이지 원문");
+    }
+
+    private static PgVectorEmbeddingStore pgVectorStore(String table) {
+        return PgVectorEmbeddingStore.builder()
+                .host(POSTGRES.getHost())
+                .port(POSTGRES.getFirstMappedPort())
+                .database(POSTGRES.getDatabaseName())
+                .user(POSTGRES.getUsername())
+                .password(POSTGRES.getPassword())
+                .table(table)
+                .dimension(DeterministicEmbeddingModel.DIMENSION)
+                .createTable(true)
+                .build();
+    }
+
+    private static JdbcTemplate jdbcTemplate() {
+        DriverManagerDataSource ds = new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+        ds.setDriverClassName("org.postgresql.Driver");
+        return new JdbcTemplate(ds);
+    }
+
+    private static int countRows(JdbcTemplate jdbc, String table) {
+        Integer count = jdbc.queryForObject("SELECT count(*) FROM " + table, Integer.class);
+        return count == null ? 0 : count;
+    }
+
+    private static List<String> texts(JdbcTemplate jdbc, String table) {
+        return jdbc.queryForList("SELECT text FROM " + table + " ORDER BY text", String.class);
+    }
+
+    private static Document document(String id, String source, String text) {
+        Metadata metadata = new Metadata();
+        metadata.put("id", id);
+        metadata.put("source", source);
+        return Document.from(text, metadata);
+    }
+
+    private static class DeterministicEmbeddingModel implements EmbeddingModel {
+
+        static final int DIMENSION = 8;
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+            return Response.from(textSegments.stream()
+                    .map(segment -> embeddingFor(segment.text()))
+                    .toList());
+        }
+
+        @Override
+        public int dimension() {
+            return DIMENSION;
+        }
+
+        private Embedding embeddingFor(String text) {
+            float[] vector = new float[DIMENSION];
+            int seed = Objects.hashCode(text);
+            for (int i = 0; i < vector.length; i++) {
+                seed = seed * 31 + i;
+                vector[i] = 0.1f + (Math.floorMod(seed, 1000) / 1000.0f);
+            }
+            return Embedding.from(vector);
+        }
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterStaleChunkTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterStaleChunkTest.java
@@ -1,0 +1,254 @@
+package com.example.chat.config.etl.writers;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 벡터 재색인 시 기존 청크 삭제와 배치 임베딩 동작을 검증한다.
+ */
+class EgovVectorStoreWriterStaleChunkTest {
+
+    @Test
+    @DisplayName("같은 id를 재색인하면 이전 청크가 누적되지 않는다")
+    void reindexingSameIdIsIdempotent() {
+        InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        DeterministicEmbeddingModel embeddingModel = new DeterministicEmbeddingModel();
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store, embeddingModel);
+
+        writer.write(List.of(
+                document("doc-a", "a.txt", "doc-a v1 첫 번째 청크"),
+                document("doc-a", "a.txt", "doc-a v1 두 번째 청크")));
+        writer.write(List.of(
+                document("doc-a", "a.txt", "doc-a v2 첫 번째 청크"),
+                document("doc-a", "a.txt", "doc-a v2 두 번째 청크")));
+
+        List<String> texts = storedTexts(store, embeddingModel);
+        assertThat(texts).hasSize(2);
+        assertThat(texts).containsExactlyInAnyOrder("doc-a v2 첫 번째 청크", "doc-a v2 두 번째 청크");
+        assertThat(texts).noneMatch(text -> text.contains("v1"));
+    }
+
+    @Test
+    @DisplayName("source가 같아도 배치에 없는 페이지 id는 삭제하지 않는다")
+    void reindexingOnePageDoesNotDeleteOtherPageWithSameSource() {
+        InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        DeterministicEmbeddingModel embeddingModel = new DeterministicEmbeddingModel();
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store, embeddingModel);
+
+        writer.write(List.of(document("pdf-x_1", "x.pdf", "x.pdf 1페이지 원문")));
+        writer.write(List.of(document("pdf-x_2", "x.pdf", "x.pdf 2페이지 원문")));
+        writer.write(List.of(document("pdf-x_2", "x.pdf", "x.pdf 2페이지 수정본")));
+
+        List<String> texts = storedTexts(store, embeddingModel);
+        assertThat(texts).hasSize(2);
+        assertThat(texts).contains("x.pdf 1페이지 원문", "x.pdf 2페이지 수정본");
+        assertThat(texts).doesNotContain("x.pdf 2페이지 원문");
+    }
+
+    @Test
+    @DisplayName("write 1회는 embedAll 1회만 호출하고 개별 embed를 호출하지 않는다")
+    void writeUsesSingleBatchEmbeddingCall() {
+        InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        DeterministicEmbeddingModel embeddingModel = new DeterministicEmbeddingModel();
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store, embeddingModel);
+
+        writer.write(List.of(
+                document("doc-1", "a.txt", "N3 첫 번째 청크"),
+                document("doc-2", "b.txt", "N3 두 번째 청크"),
+                document("doc-3", "c.txt", "N3 세 번째 청크")));
+
+        assertThat(embeddingModel.embedAllCalls).isEqualTo(1);
+        assertThat(embeddingModel.individualEmbedCalls).isZero();
+    }
+
+    @Test
+    @DisplayName("id가 없거나 blank인 문서도 삭제 없이 정상 저장한다")
+    void documentsWithoutIdAreStoredWithoutDeleteFailure() {
+        InMemoryEmbeddingStore<TextSegment> delegate = new InMemoryEmbeddingStore<>();
+        SpyEmbeddingStore store = new SpyEmbeddingStore(delegate);
+        DeterministicEmbeddingModel embeddingModel = new DeterministicEmbeddingModel();
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store, embeddingModel);
+
+        writer.write(List.of(
+                document(null, "no-id.txt", "id 없는 청크"),
+                document("   ", "blank-id.txt", "blank id 청크")));
+
+        assertThat(store.removeAllFilterCalls).isZero();
+        assertThat(storedTexts(store, embeddingModel)).containsExactlyInAnyOrder("id 없는 청크", "blank id 청크");
+    }
+
+    @Test
+    @DisplayName("삭제 대상 id가 200건을 넘으면 removeAll(Filter)을 분할 호출한다")
+    void deleteIdsAreSplitIntoBatchesOfTwoHundred() {
+        InMemoryEmbeddingStore<TextSegment> delegate = new InMemoryEmbeddingStore<>();
+        SpyEmbeddingStore store = new SpyEmbeddingStore(delegate);
+        DeterministicEmbeddingModel embeddingModel = new DeterministicEmbeddingModel();
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store, embeddingModel);
+        List<Document> documents = new ArrayList<>();
+        for (int i = 0; i < 250; i++) {
+            documents.add(document("doc-" + i, "bulk.txt", "bulk 청크 " + i));
+        }
+
+        writer.write(documents);
+
+        assertThat(store.removeAllFilterCalls).isEqualTo(2);
+        assertThat(store.filters).hasSize(2);
+        assertThat(storedTexts(store, embeddingModel)).hasSize(250);
+    }
+
+    private static Document document(String id, String source, String text) {
+        Metadata metadata = new Metadata();
+        if (id != null) {
+            metadata.put("id", id);
+        }
+        metadata.put("source", source);
+        return Document.from(text, metadata);
+    }
+
+    private static List<String> storedTexts(EmbeddingStore<TextSegment> store, DeterministicEmbeddingModel embeddingModel) {
+        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(embeddingModel.embeddingFor("검색 질의"))
+                .maxResults(1000)
+                .minScore(0.0)
+                .build();
+        return store.search(request).matches().stream()
+                .map(EmbeddingMatch::embedded)
+                .map(TextSegment::text)
+                .toList();
+    }
+
+    private static class DeterministicEmbeddingModel implements EmbeddingModel {
+
+        static final int DIMENSION = 8;
+
+        int embedAllCalls;
+        int individualEmbedCalls;
+
+        @Override
+        public Response<Embedding> embed(String text) {
+            individualEmbedCalls++;
+            return Response.from(embeddingFor(text));
+        }
+
+        @Override
+        public Response<Embedding> embed(TextSegment textSegment) {
+            individualEmbedCalls++;
+            return Response.from(embeddingFor(textSegment.text()));
+        }
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+            embedAllCalls++;
+            return Response.from(textSegments.stream()
+                    .map(segment -> embeddingFor(segment.text()))
+                    .toList());
+        }
+
+        @Override
+        public int dimension() {
+            return DIMENSION;
+        }
+
+        Embedding embeddingFor(String text) {
+            float[] vector = new float[DIMENSION];
+            int seed = Objects.hashCode(text);
+            for (int i = 0; i < vector.length; i++) {
+                seed = seed * 31 + i;
+                vector[i] = 0.1f + (Math.floorMod(seed, 1000) / 1000.0f);
+            }
+            return Embedding.from(vector);
+        }
+    }
+
+    private static class SpyEmbeddingStore implements EmbeddingStore<TextSegment> {
+
+        private final EmbeddingStore<TextSegment> delegate;
+        private final List<Filter> filters = new ArrayList<>();
+        private int removeAllFilterCalls;
+
+        SpyEmbeddingStore(EmbeddingStore<TextSegment> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String add(Embedding embedding) {
+            return delegate.add(embedding);
+        }
+
+        @Override
+        public void add(String id, Embedding embedding) {
+            delegate.add(id, embedding);
+        }
+
+        @Override
+        public String add(Embedding embedding, TextSegment embedded) {
+            return delegate.add(embedding, embedded);
+        }
+
+        @Override
+        public List<String> addAll(List<Embedding> embeddings) {
+            return delegate.addAll(embeddings);
+        }
+
+        @Override
+        public List<String> addAll(List<Embedding> embeddings, List<TextSegment> embedded) {
+            return delegate.addAll(embeddings, embedded);
+        }
+
+        @Override
+        public List<String> generateIds(int n) {
+            return delegate.generateIds(n);
+        }
+
+        @Override
+        public void addAll(List<String> ids, List<Embedding> embeddings, List<TextSegment> embedded) {
+            delegate.addAll(ids, embeddings, embedded);
+        }
+
+        @Override
+        public void remove(String id) {
+            delegate.remove(id);
+        }
+
+        @Override
+        public void removeAll(Collection<String> ids) {
+            delegate.removeAll(ids);
+        }
+
+        @Override
+        public void removeAll(Filter filter) {
+            removeAllFilterCalls++;
+            filters.add(filter);
+            delegate.removeAll(filter);
+        }
+
+        @Override
+        public void removeAll() {
+            delegate.removeAll();
+        }
+
+        @Override
+        public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
+            return delegate.search(request);
+        }
+    }
+}


### PR DESCRIPTION
## 변경 이유

`EgovVectorStoreWriter.write()`는 벡터 저장소에 `addAll`만 호출합니다. 삭제는 어디에서도 하지 않습니다.

```java
embeddingStore.addAll(embeddings, segments);
```

PgVector는 행마다 새 UUID를 부여하므로, 같은 문서를 다시 색인하면 이전 청크가 그대로 남고 새 청크가 추가됩니다. 문서를 N번 수정하면 옛 본문 N-1벌이 검색 대상에 남습니다. 원본 파일을 삭제해도 벡터와 해시는 남습니다.

재색인은 정상 경로입니다. `EgovDocumentServiceImpl`이 파일 해시로 변경분을 골라내 이 Writer로 넘기므로, 문서를 고칠 때마다 이 경로를 지납니다.

검색 결과가 어떻게 되는지는 설정에 따라 갈립니다.

- 기본 설정(하이브리드 off): `EgovRagConfig` 65~69행 기준 top-k 3이고 중복 제거가 없어, 옛 청크와 새 청크가 같은 자리를 두고 경쟁합니다.
- 하이브리드 on: `EgovHybridContentRetriever`의 `fusionKey`(177~181행)가 `id:<문서id>`로 묶어 한 항목으로 융합합니다. 대표로 뽑히는 것은 dense 상위 청크이므로, 옛 청크가 대표가 되면 현재 본문이 결과에서 가려집니다. 항목 수가 늘지 않아 겉으로는 정상으로 보입니다.

## 변경 내용

`write()`가 임베딩 생성 → 기존 벡터 삭제 → 저장 순서로 동작하도록 고쳤습니다.

- 삭제 키는 메타데이터 `id`입니다. 리더 5종이 모두 `id`를 넣고(`doc-<파일명>`, `pdf-<파일명>_<페이지>`), `EgovEnhancedDocumentTransformer` 69행에서 청크가 부모 메타데이터를 상속하므로 청크 단계에서도 값이 있습니다. `metadataKey("id").isIn(...)`로 삭제합니다.
- `source`(파일명)를 키로 쓰지 않았습니다. PDF 리더는 페이지마다 Document를 만들고 변경 판정도 페이지 단위입니다. 5페이지 중 3페이지만 고치면 배치에 3페이지만 들어오는데, `source`로 지우면 나머지 2페이지까지 사라집니다. 그 2페이지는 해시가 그대로라 다시 색인되지 않아 영구히 유실됩니다. 이 조건을 회귀 테스트로 고정했습니다.
- 임베딩을 `embed` 반복 호출에서 `embedAll` 한 번으로 바꿨습니다. 성능 목적이 아니라 순서를 위해 필요합니다. 임베딩이 먼저 끝나야 임베딩 실패 시 삭제가 일어나지 않습니다. 문서 100개 색인 시 임베딩 호출은 100회에서 1회가 됩니다.
- 삭제 대상 id가 없으면 경고만 남기고 저장은 진행합니다. langchain4j의 `isIn`은 빈 컬렉션에 예외를 던지므로 가드가 필요합니다.
- id 목록은 200건씩 나눠 삭제합니다. IN 절 길이 상한을 넘지 않기 위해서입니다.

크로스 스토어 트랜잭션은 도입하지 않았습니다. 정합성 기준은 기존 설계 그대로 "저장 성공 후 해시 저장"입니다(`EgovDocumentServiceImpl` 140행 → 144행). 삭제 후 저장이 실패하면 해시가 갱신되지 않으므로 다음 재색인이 같은 문서를 다시 처리해 복구합니다. 부분 삽입도 다음 회차의 삭제가 정리합니다. 수정 후 재시도가 멱등이 되는 것이 이번 변경의 핵심이며, 지금은 재시도할수록 중복이 늘어납니다.

## 테스트 방법

```
cd langchain4j-ai-rag-postgre && mvn -B test
```

모듈 전체 90건이 통과합니다(신규 7건 포함, 실패·오류 0건).

신규 테스트는 두 종류입니다.

- `EgovVectorStoreWriterStaleChunkTest` — `InMemoryEmbeddingStore`와 결정적 임베딩 스텁으로 Docker 없이 동작합니다. 같은 id 재색인 시 이전 청크 부재, 같은 `source`의 다른 페이지 생존, id 없는 문서의 저장 성공, `embedAll` 1회 호출, 200건 분할 5건입니다.
- `EgovVectorStoreWriterPgVectorDbTest` — `pgvector/pgvector:pg17`을 `asCompatibleSubstituteFor("postgres")`로 얹어 실제 엔진에서 메타데이터 필터 삭제가 성립하는지 확인합니다. 기존 `EgovHybridLexicalSearchDbTest`가 쓰는 Testcontainers 설정을 그대로 사용해 신규 의존성은 없습니다. 재색인 후 잔존 행 수와, 같은 `source`를 공유하는 다른 id의 행이 남는지 2건입니다.

회귀 여부는 본문 수정만 되돌리고 테스트만 적용해 확인했습니다. 이 상태에서 7건 중 6건이 실패합니다(잔존 행 2배, `embed` 반복 호출, 분할 미발생).

## 영향 범위

- 수정 파일은 `EgovVectorStoreWriter.java`(본문 34줄)와 신규 테스트 2개입니다. `write(List<Document>)` 시그니처와 호출부는 그대로입니다.
- 설정 추가는 없습니다. 이전 청크가 남는 것이 의도된 동작이라고 보기 어려워 토글을 두지 않았습니다. 단계적 적용이 필요하다면 기본값 true인 설정으로 감싸겠습니다.
- 같은 파일명이 서로 다른 하위 디렉터리에 있으면 문서 id가 같아집니다. 지금은 두 파일의 청크가 함께 쌓이지만 이 변경 이후에는 재색인 때마다 서로를 지웁니다. 증상은 바뀌지만 원인은 리더가 파일명만으로 id를 만드는 쪽에 있어 이 PR 범위 밖입니다. 별도로 정리해 올리겠습니다.
- spring-ai 모듈은 포함하지 않았습니다. 그쪽은 청크 id가 실행마다 새로 생기고 RedisVectorStore 인덱스 스키마에 메타데이터 필드가 선언돼 있지 않아 필터 삭제가 성립하지 않습니다. 접근 자체가 달라야 해서 별도 PR로 분리합니다.
