### PR TITLE
fix(langchain4j): application.yml이 선언했지만 읽히지 않는 설정 키 정리

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -58,8 +58,6 @@ pgvector:
   dimension: 768
   # 인덱스 생성 여부
   create-table: true
-  # 거리 측정 방식 (cosine, euclidean, inner_product)
-  distance-type: cosine
 
 # 문서 처리 설정
 document:
@@ -71,11 +69,6 @@ document:
   hwp-path: file:C:/workspace-test/upload/data/**/*.hwp
   # HWPX 문서 경로. 설정하지 않으면 건너뜀. 예: file:C:/workspace-test/upload/data/**/*.hwpx
   hwpx-path: file:C:/workspace-test/upload/data/**/*.hwpx
-
-  # PDF 리더 설정
-  pdf:
-    page-top-margin: 0
-    pages-per-document: 1
 
   # 문서 변환 설정
   # 청크 크기 설정 (토큰 단위)

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovYamlBindingTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovYamlBindingTest.java
@@ -1,0 +1,121 @@
+package com.example.chat.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * {@code application.yml}이 선언한 설정 키가 실제로 읽히는지 검증한다.
+ *
+ * <p>읽히지 않는 키는 조용히 무시된다. 값을 바꿔도 아무 일이 일어나지 않으므로 설정을 바꾼
+ * 사람은 바뀐 줄 알고, 다음 사람은 그 값을 사실로 읽는다. {@code pgvector.distance-type}과
+ * {@code document.pdf.*}가 그런 경우였다.
+ *
+ * <p>어느 클래스가 읽는지는 미리 정하지 않는다. 모듈의 모든 클래스에서
+ * {@code @Value} 자리표시자를 모아 비교하므로, 읽는 자리를 다른 클래스로 옮겨도 통과한다.
+ */
+class EgovYamlBindingTest {
+
+    /** 검사 대상 — yml 경로와, 그 아래 키가 모두 읽혀야 하는 블록. */
+    private static final List<String> WATCHED = List.of("pgvector", "document.pdf");
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([A-Za-z0-9._-]+)");
+
+    @Test
+    void everyWatchedKeyInTheMainYamlIsRead() throws Exception {
+        assertThat(unreadKeysIn(Path.of("src/main/resources/application.yml"))).isEmpty();
+    }
+
+    @Test
+    void everyWatchedKeyInTheTestYamlIsRead() throws Exception {
+        assertThat(unreadKeysIn(Path.of("src/test/resources/application.yml"))).isEmpty();
+    }
+
+    /** yml 에는 있는데 {@code @Value} 로 읽는 곳이 없는 키. */
+    private TreeSet<String> unreadKeysIn(Path yaml) throws Exception {
+        TreeSet<String> declared = declaredKeys(yaml);
+        declared.removeAll(placeholders());
+        return declared;
+    }
+
+    private TreeSet<String> declaredKeys(Path yaml) throws Exception {
+        assertThat(yaml).as("설정 파일을 찾지 못했다").exists();
+        Map<String, Object> root;
+        try (InputStream in = Files.newInputStream(yaml)) {
+            root = new Yaml().load(in);
+        }
+        TreeSet<String> keys = new TreeSet<>();
+        for (String block : WATCHED) {
+            Object node = root;
+            for (String step : block.split("\\.")) {
+                node = node instanceof Map ? ((Map<?, ?>) node).get(step) : null;
+            }
+            if (node instanceof Map) {
+                ((Map<?, ?>) node).keySet().forEach(k -> keys.add(block + "." + k));
+            }
+        }
+        assertThat(keys).as("%s 에서 검사할 블록을 하나도 찾지 못했다", yaml).isNotEmpty();
+        return keys;
+    }
+
+    /** 모듈의 모든 클래스가 {@code @Value} 로 참조하는 키. */
+    private TreeSet<String> placeholders() throws Exception {
+        TreeSet<String> found = new TreeSet<>();
+        Resource[] classes = new PathMatchingResourcePatternResolver()
+                .getResources("classpath*:com/example/chat/**/*.class");
+        for (Resource resource : classes) {
+            String path = resource.getURL().getPath();
+            int start = path.indexOf("com/example/chat");
+            if (start < 0) {
+                continue;
+            }
+            String name = path.substring(start).replace(".class", "").replace('/', '.');
+            Class<?> type;
+            try {
+                type = Class.forName(name, false, getClass().getClassLoader());
+            } catch (Throwable ignored) { // 로딩할 수 없는 클래스는 @Value 도 가질 수 없다
+                continue;
+            }
+            for (Field field : type.getDeclaredFields()) {
+                collect(field.getAnnotation(Value.class), found);
+            }
+            List<Executable> members = new ArrayList<>(List.of(type.getDeclaredConstructors()));
+            members.addAll(List.of(type.getDeclaredMethods()));
+            for (Executable member : members) {
+                collect(member.getAnnotation(Value.class), found);
+                for (Parameter parameter : member.getParameters()) {
+                    collect(parameter.getAnnotation(Value.class), found);
+                }
+            }
+        }
+        assertThat(found).as("모듈에서 @Value 를 하나도 찾지 못했다 — 스캔이 비었다").isNotEmpty();
+        return found;
+    }
+
+    private void collect(Value value, TreeSet<String> into) {
+        if (value == null) {
+            return;
+        }
+        Matcher matcher = PLACEHOLDER.matcher(value.value());
+        while (matcher.find()) {
+            into.add(matcher.group(1));
+        }
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/test/resources/application.yml
@@ -49,16 +49,11 @@ pgvector:
   table-name: document_embeddings
   dimension: 768
   create-table: false
-  distance-type: cosine
 
 # 문서 처리 설정
 document:
   path: file:src/test/resources/non-existent-directory/*.md
   pdf-path: file:src/test/resources/non-existent-directory/*.pdf
-
-  pdf:
-    page-top-margin: 0
-    pages-per-document: 1
 
   chunk-size: 4000
   min-chunk-size-chars: 350


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`application.yml`에만 있고 java 어디서도 읽히지 않는 키가 셋 있습니다.

### 1. `pgvector.distance-type`

`langchain4j-ai-rag-postgre`의 `application.yml`은 `pgvector` 아래 아홉 개 키를 선언합니다. `EgovLangChain4jConfig`는 그중 여덟 개를 `@Value`로 읽어 같은 빌더 체인에 넘기는데, `distance-type`만 읽는 곳이 없습니다.

```
$ grep -oE '\$\{pgvector\.[a-z-]+' EgovLangChain4jConfig.java | sed 's/.*pgvector\.//' | sort
create-table
database
dimension
host
password
port
table-name
username
```

`README-langchain4j-ai-rag-postgre.md`가 안내하는 `pgvector` 설정도 같은 여덟 개입니다. 아홉 번째 키는 `application.yml`에만 있고, 주석은 선택지 셋을 안내합니다.

```yaml
  # 거리 측정 방식 (cosine, euclidean, inner_product)
  distance-type: cosine
```

배선을 추가하는 방향은 쓸 수 없었습니다. `langchain4j-pgvector 1.8.0-beta15`의 빌더에 거리 방식을 고르는 메서드가 없습니다.

```
$ javap 'dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore$PgVectorEmbeddingStoreBuilder'
build  createTable  database  dimension  dropTableFirst  host  indexListSize
metadataStorageConfig  password  port  table  useIndex  user
```

조회 SQL도 코사인 연산자 `<=>`로 고정돼 있습니다. 같은 쿼리에 세 번 들어가고, 이 jar 안에서 `<->`(L2)와 `<#>`(내적)는 한 클래스에도 나오지 않습니다.

```
SELECT (2 - (embedding <=> '%s')) / 2 AS score, ...
 WHERE round(cast(float8 (embedding <=> '%s') as numeric), 8) <= ...
 ORDER BY embedding <=> '%s' LIMIT %s;
```

`euclidean`이나 `inner_product`로 바꿔도 검색 결과가 달라지지 않습니다.

### 2. `document.pdf.page-top-margin` · `document.pdf.pages-per-document`

형제 `spring-ai` 모듈은 같은 이름의 두 값을 `EgovPdfReader`에서 읽어 `PdfDocumentReaderConfig`에 넘깁니다.

```java
// spring-ai-rag-redis-stack/.../EgovPdfReader.java
@Value("${spring.ai.document.pdf.page-top-margin:0}")
@Value("${spring.ai.document.pdf.pages-per-document:1}")
        ...
        .withPageTopMargin(pageTopMargin)
        .withPagesPerDocument(pagesPerDocument)
```

langchain4j 모듈은 #57 이후 PDFBox `PDFTextStripper`로 **페이지 단위 파싱을 직접** 합니다.

```java
for (int page = 1; page <= pageCount; page++) {
    stripper.setStartPage(page);
    stripper.setEndPage(page);
    ...
}
```

`pages-per-document: 1`은 이 동작과 값이 우연히 같을 뿐 읽히지 않고, `page-top-margin`은 대응하는 개념이 없습니다. `pages-per-document`를 구현하면 #57이 세운 "한 페이지가 한 Document, `page_number` 기록" 설계를 되돌리게 되어 배선 대신 제거를 택했습니다.

### 처방

세 키를 `main`·`test` 양쪽 yml 에서 지웠습니다. 주석만 고치는 방법도 있으나, 읽히지 않는 키가 남으면 값을 바꿔보고 바뀐 줄 알게 됩니다.

### 영향 범위

읽히지 않던 값이라 동작이 달라지는 곳이 없습니다. 임베딩 저장·검색은 이전과 같이 코사인으로, PDF 파싱은 이전과 같이 페이지 단위로 동작합니다.

`spring-ai` 모듈의 `spring.ai.document.pdf.*`는 실제로 읽히므로 건드리지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

yml이 선언한 키가 실제로 `@Value`로 읽히는지 검사하는 테스트를 추가했습니다. 클래스를 지정하지 않고 모듈 전체의 `@Value`를 모아 비교합니다.

수정 전

```
[ERROR] EgovYamlBindingTest.everyWatchedKeyInTheMainYamlIsRead:43
        Expecting empty but was: ["document.pdf.page-top-margin",
                                  "document.pdf.pages-per-document",
                                  "pgvector.distance-type"]
[ERROR] EgovYamlBindingTest.everyWatchedKeyInTheTestYamlIsRead:48
        Expecting empty but was: ["document.pdf.page-top-margin",
                                  "document.pdf.pages-per-document",
                                  "pgvector.distance-type"]
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

모듈 전체

```
[INFO] Tests run: 133, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

설정과 테스트만 바뀌어 화면 출력이 달라지지 않습니다.
