### PR TITLE
fix: HWPX 추출에서 문단·표 구조가 사라지는 문제 수정 (#77)

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpxReader.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpxReader.java
@@ -6,6 +6,7 @@ import kr.dogfoot.hwpxlib.object.HWPXFile;
 import kr.dogfoot.hwpxlib.reader.HWPXReader;
 import kr.dogfoot.hwpxlib.tool.textextractor.TextExtractMethod;
 import kr.dogfoot.hwpxlib.tool.textextractor.TextExtractor;
+import kr.dogfoot.hwpxlib.tool.textextractor.TextMarks;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -27,6 +28,24 @@ import java.util.List;
 @Slf4j
 @Component
 public class EgovHwpxReader {
+
+    /**
+     * 문단·표 구조를 남기기 위한 추출 표식.
+     *
+     * <p>hwpxlib의 {@code TextExtractor}는 {@code TextMarks}가 {@code null}이면 구분자를 하나도 넣지
+     * 않는다({@code TextBuilder.paraSeparator()} 등이 즉시 반환). 그 결과 문서 전체가 개행 없는 한 줄이
+     * 되고, 표는 셀 값이 이어 붙어 행과 열의 관계가 사라진다.</p>
+     *
+     * <p>문단·표 행·표 셀 세 가지만 지정한다. 컨테이너·도형 등 나머지 표식은 지정하지 않아 기존과 같은
+     * 텍스트가 나온다. 셀 구분자는 셀 사이에만 들어가며 행 맨 앞에는 붙지 않는다. 줄 맨 앞의 파이프는
+     * 문장 분할기가 마크다운 블록 시작으로 인식해 의도하지 않은 경계를 만든다.</p>
+     *
+     * <p>지정 후에는 값을 바꾸지 않으므로 인스턴스를 공유한다.</p>
+     */
+    private static final TextMarks STRUCTURE_MARKS = new TextMarks()
+            .paraSeparatorAnd("\n")
+            .tableRowSeparatorAnd("\n")
+            .tableCellSeparatorAnd(" | ");
 
     @Value("${document.hwpx-path:#{null}}")
     private String hwpxDocumentPath;
@@ -102,7 +121,7 @@ public class EgovHwpxReader {
                     hwpxFile,
                     TextExtractMethod.InsertControlTextBetweenParagraphText,
                     false,
-                    null);
+                    STRUCTURE_MARKS);
 
             if (content == null || content.trim().isEmpty()) {
                 log.warn("HWPX 파일 '{}'에서 추출된 텍스트가 없습니다.", filename);

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovHwpxStructureExtractionTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovHwpxStructureExtractionTest.java
@@ -1,0 +1,128 @@
+package com.example.chat.config.etl.readers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kr.dogfoot.hwpxlib.object.HWPXFile;
+import kr.dogfoot.hwpxlib.object.content.section_xml.SectionXMLFile;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.Para;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.Run;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.T;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.object.Table;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.object.table.Tc;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.object.table.Tr;
+import kr.dogfoot.hwpxlib.tool.blankfilemaker.BlankFileMaker;
+import kr.dogfoot.hwpxlib.tool.textextractor.TextExtractMethod;
+import kr.dogfoot.hwpxlib.tool.textextractor.TextExtractor;
+import kr.dogfoot.hwpxlib.tool.textextractor.TextMarks;
+
+/**
+ * HWPX 추출이 문단과 표 구조를 남기는지 검증한다.
+ *
+ * <p>문서를 메모리에서 만들어 리더가 쓰는 표식으로 추출한다. 샘플 파일을 저장소에 두지 않고도
+ * 결정적으로 확인할 수 있다.</p>
+ */
+class EgovHwpxStructureExtractionTest {
+
+    /** 리더가 실제로 쓰는 표식을 그대로 가져온다. */
+    private TextMarks readerMarks() throws Exception {
+        Field field = EgovHwpxReader.class.getDeclaredField("STRUCTURE_MARKS");
+        field.setAccessible(true);
+        return (TextMarks) field.get(null);
+    }
+
+    private void addText(Para para, String text) {
+        Run run = para.addNewRun();
+        run.charPrIDRefAnd("0");
+        T t = run.addNewT();
+        t.addText(text);
+    }
+
+    private void addCell(Tr row, String text) {
+        Tc cell = row.addNewTc();
+        cell.createSubList();
+        addText(cell.subList().addNewPara(), text);
+    }
+
+    /** 문단 2개와 3×3 표 하나를 담은 문서. */
+    private HWPXFile sampleDocument() throws Exception {
+        HWPXFile file = BlankFileMaker.make();
+        SectionXMLFile section = file.sectionXMLFileList().get(0);
+        addText(section.addNewPara(), "제1조(목적) 이 규정은 수수료 기준을 정함을 목적으로 한다");
+        addText(section.addNewPara(), "제2조(수수료) 수수료는 별표와 같다");
+
+        Para tableParagraph = section.addNewPara();
+        Run run = tableParagraph.addNewRun();
+        run.charPrIDRefAnd("0");
+        Table table = run.addNewTable();
+        String[][] rows = {
+                {"민원종류", "수수료", "처리기간"},
+                {"주민등록등본", "400원", "즉시"},
+                {"가족관계증명서", "1000원", "3일"}};
+        for (String[] row : rows) {
+            Tr tr = table.addNewTr();
+            for (String cell : row) {
+                addCell(tr, cell);
+            }
+        }
+        return file;
+    }
+
+    private String extract(TextMarks marks) throws Exception {
+        return TextExtractor.extract(sampleDocument(),
+                TextExtractMethod.InsertControlTextBetweenParagraphText, false, marks);
+    }
+
+    @Test
+    @DisplayName("문단 사이에 개행이 들어간다")
+    void paragraphsAreSeparated() throws Exception {
+        String extracted = extract(readerMarks());
+
+        assertThat(extracted).contains("정함을 목적으로 한다\n제2조(수수료)");
+    }
+
+    @Test
+    @DisplayName("표는 행마다 줄이 나뉘고 셀은 구분자로 이어진다")
+    void tableRowsAndCellsAreSeparated() throws Exception {
+        String extracted = extract(readerMarks());
+
+        assertThat(extracted)
+                .contains("민원종류 | 수수료 | 처리기간")
+                .contains("주민등록등본 | 400원 | 즉시")
+                .contains("가족관계증명서 | 1000원 | 3일");
+    }
+
+    @Test
+    @DisplayName("셀 구분자는 행 맨 앞에 붙지 않는다")
+    void cellSeparatorDoesNotStartALine() throws Exception {
+        String extracted = extract(readerMarks());
+
+        for (String line : extracted.split("\n")) {
+            assertThat(line.trim()).doesNotStartWith("|");
+        }
+    }
+
+    @Test
+    @DisplayName("표식이 없으면 구조가 모두 사라진다")
+    void withoutMarksEverythingCollapsesIntoOneLine() throws Exception {
+        String extracted = extract(null);
+
+        assertThat(extracted).doesNotContain("\n");
+        // 표의 행 관계가 남지 않아 셀 값이 그대로 이어 붙는다
+        assertThat(extracted).contains("주민등록등본400원즉시");
+    }
+
+    @Test
+    @DisplayName("본문 글자는 표식 적용 전후가 같다")
+    void textContentIsUnchanged() throws Exception {
+        String withoutMarks = extract(null);
+        String withMarks = extract(readerMarks());
+
+        String stripped = withMarks.replace("\n", "").replace(" | ", "");
+        assertThat(stripped).isEqualTo(withoutMarks);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpxReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpxReader.java
@@ -15,12 +15,31 @@ import kr.dogfoot.hwpxlib.object.HWPXFile;
 import kr.dogfoot.hwpxlib.reader.HWPXReader;
 import kr.dogfoot.hwpxlib.tool.textextractor.TextExtractMethod;
 import kr.dogfoot.hwpxlib.tool.textextractor.TextExtractor;
+import kr.dogfoot.hwpxlib.tool.textextractor.TextMarks;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 public class EgovHwpxReader implements DocumentReader {
+
+    /**
+     * 문단·표 구조를 남기기 위한 추출 표식.
+     *
+     * <p>hwpxlib의 {@code TextExtractor}는 {@code TextMarks}가 {@code null}이면 구분자를 하나도 넣지
+     * 않는다({@code TextBuilder.paraSeparator()} 등이 즉시 반환). 그 결과 문서 전체가 개행 없는 한 줄이
+     * 되고, 표는 셀 값이 이어 붙어 행과 열의 관계가 사라진다.</p>
+     *
+     * <p>문단·표 행·표 셀 세 가지만 지정한다. 컨테이너·도형 등 나머지 표식은 지정하지 않아 기존과 같은
+     * 텍스트가 나온다. 셀 구분자는 셀 사이에만 들어가며 행 맨 앞에는 붙지 않는다. 줄 맨 앞의 파이프는
+     * 문장 분할기가 마크다운 블록 시작으로 인식해 의도하지 않은 경계를 만든다.</p>
+     *
+     * <p>지정 후에는 값을 바꾸지 않으므로 인스턴스를 공유한다.</p>
+     */
+    private static final TextMarks STRUCTURE_MARKS = new TextMarks()
+            .paraSeparatorAnd("\n")
+            .tableRowSeparatorAnd("\n")
+            .tableCellSeparatorAnd(" | ");
 
     @Value("${spring.ai.document.hwpx-path:#{null}}")
     private String hwpxDocumentPath;
@@ -82,7 +101,7 @@ public class EgovHwpxReader implements DocumentReader {
                 hwpxFile,
                 TextExtractMethod.InsertControlTextBetweenParagraphText,
                 false,
-                null
+                STRUCTURE_MARKS
         );
 
         if (content == null || content.trim().isEmpty()) {

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovHwpxStructureExtractionTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovHwpxStructureExtractionTest.java
@@ -1,0 +1,128 @@
+package com.example.chat.config.etl.readers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kr.dogfoot.hwpxlib.object.HWPXFile;
+import kr.dogfoot.hwpxlib.object.content.section_xml.SectionXMLFile;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.Para;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.Run;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.T;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.object.Table;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.object.table.Tc;
+import kr.dogfoot.hwpxlib.object.content.section_xml.paragraph.object.table.Tr;
+import kr.dogfoot.hwpxlib.tool.blankfilemaker.BlankFileMaker;
+import kr.dogfoot.hwpxlib.tool.textextractor.TextExtractMethod;
+import kr.dogfoot.hwpxlib.tool.textextractor.TextExtractor;
+import kr.dogfoot.hwpxlib.tool.textextractor.TextMarks;
+
+/**
+ * HWPX 추출이 문단과 표 구조를 남기는지 검증한다.
+ *
+ * <p>문서를 메모리에서 만들어 리더가 쓰는 표식으로 추출한다. 샘플 파일을 저장소에 두지 않고도
+ * 결정적으로 확인할 수 있다.</p>
+ */
+class EgovHwpxStructureExtractionTest {
+
+    /** 리더가 실제로 쓰는 표식을 그대로 가져온다. */
+    private TextMarks readerMarks() throws Exception {
+        Field field = EgovHwpxReader.class.getDeclaredField("STRUCTURE_MARKS");
+        field.setAccessible(true);
+        return (TextMarks) field.get(null);
+    }
+
+    private void addText(Para para, String text) {
+        Run run = para.addNewRun();
+        run.charPrIDRefAnd("0");
+        T t = run.addNewT();
+        t.addText(text);
+    }
+
+    private void addCell(Tr row, String text) {
+        Tc cell = row.addNewTc();
+        cell.createSubList();
+        addText(cell.subList().addNewPara(), text);
+    }
+
+    /** 문단 2개와 3×3 표 하나를 담은 문서. */
+    private HWPXFile sampleDocument() throws Exception {
+        HWPXFile file = BlankFileMaker.make();
+        SectionXMLFile section = file.sectionXMLFileList().get(0);
+        addText(section.addNewPara(), "제1조(목적) 이 규정은 수수료 기준을 정함을 목적으로 한다");
+        addText(section.addNewPara(), "제2조(수수료) 수수료는 별표와 같다");
+
+        Para tableParagraph = section.addNewPara();
+        Run run = tableParagraph.addNewRun();
+        run.charPrIDRefAnd("0");
+        Table table = run.addNewTable();
+        String[][] rows = {
+                {"민원종류", "수수료", "처리기간"},
+                {"주민등록등본", "400원", "즉시"},
+                {"가족관계증명서", "1000원", "3일"}};
+        for (String[] row : rows) {
+            Tr tr = table.addNewTr();
+            for (String cell : row) {
+                addCell(tr, cell);
+            }
+        }
+        return file;
+    }
+
+    private String extract(TextMarks marks) throws Exception {
+        return TextExtractor.extract(sampleDocument(),
+                TextExtractMethod.InsertControlTextBetweenParagraphText, false, marks);
+    }
+
+    @Test
+    @DisplayName("문단 사이에 개행이 들어간다")
+    void paragraphsAreSeparated() throws Exception {
+        String extracted = extract(readerMarks());
+
+        assertThat(extracted).contains("정함을 목적으로 한다\n제2조(수수료)");
+    }
+
+    @Test
+    @DisplayName("표는 행마다 줄이 나뉘고 셀은 구분자로 이어진다")
+    void tableRowsAndCellsAreSeparated() throws Exception {
+        String extracted = extract(readerMarks());
+
+        assertThat(extracted)
+                .contains("민원종류 | 수수료 | 처리기간")
+                .contains("주민등록등본 | 400원 | 즉시")
+                .contains("가족관계증명서 | 1000원 | 3일");
+    }
+
+    @Test
+    @DisplayName("셀 구분자는 행 맨 앞에 붙지 않는다")
+    void cellSeparatorDoesNotStartALine() throws Exception {
+        String extracted = extract(readerMarks());
+
+        for (String line : extracted.split("\n")) {
+            assertThat(line.trim()).doesNotStartWith("|");
+        }
+    }
+
+    @Test
+    @DisplayName("표식이 없으면 구조가 모두 사라진다")
+    void withoutMarksEverythingCollapsesIntoOneLine() throws Exception {
+        String extracted = extract(null);
+
+        assertThat(extracted).doesNotContain("\n");
+        // 표의 행 관계가 남지 않아 셀 값이 그대로 이어 붙는다
+        assertThat(extracted).contains("주민등록등본400원즉시");
+    }
+
+    @Test
+    @DisplayName("본문 글자는 표식 적용 전후가 같다")
+    void textContentIsUnchanged() throws Exception {
+        String withoutMarks = extract(null);
+        String withMarks = extract(readerMarks());
+
+        String stripped = withMarks.replace("\n", "").replace(" | ", "");
+        assertThat(stripped).isEqualTo(withoutMarks);
+    }
+}


### PR DESCRIPTION
#77에서 정리해 주신 방향대로 구현했습니다. 토글과 새 클래스는 두지 않고 리더를 직접 고쳤습니다.

## 변경 이유

두 모듈의 `EgovHwpxReader`가 `TextExtractor.extract()`에 `TextMarks`를 `null`로 넘깁니다.

```java
String content = TextExtractor.extract(
        hwpxFile,
        TextExtractMethod.InsertControlTextBetweenParagraphText,
        false,
        null          // TextMarks
);
```

hwpxlib의 `TextBuilder.paraSeparator()`·`tableRowSeparator()`·`tableCellSeparator()`는 `textMarks`가 `null`이면 즉시 반환합니다. 구분자가 하나도 들어가지 않아 문서 전체가 개행 없는 한 줄이 되고, 표는 셀 값이 이어 붙어 행과 열의 관계가 사라집니다.

문단 2개와 3×3 표 하나를 담은 문서를 리더와 같은 인자로 추출한 결과입니다.

```
제1조(목적) 이 규정은 수수료 기준을 정함을 목적으로 한다제2조(수수료) 수수료는 별표와 같다민원종류수수료처리기간주민등록등본400원즉시가족관계증명서1000원3일

길이=90 / 개행수=0
```

`주민등록등본400원즉시가족관계증명서1000원3일`에는 어느 값이 어느 항목인지가 남아 있지 않습니다.

업로드로 받는 확장자가 `.md`·`.hwp`·`.hwpx`이고 청크 크기가 4000자이므로, 개행 없는 덩어리는 조문이나 표 중간에서 잘립니다. 한국어 문장경계 분할기도 종결어미와 마침표를 경계로 삼아 표에서는 동작하지 않습니다.

## 변경 내용

`TextMarks`를 문단·표 행·표 셀 세 가지만 지정합니다.

```java
private static final TextMarks STRUCTURE_MARKS = new TextMarks()
        .paraSeparatorAnd("\n")
        .tableRowSeparatorAnd("\n")
        .tableCellSeparatorAnd(" | ");
```

같은 문서의 추출 결과가 이렇게 바뀝니다.

```
제1조(목적) 이 규정은 수수료 기준을 정함을 목적으로 한다
제2조(수수료) 수수료는 별표와 같다
민원종류 | 수수료 | 처리기간
주민등록등본 | 400원 | 즉시
가족관계증명서 | 1000원 | 3일

길이=113 / 개행수=5
```

말씀하신 세 가지를 반영했습니다.

- **토글 없이 리더 직접 수정.** 컨테이너·도형 표식은 지정하지 않으므로 그쪽 출력은 이전과 같습니다. 켜고 끌 대상이 없어 설정을 두지 않았습니다.
- **셀 구분자는 셀 사이에만.** hwpxlib이 셀 앞이 아니라 셀 사이에 넣어 행 맨 앞에는 파이프가 붙지 않습니다. 줄 맨 앞 파이프가 `isMarkdownBlockStart`에 걸리는 문제를 피하려고 이 동작을 테스트로 고정했습니다.
- **`normalization.normalize-newlines`.** 아래 "운영 시 설정"에 적었습니다.

두 모듈에 같은 상수와 같은 테스트를 넣었습니다. `TextMarks` API는 langchain4j가 쓰는 hwpxlib 1.0.5와 spring-ai가 쓰는 1.0.8 양쪽에 있어 의존성 버전은 건드리지 않았습니다.

## 운영 시 설정

`EgovContentFormatTransformer`가 분할기보다 먼저 실행되고, 기본값 `normalize-newlines: true`가 연속 개행을 하나로 줄입니다. 이번 변경으로 생긴 문단·표 행 경계는 단일 개행이라 이 단계에서 사라지지 않지만, 문단 사이 빈 줄을 경계로 쓰려면 `normalization.normalize-newlines: false`가 필요합니다.

표 행 사이는 단일 개행이므로 분할기가 별도 경계로 인식하지는 않습니다. 표가 한 구간에 함께 남을 수 있고 이때도 내용 손실은 없습니다.

## 테스트 방법

```
cd spring-ai-rag-redis-stack && mvn -B test
cd langchain4j-ai-rag-postgre && mvn -B test
```

spring-ai 132건, langchain4j 129건이 통과합니다(각 신규 5건 포함, 실패·오류 0건). main 기준으로는 127건과 124건입니다.

테스트는 `BlankFileMaker`로 문서를 메모리에서 만들어 검증하므로 샘플 파일을 저장소에 두지 않습니다. 확인 항목은 문단 사이 개행, 표의 행 분리와 셀 구분자, 행 맨 앞에 파이프가 붙지 않는지, 표식이 없을 때 구조가 모두 사라지는지, 표식 적용 전후로 본문 글자가 같은지입니다.

수정 전 동작은 네 번째 항목이 직접 고정합니다. `TextMarks`에 `null`을 넘겨 추출하면 개행이 하나도 없고 `주민등록등본400원즉시`가 이어 붙는다는 것을 확인합니다.

## 영향 범위

- 수정 파일은 두 모듈의 `EgovHwpxReader.java`(각 본문 4줄과 주석)와 신규 테스트 2개입니다.
- HWPX 문서에서 뽑히는 텍스트가 달라지므로 이미 색인한 문서는 재색인해야 새 구조가 반영됩니다. 본문 글자 자체는 바뀌지 않습니다.
- 설정 키, 공개 API, 의존성 변경은 없습니다.

HWP(바이너리) 쪽은 이번 PR에 넣지 않았습니다. hwplib은 `ControlTable.getRowList()`·`Row.getCellList()`를 직접 순회해야 해서 접근이 다릅니다. 이 형식이 확정되면 같은 출력이 나오도록 맞춰 별도로 올리겠습니다.
