### PR TITLE
fix(langchain4j): application.yml이 문서화한 청크 한도 2종이 적용되지 않던 문제 수정

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovEnhancedDocumentTransformer.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/transformers/EgovEnhancedDocumentTransformer.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * 문서 변환기
@@ -23,11 +22,18 @@ import java.util.stream.Collectors;
 public class EgovEnhancedDocumentTransformer implements DocumentTransformer {
 
     private final DocumentSplitter documentSplitter;
+    private final int minChunkLengthToEmbed;
+    private final int maxNumChunks;
 
     public EgovEnhancedDocumentTransformer(
             @Value("${document.chunk-size}") int chunkSize,
             @Value("${document.min-chunk-size-chars}") int minChunkSizeChars,
+            @Value("${document.min-chunk-length-to-embed}") int minChunkLengthToEmbed,
+            @Value("${document.max-num-chunks}") int maxNumChunks,
             ObjectProvider<EgovKoreanSentenceSplitter> koreanSentenceSplitterProvider) {
+
+        this.minChunkLengthToEmbed = minChunkLengthToEmbed;
+        this.maxNumChunks = maxNumChunks;
 
         // LangChain4j의 DocumentSplitter 생성
         // 토큰 기반 분할 (최대 토큰 수, 오버랩)
@@ -40,8 +46,8 @@ public class EgovEnhancedDocumentTransformer implements DocumentTransformer {
         if (koreanSentenceSplitter != null) {
             log.info("문서 분할기 선택 - splitter: {}", this.documentSplitter.getClass().getSimpleName());
         }
-        log.info("EnhancedDocumentTransformer 초기화 - chunkSize: {}, minChunkSize: {}",
-                chunkSize, minChunkSizeChars);
+        log.info("EnhancedDocumentTransformer 초기화 - chunkSize: {}, minChunkSize: {}, minChunkLengthToEmbed: {}, maxNumChunks: {}",
+                chunkSize, minChunkSizeChars, minChunkLengthToEmbed, maxNumChunks);
     }
 
     @Override
@@ -70,11 +76,19 @@ public class EgovEnhancedDocumentTransformer implements DocumentTransformer {
         List<Document> splitDocs = new ArrayList<>();
         for (Document doc : documents) {
             List<TextSegment> segments = documentSplitter.split(doc);
-            // TextSegment를 Document로 변환
-            List<Document> chunks = segments.stream()
-                    .map(segment -> Document.from(segment.text(), segment.metadata()))
-                    .collect(Collectors.toList());
-            splitDocs.addAll(chunks);
+            // TextSegment를 Document로 변환하면서 설정된 청크 한도를 적용한다.
+            int kept = 0;
+            for (TextSegment segment : segments) {
+                if (kept >= maxNumChunks) {
+                    break;
+                }
+                String text = segment.text();
+                if (text == null || text.trim().length() <= minChunkLengthToEmbed) {
+                    continue;
+                }
+                splitDocs.add(Document.from(text, segment.metadata()));
+                kept++;
+            }
         }
         log.info("문서 분할 완료: {}개 청크 생성", splitDocs.size());
 

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/EgovKoreanChunkingToggleTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/EgovKoreanChunkingToggleTest.java
@@ -86,7 +86,8 @@ class EgovKoreanChunkingToggleTest {
         @Bean
         EgovEnhancedDocumentTransformer egovEnhancedDocumentTransformer(
                 ObjectProvider<EgovKoreanSentenceSplitter> koreanSentenceSplitterProvider) {
-            return new EgovEnhancedDocumentTransformer(500, 1, koreanSentenceSplitterProvider);
+            // 청크 한도는 이 테스트의 관심사가 아니므로 아무것도 걸러내지 않는 값을 쓴다.
+            return new EgovEnhancedDocumentTransformer(500, 1, 0, Integer.MAX_VALUE, koreanSentenceSplitterProvider);
         }
     }
 }

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovEnhancedDocumentTransformerChunkLimitTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/transformers/EgovEnhancedDocumentTransformerChunkLimitTest.java
@@ -1,0 +1,54 @@
+package com.example.chat.config.etl.transformers;
+
+import dev.langchain4j.data.document.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * application.yml 이 문서화한 청크 한도(document.max-num-chunks,
+ * document.min-chunk-length-to-embed)가 실제 분할 결과에 적용되는지 검증한다.
+ */
+class EgovEnhancedDocumentTransformerChunkLimitTest {
+
+    private static final int CHUNK_SIZE = 500;
+
+    @SuppressWarnings("unchecked")
+    private EgovEnhancedDocumentTransformer transformer(int minChunkLengthToEmbed, int maxNumChunks) {
+        ObjectProvider<EgovKoreanSentenceSplitter> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(null);
+        return new EgovEnhancedDocumentTransformer(CHUNK_SIZE, 1, minChunkLengthToEmbed, maxNumChunks, provider);
+    }
+
+    private Document longDocument() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 3000; i++) {
+            sb.append("이것은 ").append(i).append("번째 문장입니다. ");
+        }
+        return Document.from(sb.toString());
+    }
+
+    @Test
+    @DisplayName("max-num-chunks 를 넘는 청크는 만들지 않는다")
+    void limitsNumberOfChunks() {
+        int unlimited = transformer(0, Integer.MAX_VALUE).transformAll(List.of(longDocument())).size();
+        assertThat(unlimited).isGreaterThan(3);
+
+        List<Document> capped = transformer(0, 3).transformAll(List.of(longDocument()));
+        assertThat(capped).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("min-chunk-length-to-embed 보다 짧은 청크는 임베딩 대상에서 제외한다")
+    void dropsChunksShorterThanMinLength() {
+        List<Document> chunks = transformer(100_000, Integer.MAX_VALUE)
+                .transformAll(List.of(longDocument()));
+        assertThat(chunks).isEmpty();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

langchain4j 모듈의 `application.yml`은 spring-ai 모듈과 같은 주석·같은 값으로 청크 한도를 선언합니다.

```yaml
  # 최대 청크 수
  max-num-chunks: 500

  # 임베딩할 최소 청크 길이
  min-chunk-length-to-embed: 50
```

이 두 값은 langchain4j 모듈의 java 소스 전체에서 참조가 한 건도 없었습니다.

```
$ grep -rn "maxNumChunks\|minChunkLengthToEmbed" langchain4j-ai-rag-postgre/src/main/java
(결과 없음)
```

`EgovEnhancedDocumentTransformer.transformAll`이 splitter가 만든 세그먼트를 그대로 `Document`로 옮기기만 해서, 임베딩 최소 길이에 못 미치는 조각도 저장되고 문서가 아무리 커도 청크 수가 제한되지 않았습니다.

형제 spring-ai 모듈은 같은 값 네 개를 모두 `TokenTextSplitter` 생성자에 넘겨 실제로 강제합니다. 두 한도의 의미도 그 모듈의 `EgovKoreanSentenceSplitter`에 코드로 나와 있어 그대로 따랐습니다 — `maxNumChunks`는 청크 수 상한(`chunks.size() >= maxNumChunks`면 중단), `minChunkLengthToEmbed`는 `trimmed.length() > minChunkLengthToEmbed`인 청크만 통과.

AS-IS

```java
List<TextSegment> segments = documentSplitter.split(doc);
List<Document> chunks = segments.stream()
        .map(segment -> Document.from(segment.text(), segment.metadata()))
        .collect(Collectors.toList());
splitDocs.addAll(chunks);
```

TO-BE

```java
List<TextSegment> segments = documentSplitter.split(doc);
// TextSegment를 Document로 변환하면서 설정된 청크 한도를 적용한다.
int kept = 0;
for (TextSegment segment : segments) {
    if (kept >= maxNumChunks) {
        break;
    }
    String text = segment.text();
    if (text == null || text.trim().length() <= minChunkLengthToEmbed) {
        continue;
    }
    splitDocs.add(Document.from(text, segment.metadata()));
    kept++;
}
```

한도는 spring-ai 형제와 마찬가지로 문서 단위로 적용됩니다. 청크 내용은 바꾸지 않고 통과 여부만 판단합니다.

`min-chunk-size-chars`는 범위에서 뺐습니다. 이 값은 분할기 내부에서 끊을 위치를 고르는 힌트라 `DocumentSplitters.recursive`에 대응하는 설정이 없습니다.

### 영향 범위

`application.yml`은 건드리지 않았습니다(이미 선언된 키를 읽기만 합니다). 생성자 호출부는 프로덕션 1곳과 테스트 2곳뿐이고 모두 이 커밋에서 함께 고쳤습니다. spring-ai 모듈은 이미 이 한도를 강제하고 있어 변경하지 않았습니다.

기존 `EgovKoreanChunkingToggleTest`는 생성자 인자가 늘어 함께 고쳤습니다. 그 테스트의 관심사는 토글 동작이므로 아무것도 걸러내지 않는 값(`0`, `Integer.MAX_VALUE`)을 넣었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovEnhancedDocumentTransformerChunkLimitTest`를 추가했습니다. 한도 적용 로직만 되돌리고(생성자 인자는 유지) 테스트를 돌리면 2건 모두 실패합니다.

수정 전(RED)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovEnhancedDocumentTransformerChunkLimitTest.dropsChunksShorterThanMinLength
[ERROR]   EgovEnhancedDocumentTransformerChunkLimitTest.limitsNumberOfChunks
```

수정 후(GREEN, 모듈 전체)

```
[INFO] Tests run: 126, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

백엔드 문서 변환 로직 변경이라 화면과 무관하여 JUnit 단위 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
