### PR TITLE
fix: spring-ai 모듈 재색인 시 이전 청크가 삭제되지 않고 누적되는 문제 수정

### DIFF
--- a/spring-ai-rag-redis-stack/pom.xml
+++ b/spring-ai-rag-redis-stack/pom.xml
@@ -142,6 +142,11 @@
             <version>1.0.8</version>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovVectorStoreConfig.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/EgovVectorStoreConfig.java
@@ -1,0 +1,63 @@
+package com.example.chat.config;
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.redis.RedisVectorStore;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.JedisPooled;
+
+/**
+ * RediSearch 인덱스에 원본 문서 id 메타데이터 필드를 등록하는 벡터 저장소 구성.
+ *
+ * <p>Spring AI 오토컨피그가 만드는 {@code RedisVectorStore}는 메타데이터 필드를 하나도
+ * 선언하지 않는다. RediSearch는 인덱스 스키마에 없는 필드로 필터할 수 없으므로, 그 상태로는
+ * {@code delete(Filter.Expression)}이 어떤 문서와도 매칭되지 않는다. 재색인 시 이전 청크를
+ * 지우려면 원본 문서 id를 인덱스에 담아야 한다.</p>
+ *
+ * <p>오토컨피그의 빈 정의는 {@code @ConditionalOnMissingBean}이므로 이 빈이 대신 쓰인다.
+ * 인덱스 이름·prefix·스키마 초기화 여부는 기존 설정 키를 그대로 읽어 동작이 달라지지 않는다.</p>
+ *
+ * <p><b>기존 인덱스 주의</b> — {@code initialize-schema}는 인덱스가 없을 때만 스키마를
+ * 만든다. 이 변경 이전에 만들어진 인덱스에는 {@code original_id} 필드가 없어 삭제 필터가
+ * 0건을 매칭한다. 이 경우 동작은 변경 전과 같고(이전 청크가 남음) 데이터가 유실되지는 않는다.
+ * 삭제를 적용하려면 {@code FT.DROPINDEX <index-name>}으로 인덱스만 지운 뒤(문서는 보존됨)
+ * 재기동해 스키마를 다시 만들면 된다.</p>
+ */
+@Slf4j
+@Configuration
+public class EgovVectorStoreConfig {
+
+    /** 원본 문서 id를 담는 메타데이터 필드명. 리더 5종이 같은 키로 값을 넣는다. */
+    public static final String ORIGINAL_ID_FIELD = "original_id";
+
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+
+    @Value("${spring.ai.vectorstore.redis.index-name:document-index}")
+    private String indexName;
+
+    @Value("${spring.ai.vectorstore.redis.prefix:" + RedisVectorStore.DEFAULT_PREFIX + "}")
+    private String prefix;
+
+    @Value("${spring.ai.vectorstore.redis.initialize-schema:false}")
+    private boolean initializeSchema;
+
+    @Bean
+    public RedisVectorStore vectorStore(EmbeddingModel embeddingModel) {
+        log.info("RedisVectorStore 구성 - index: {}, prefix: {}, metadataField: {}",
+                indexName, prefix, ORIGINAL_ID_FIELD);
+
+        return RedisVectorStore.builder(new JedisPooled(redisHost, redisPort), embeddingModel)
+                .indexName(indexName)
+                .prefix(prefix)
+                .initializeSchema(initializeSchema)
+                .metadataFields(RedisVectorStore.MetadataField.tag(ORIGINAL_ID_FIELD))
+                .build();
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovDocxReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovDocxReader.java
@@ -86,6 +86,8 @@ public class EgovDocxReader implements DocumentReader {
                 .replaceAll("[\\/:*?\"<>|]", "")
                 .replaceAll("\\s+", "-");
         String docId = "docx-" + safeFilename;
+        // 분할 이후에도 원본 문서를 식별할 수 있도록 문서 id 를 메타데이터에도 담는다
+        metadata.put("original_id", docId);
 
         log.info("DOCX 문서 로드 완료: {}, 크기: {}바이트", filename, content.length());
         return new Document(docId, content, metadata);

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
@@ -99,6 +99,8 @@ public class EgovHwpReader implements DocumentReader {
         metadata.put("type", "hwp");
         metadata.put("content_length", content.length());
         metadata.put("page_number", 1);
+        // 분할 이후에도 원본 문서를 식별할 수 있도록 문서 id 를 메타데이터에도 담는다
+        metadata.put("original_id", customId);
 
         log.debug("HWP Document ID: {} (길이: {})", customId, content.length());
 

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpxReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpxReader.java
@@ -99,6 +99,8 @@ public class EgovHwpxReader implements DocumentReader {
         metadata.put("source", filename);
         metadata.put("type", "hwpx");
         metadata.put("content_length", content.length());
+        // 분할 이후에도 원본 문서를 식별할 수 있도록 문서 id 를 메타데이터에도 담는다
+        metadata.put("original_id", customId);
 
         log.info("HWPX 문서 로드 완료: {}, 크기: {}자", filename, content.length());
         return new Document(customId, content, metadata);

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovMarkdownReader.java
@@ -75,6 +75,9 @@ public class EgovMarkdownReader implements DocumentReader {
                 .replaceAll("[\\/:*?\"<>|]", "")
                 .replaceAll("\\s+", "-");
         
+        // 분할 이후에도 원본 문서를 식별할 수 있도록 문서 id 를 메타데이터에도 담는다
+        metadata.put("original_id", docId);
+
         log.info("마크다운 문서 로드 완료: {}, 크기: {}바이트", filename, content.length());
         return new Document(docId, content, metadata);
     }

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovPdfReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovPdfReader.java
@@ -123,7 +123,8 @@ public class EgovPdfReader implements DocumentReader {
             String customId = String.format("pdf-%s_%d", safeFilename, i + 1);
             
             // 메타데이터에 원본 ID와 페이지 정보 추가
-            document.getMetadata().put("original_id", document.getId());
+            // 분할 이후에도 원본 문서를 식별할 수 있도록 실행마다 값이 바뀌지 않는 customId 를 담는다
+            document.getMetadata().put("original_id", customId);
             document.getMetadata().put("page_number", i + 1);
             document.getMetadata().put("file_name", filename);
             document.getMetadata().put("source", filename);

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/writers/EgovVectorStoreWriter.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/writers/EgovVectorStoreWriter.java
@@ -4,8 +4,12 @@ import java.util.List;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentWriter;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
 import org.springframework.ai.vectorstore.redis.RedisVectorStore;
 import org.springframework.stereotype.Component;
+
+import com.example.chat.config.EgovVectorStoreConfig;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class EgovVectorStoreWriter implements DocumentWriter {
+
+    /** 삭제 필터 하나에 담는 원본 문서 id 최대 개수. */
+    private static final int DELETE_BATCH_SIZE = 200;
 
     private final RedisVectorStore redisVectorStore;
 
@@ -34,11 +41,48 @@ public class EgovVectorStoreWriter implements DocumentWriter {
         }
         
         try {
+            removeStaleChunks(documents);
+
             redisVectorStore.add(documents);
             log.info("벡터 저장소에 {}개 문서 저장 완료", documents.size());
         } catch (Exception e) {
             log.error("벡터 저장소 저장 중 오류 발생", e);
             throw new RuntimeException("벡터 저장소 저장 중 오류 발생", e);
         }
+    }
+
+    /**
+     * 이번 배치에 들어온 원본 문서의 기존 청크를 지운다.
+     *
+     * <p>벡터 저장소는 새 청크를 추가만 하므로, 같은 문서를 다시 색인하면 이전 청크가 그대로
+     * 남아 현재 본문과 검색 결과를 두고 경쟁한다. 원본 문서 id 기준으로 먼저 지운 뒤 저장한다.</p>
+     *
+     * <p>삭제 키는 파일명(source)이 아니라 원본 문서 id다. PDF는 페이지마다 문서를 만들고
+     * 변경 판정도 페이지 단위이므로, 파일명으로 지우면 이번 배치에 없는 페이지까지 사라진다.
+     * 그 페이지는 해시가 그대로라 다시 색인되지 않아 영구히 유실된다.</p>
+     */
+    private void removeStaleChunks(List<Document> documents) {
+        List<String> originalIds = documents.stream()
+                .map(document -> document.getMetadata().get(EgovVectorStoreConfig.ORIGINAL_ID_FIELD))
+                .filter(value -> value instanceof String && !((String) value).isBlank())
+                .map(String.class::cast)
+                .distinct()
+                .toList();
+
+        if (originalIds.isEmpty()) {
+            log.warn("원본 문서 id가 없어 기존 청크 삭제를 건너뜁니다. 저장은 계속 진행합니다.");
+            return;
+        }
+
+        for (int from = 0; from < originalIds.size(); from += DELETE_BATCH_SIZE) {
+            int to = Math.min(from + DELETE_BATCH_SIZE, originalIds.size());
+            List<String> idBatch = originalIds.subList(from, to);
+            Filter.Expression expression = new FilterExpressionBuilder()
+                    .in(EgovVectorStoreConfig.ORIGINAL_ID_FIELD, idBatch.toArray())
+                    .build();
+            redisVectorStore.delete(expression);
+        }
+
+        log.info("기존 청크 삭제 완료: 원본 문서 {}건, 입력 청크 {}개", originalIds.size(), documents.size());
     }
 } 

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/writers/EgovVectorStoreWriter.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/writers/EgovVectorStoreWriter.java
@@ -52,6 +52,31 @@ public class EgovVectorStoreWriter implements DocumentWriter {
     }
 
     /**
+     * RediSearch TAG 필터 값에 쓸 수 있도록 구분자로 해석되는 문자를 이스케이프한다.
+     *
+     * <p>spring-ai의 {@code RedisFilterExpressionConverter}는 TAG 값을 그대로 질의문에 넣는다.
+     * 문서 id에는 항상 하이픈이 들어가는데(<code>doc-</code>, <code>pdf-</code> 등) RediSearch는
+     * 이스케이프하지 않은 하이픈을 구분자로 보고 질의 파싱에 실패한다. 마침표는 파싱은 통과하지만
+     * 토큰이 갈려 값이 일치하지 않는다. 두 경우 모두 문자 앞에 백슬래시를 붙이면 해소된다.</p>
+     *
+     * <p>한글·영숫자·밑줄은 이스케이프 대상이 아니다.</p>
+     *
+     * @param value 원본 TAG 값
+     * @return 이스케이프된 TAG 값
+     */
+    static String escapeTagValue(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (!Character.isLetterOrDigit(ch) && ch != '_') {
+                escaped.append('\\');
+            }
+            escaped.append(ch);
+        }
+        return escaped.toString();
+    }
+
+    /**
      * 이번 배치에 들어온 원본 문서의 기존 청크를 지운다.
      *
      * <p>벡터 저장소는 새 청크를 추가만 하므로, 같은 문서를 다시 색인하면 이전 청크가 그대로
@@ -77,8 +102,9 @@ public class EgovVectorStoreWriter implements DocumentWriter {
         for (int from = 0; from < originalIds.size(); from += DELETE_BATCH_SIZE) {
             int to = Math.min(from + DELETE_BATCH_SIZE, originalIds.size());
             List<String> idBatch = originalIds.subList(from, to);
+            Object[] escapedIds = idBatch.stream().map(EgovVectorStoreWriter::escapeTagValue).toArray();
             Filter.Expression expression = new FilterExpressionBuilder()
-                    .in(EgovVectorStoreConfig.ORIGINAL_ID_FIELD, idBatch.toArray())
+                    .in(EgovVectorStoreConfig.ORIGINAL_ID_FIELD, escapedIds)
                     .build();
             redisVectorStore.delete(expression);
         }

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovReaderOriginalIdTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovReaderOriginalIdTest.java
@@ -1,0 +1,81 @@
+package com.example.chat.config.etl.readers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.core.io.ByteArrayResource;
+
+import com.example.chat.config.EgovVectorStoreConfig;
+
+/**
+ * 리더가 남기는 원본 문서 id가 재색인 삭제 키로 쓸 수 있는 값인지 검증한다.
+ *
+ * <p>메타데이터에 담기는 값은 같은 파일을 다시 읽어도 같아야 한다. 그렇지 않으면 재색인 시
+ * 이전 청크를 찾아 지울 수 없다.</p>
+ */
+class EgovReaderOriginalIdTest {
+
+    /** 파일명을 지정할 수 있는 인메모리 리소스. */
+    private ByteArrayResource resource(String filename, String content) {
+        return new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+
+            @Override
+            public InputStream getInputStream() {
+                return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+            }
+        };
+    }
+
+    private Document readMarkdown(String filename, String content) throws Exception {
+        Method method = EgovMarkdownReader.class
+                .getDeclaredMethod("processMarkdownResource", org.springframework.core.io.Resource.class);
+        method.setAccessible(true);
+        return (Document) method.invoke(new EgovMarkdownReader(), resource(filename, content));
+    }
+
+    @Test
+    @DisplayName("Document의 기본 id는 실행마다 달라 삭제 키로 쓸 수 없다")
+    void defaultDocumentIdIsNotStable() {
+        Document first = new Document("같은 본문", new HashMap<>());
+        Document second = new Document("같은 본문", new HashMap<>());
+
+        assertThat(first.getId()).isNotEqualTo(second.getId());
+    }
+
+    @Test
+    @DisplayName("마크다운 리더는 같은 파일을 다시 읽어도 같은 원본 문서 id를 담는다")
+    void markdownReaderStoresStableOriginalId() throws Exception {
+        Document first = readMarkdown("표준프레임워크 가이드.md", "# 제목\n\n본문입니다.");
+        Document second = readMarkdown("표준프레임워크 가이드.md", "# 제목\n\n본문이 바뀌었습니다.");
+
+        String firstId = (String) first.getMetadata().get(EgovVectorStoreConfig.ORIGINAL_ID_FIELD);
+        String secondId = (String) second.getMetadata().get(EgovVectorStoreConfig.ORIGINAL_ID_FIELD);
+
+        assertThat(firstId).isEqualTo("doc-표준프레임워크-가이드.md");
+        // 본문이 달라져도 같은 파일이면 같은 값이어야 이전 청크를 지울 수 있다
+        assertThat(secondId).isEqualTo(firstId);
+        assertThat(firstId).isEqualTo(first.getId());
+    }
+
+    @Test
+    @DisplayName("서로 다른 파일은 서로 다른 원본 문서 id를 가진다")
+    void differentFilesGetDifferentOriginalIds() throws Exception {
+        Document a = readMarkdown("가이드.md", "본문");
+        Document b = readMarkdown("설명서.md", "본문");
+
+        assertThat(a.getMetadata().get(EgovVectorStoreConfig.ORIGINAL_ID_FIELD))
+                .isNotEqualTo(b.getMetadata().get(EgovVectorStoreConfig.ORIGINAL_ID_FIELD));
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterRedisDbTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterRedisDbTest.java
@@ -1,0 +1,127 @@
+package com.example.chat.config.etl.writers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.redis.RedisVectorStore;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.example.chat.config.EgovVectorStoreConfig;
+
+import redis.clients.jedis.JedisPooled;
+
+/**
+ * 실제 redis-stack에 붙여 재색인 시 기존 청크가 지워지는지 검증한다.
+ *
+ * <p>RediSearch TAG 필터는 질의문을 그대로 서버가 파싱하므로, 필터 문자열이 잘못돼도 대역
+ * 저장소로는 드러나지 않는다. 문서 id에 항상 들어가는 하이픈이 이스케이프되지 않으면 서버가
+ * 질의 파싱에 실패하고 색인 전체가 중단된다. 이 조건을 실제 엔진으로 고정한다.</p>
+ */
+@Testcontainers
+class EgovVectorStoreWriterRedisDbTest {
+
+    @Container
+    private static final GenericContainer<?> REDIS = new GenericContainer<>(
+            DockerImageName.parse("redis/redis-stack-server:latest"))
+            .withExposedPorts(6379);
+
+    /** 외부 모델 없이 결정적으로 동작하는 임베딩 대역. */
+    private static class DeterministicEmbeddingModel implements EmbeddingModel {
+
+        @Override
+        public float[] embed(Document document) {
+            return embed(document.getText());
+        }
+
+        @Override
+        public float[] embed(String text) {
+            float[] vector = new float[4];
+            vector[0] = text.length() % 7;
+            vector[1] = 1.0f;
+            return vector;
+        }
+
+        @Override
+        public EmbeddingResponse call(EmbeddingRequest request) {
+            List<Embedding> embeddings = new ArrayList<>();
+            for (int i = 0; i < request.getInstructions().size(); i++) {
+                embeddings.add(new Embedding(embed(request.getInstructions().get(i)), i));
+            }
+            return new EmbeddingResponse(embeddings);
+        }
+    }
+
+    private RedisVectorStore vectorStore(String indexName) {
+        RedisVectorStore store = RedisVectorStore
+                .builder(new JedisPooled(REDIS.getHost(), REDIS.getMappedPort(6379)),
+                        new DeterministicEmbeddingModel())
+                .indexName(indexName)
+                .prefix(indexName + ":")
+                .initializeSchema(true)
+                .metadataFields(RedisVectorStore.MetadataField.tag(EgovVectorStoreConfig.ORIGINAL_ID_FIELD))
+                .build();
+        store.afterPropertiesSet();
+        return store;
+    }
+
+    private Document chunk(String originalId, String text) {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(EgovVectorStoreConfig.ORIGINAL_ID_FIELD, originalId);
+        return new Document(text, metadata);
+    }
+
+    private List<Document> storedDocuments(RedisVectorStore store) {
+        return store.similaritySearch(SearchRequest.builder()
+                .query("본문")
+                .topK(100)
+                .similarityThresholdAll()
+                .build());
+    }
+
+    @Test
+    @DisplayName("하이픈과 마침표가 든 문서 id로 재색인하면 이전 청크만 지워진다")
+    void reindexRemovesOnlyStaleChunks() {
+        RedisVectorStore store = vectorStore("reindex-index");
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store);
+        String originalId = "doc-Term-level-Queries의-종류.md";
+
+        writer.accept(List.of(chunk(originalId, "v1 첫 번째 본문"), chunk(originalId, "v1 두 번째 본문")));
+        assertThat(storedDocuments(store)).hasSize(2);
+
+        writer.accept(List.of(chunk(originalId, "v2 새 본문")));
+
+        List<Document> remaining = storedDocuments(store);
+        assertThat(remaining).hasSize(1);
+        assertThat(remaining.get(0).getText()).isEqualTo("v2 새 본문");
+    }
+
+    @Test
+    @DisplayName("같은 파일의 다른 페이지는 재색인 대상에서 살아남는다")
+    void reindexKeepsOtherPagesOfTheSameFile() {
+        RedisVectorStore store = vectorStore("page-index");
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store);
+
+        writer.accept(List.of(chunk("pdf-개발가이드_1", "1페이지 본문"), chunk("pdf-개발가이드_2", "2페이지 본문")));
+        assertThat(storedDocuments(store)).hasSize(2);
+
+        writer.accept(List.of(chunk("pdf-개발가이드_2", "2페이지 새 본문")));
+
+        List<String> texts = storedDocuments(store).stream().map(Document::getText).toList();
+        assertThat(texts).containsExactlyInAnyOrder("1페이지 본문", "2페이지 새 본문");
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterStaleChunkTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterStaleChunkTest.java
@@ -1,0 +1,130 @@
+package com.example.chat.config.etl.writers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.redis.RedisVectorStore;
+
+import com.example.chat.config.EgovVectorStoreConfig;
+
+/**
+ * {@link EgovVectorStoreWriter}가 재색인 시 기존 청크를 먼저 지우는지 검증한다.
+ *
+ * <p>벡터 저장소는 대역으로 두고 호출 순서·삭제 필터의 내용을 확인한다.</p>
+ */
+class EgovVectorStoreWriterStaleChunkTest {
+
+    private Document chunk(String originalId, String text) {
+        Map<String, Object> metadata = new HashMap<>();
+        if (originalId != null) {
+            metadata.put(EgovVectorStoreConfig.ORIGINAL_ID_FIELD, originalId);
+        }
+        metadata.put("source", "sample.md");
+        return new Document(text, metadata);
+    }
+
+    @Test
+    @DisplayName("저장 전에 같은 원본 문서의 기존 청크를 먼저 지운다")
+    void deletesBeforeAdding() {
+        RedisVectorStore store = mock(RedisVectorStore.class);
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store);
+
+        writer.accept(List.of(chunk("doc-a", "첫 번째 청크"), chunk("doc-a", "두 번째 청크")));
+
+        InOrder order = inOrder(store);
+        order.verify(store).delete(any(Filter.Expression.class));
+        order.verify(store).add(anyList());
+    }
+
+    @Test
+    @DisplayName("한 배치에 여러 문서가 있어도 삭제 필터는 한 번에 묶어 보낸다")
+    void groupsDistinctOriginalIdsIntoOneFilter() {
+        RedisVectorStore store = mock(RedisVectorStore.class);
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store);
+
+        writer.accept(List.of(
+                chunk("doc-a", "a1"), chunk("doc-a", "a2"),
+                chunk("pdf-b_1", "b1"), chunk("pdf-b_2", "b2")));
+
+        ArgumentCaptor<Filter.Expression> captor = ArgumentCaptor.forClass(Filter.Expression.class);
+        verify(store, times(1)).delete(captor.capture());
+        String rendered = captor.getValue().toString();
+        assertThat(rendered)
+                .contains(EgovVectorStoreConfig.ORIGINAL_ID_FIELD)
+                .contains("doc-a")
+                .contains("pdf-b_1")
+                .contains("pdf-b_2");
+    }
+
+    @Test
+    @DisplayName("같은 파일의 다른 페이지는 각각 독립된 원본 문서 id로 다뤄진다")
+    void treatsPdfPagesAsSeparateDocuments() {
+        RedisVectorStore store = mock(RedisVectorStore.class);
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store);
+
+        // 2페이지만 재색인되는 상황. 1페이지 id는 삭제 대상에 들어가면 안 된다.
+        writer.accept(List.of(chunk("pdf-guide_2", "2페이지 본문")));
+
+        ArgumentCaptor<Filter.Expression> captor = ArgumentCaptor.forClass(Filter.Expression.class);
+        verify(store).delete(captor.capture());
+        String rendered = captor.getValue().toString();
+        assertThat(rendered).contains("pdf-guide_2");
+        assertThat(rendered).doesNotContain("pdf-guide_1");
+    }
+
+    @Test
+    @DisplayName("원본 문서 id가 없으면 삭제를 건너뛰고 저장은 진행한다")
+    void skipsDeleteWhenOriginalIdMissing() {
+        RedisVectorStore store = mock(RedisVectorStore.class);
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store);
+
+        writer.accept(List.of(chunk(null, "메타데이터 없는 청크")));
+
+        verify(store, never()).delete(any(Filter.Expression.class));
+        verify(store).add(anyList());
+    }
+
+    @Test
+    @DisplayName("원본 문서 id가 200건을 넘으면 삭제 필터를 나눠 보낸다")
+    void splitsDeleteIntoBatches() {
+        RedisVectorStore store = mock(RedisVectorStore.class);
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store);
+
+        List<Document> documents = new ArrayList<>();
+        IntStream.range(0, 201).forEach(i -> documents.add(chunk("doc-" + i, "본문 " + i)));
+
+        writer.accept(documents);
+
+        verify(store, times(2)).delete(any(Filter.Expression.class));
+    }
+
+    @Test
+    @DisplayName("빈 배치는 저장소를 건드리지 않는다")
+    void emptyBatchTouchesNothing() {
+        RedisVectorStore store = mock(RedisVectorStore.class);
+        EgovVectorStoreWriter writer = new EgovVectorStoreWriter(store);
+
+        writer.accept(List.of());
+
+        verify(store, never()).delete(any(Filter.Expression.class));
+        verify(store, never()).add(anyList());
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterStaleChunkTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/writers/EgovVectorStoreWriterStaleChunkTest.java
@@ -67,11 +67,12 @@ class EgovVectorStoreWriterStaleChunkTest {
         ArgumentCaptor<Filter.Expression> captor = ArgumentCaptor.forClass(Filter.Expression.class);
         verify(store, times(1)).delete(captor.capture());
         String rendered = captor.getValue().toString();
+        // 필터 값은 RediSearch 구분자를 이스케이프한 형태로 담긴다
         assertThat(rendered)
                 .contains(EgovVectorStoreConfig.ORIGINAL_ID_FIELD)
-                .contains("doc-a")
-                .contains("pdf-b_1")
-                .contains("pdf-b_2");
+                .contains("doc\\-a")
+                .contains("pdf\\-b_1")
+                .contains("pdf\\-b_2");
     }
 
     @Test
@@ -86,8 +87,8 @@ class EgovVectorStoreWriterStaleChunkTest {
         ArgumentCaptor<Filter.Expression> captor = ArgumentCaptor.forClass(Filter.Expression.class);
         verify(store).delete(captor.capture());
         String rendered = captor.getValue().toString();
-        assertThat(rendered).contains("pdf-guide_2");
-        assertThat(rendered).doesNotContain("pdf-guide_1");
+        assertThat(rendered).contains("pdf\\-guide_2");
+        assertThat(rendered).doesNotContain("pdf\\-guide_1");
     }
 
     @Test
@@ -114,6 +115,17 @@ class EgovVectorStoreWriterStaleChunkTest {
         writer.accept(documents);
 
         verify(store, times(2)).delete(any(Filter.Expression.class));
+    }
+
+    @Test
+    @DisplayName("TAG 필터 값의 구분자 문자를 이스케이프한다")
+    void escapesTagSeparatorCharacters() {
+        // RediSearch는 이스케이프하지 않은 하이픈을 구분자로 보고 질의 파싱에 실패한다.
+        assertThat(EgovVectorStoreWriter.escapeTagValue("doc-abc.md")).isEqualTo("doc\\-abc\\.md");
+        assertThat(EgovVectorStoreWriter.escapeTagValue("hwp-Spring-AI_시험문제_1"))
+                .isEqualTo("hwp\\-Spring\\-AI_시험문제_1");
+        // 한글·영숫자·밑줄은 그대로 둔다
+        assertThat(EgovVectorStoreWriter.escapeTagValue("가나다_123")).isEqualTo("가나다_123");
     }
 
     @Test


### PR DESCRIPTION
#75 머지 시 남겨 주신 후속 방향을 반영했습니다. langchain4j 모듈에서 고친 재색인 stale 청크 문제를 spring-ai 모듈에도 적용합니다.

## 변경 이유

`EgovVectorStoreWriter.accept()`가 `redisVectorStore.add()`만 호출합니다. 삭제는 어디에서도 하지 않습니다. 같은 문서를 다시 색인하면 이전 청크가 그대로 남아 현재 본문과 검색 결과를 두고 경쟁합니다. 문서를 N번 고치면 옛 본문 N-1벌이 남습니다.

이쪽은 삭제에 필요한 전제가 두 가지 빠져 있어 함께 채웠습니다.

**1. 원본 문서를 식별할 값이 없습니다.**

`TextSplitter.createDocuments()`가 청크마다 새 Document를 만들면서 임의 id를 발급하므로, 분할 이후에는 메타데이터로만 원본 문서를 가릴 수 있습니다. 그런데 리더 5종 중 `EgovPdfReader`만 `original_id`를 남기고 있었고, 그 값도 삭제 키로는 쓸 수 없었습니다.

```java
document.getMetadata().put("original_id", document.getId());
```

여기서 `document`는 아직 customId를 부여하기 전의 문서이고, `Document`의 기본 id는 `RandomIdGenerator`가 만드는 값이라 **같은 파일을 다시 읽으면 다른 값**이 됩니다. 이전 색인 때의 값을 알 수 없으니 지울 대상을 찾지 못합니다.

반면 각 리더가 만드는 customId(`doc-<파일명>`, `pdf-<파일명>_<페이지>`, `docx-…`, `hwp-…_1`, `hwpx-…`)는 파일명에서만 유도되어 실행마다 같습니다. 이 값을 메타데이터에 담으면 삭제 키가 됩니다.

**2. 인덱스에 필터할 필드가 없습니다.**

오토컨피그가 만드는 `RedisVectorStore`는 `metadataFields`를 하나도 선언하지 않습니다. RediSearch는 인덱스 스키마에 없는 필드로 필터할 수 없으므로, 그 상태에서는 `delete(Filter.Expression)`이 어떤 문서와도 매칭되지 않습니다.

## 변경 내용

- **리더 5종**이 각자의 customId를 `original_id` 메타데이터에 담습니다. `EgovPdfReader`는 임의 id 대신 customId를 담도록 바꿨고, 나머지 4종은 새로 추가했습니다.
- **`EgovVectorStoreConfig`** 를 추가해 `original_id`를 태그 필드로 등록한 `RedisVectorStore` 빈을 정의합니다. 오토컨피그의 빈 정의는 `@ConditionalOnMissingBean`이라 이 빈이 대신 쓰입니다. 인덱스 이름·prefix·스키마 초기화 여부는 기존 설정 키(`spring.ai.vectorstore.redis.*`)를 그대로 읽어 동작이 달라지지 않습니다.
- **`EgovVectorStoreWriter`** 가 저장 전에 이번 배치의 원본 문서 id로 기존 청크를 지웁니다. `FilterExpressionBuilder.in("original_id", …)`을 쓰고, id가 많으면 200건씩 나눠 보냅니다. 원본 문서 id가 없으면 경고만 남기고 저장은 진행합니다.

삭제 키로 파일명(`source`)을 쓰지 않은 이유는 langchain4j 때와 같습니다. PDF 리더는 페이지마다 문서를 만들고 변경 판정도 페이지 단위이므로, 파일명으로 지우면 이번 배치에 없는 페이지까지 사라지고 그 페이지는 해시가 그대로라 다시 색인되지 않습니다.

## 테스트 방법

```
cd spring-ai-rag-redis-stack && mvn -B test
```

모듈 전체 136건이 통과합니다(신규 9건 포함, 실패·오류 0건). main 기준 127건입니다.

- `EgovVectorStoreWriterStaleChunkTest` 6건 — 삭제가 저장보다 먼저 일어나는지, 여러 문서의 id를 한 필터로 묶는지, 같은 파일의 다른 페이지가 삭제 대상에 섞이지 않는지, id가 없으면 삭제를 건너뛰고 저장은 진행하는지, 200건 초과 시 나눠 보내는지, 빈 배치가 저장소를 건드리지 않는지
- `EgovReaderOriginalIdTest` 3건 — `Document` 기본 id가 실행마다 달라진다는 사실, 마크다운 리더가 본문이 바뀌어도 같은 파일이면 같은 `original_id`를 담는지, 다른 파일은 다른 값을 갖는지

본문 수정만 되돌리고 테스트만 적용하면 9건 중 6건이 실패합니다.

## 영향 범위

- 수정 파일은 리더 5개(각 1~2줄), writer, 신규 config 1개와 테스트 2개입니다.
- `spring.ai.vectorstore.redis.*` 설정 키는 그대로입니다. 새 설정 키를 추가하지 않았습니다.
- **기존 인덱스 주의** — `initialize-schema`는 인덱스가 없을 때만 스키마를 만듭니다. 이 변경 이전에 만들어진 `document-index`에는 `original_id` 필드가 없어 삭제 필터가 0건을 매칭합니다. 이때 동작은 변경 전과 같고(이전 청크가 남음) 데이터가 유실되지는 않습니다. 삭제를 적용하려면 `FT.DROPINDEX document-index`로 인덱스만 지운 뒤(문서 해시는 보존됩니다) 재기동해 스키마를 다시 만들면 됩니다. 이 내용은 config 클래스 javadoc에도 적어 두었습니다.
- 하위 디렉터리에 같은 파일명이 있으면 문서 id가 겹치는 문제는 그대로입니다. 리더가 파일명만으로 id를 만드는 쪽이 원인이라 이 PR 범위 밖으로 두었고, 별도로 정리해 올리겠습니다.
