### PR TITLE
fix: HWP 추출에서 표의 행·셀 구조가 사라지는 문제 수정 (#77)

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
@@ -4,8 +4,6 @@ import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.Metadata;
 import kr.dogfoot.hwplib.object.HWPFile;
 import kr.dogfoot.hwplib.reader.HWPReader;
-import kr.dogfoot.hwplib.tool.textextractor.TextExtractMethod;
-import kr.dogfoot.hwplib.tool.textextractor.TextExtractor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -84,7 +82,9 @@ public class EgovHwpReader {
         HWPFile hwpFile = HWPReader.fromFile(file);
 
         // 본문 + 표/각주 등 컨트롤 텍스트까지 포함하여 추출
-        String content = TextExtractor.extract(hwpFile, TextExtractMethod.AppendControlTextAfterParagraphText);
+        // 문단·표 구조를 남겨 추출한다. hwplib 기본 추출은 표의 행·셀 구분자를 넣지 않아
+        // 어느 값이 어느 행에 속하는지 복원할 수 없다.
+        String content = EgovHwpStructuredExtractor.extract(hwpFile);
 
         if (content == null || content.trim().isEmpty()) {
             log.warn("HWP 파일 '{}': 추출된 텍스트가 없습니다.", filename);

--- a/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpStructuredExtractor.java
+++ b/langchain4j-ai-rag-postgre/src/main/java/com/example/chat/config/etl/readers/EgovHwpStructuredExtractor.java
@@ -1,0 +1,140 @@
+package com.example.chat.config.etl.readers;
+
+import java.io.UnsupportedEncodingException;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.object.bodytext.Section;
+import kr.dogfoot.hwplib.object.bodytext.control.Control;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlTable;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlType;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Cell;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Row;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.Paragraph;
+import kr.dogfoot.hwplib.object.bodytext.ParagraphListInterface;
+
+/**
+ * HWP 문서에서 문단과 표 구조를 남기며 텍스트를 추출한다.
+ *
+ * <p>hwplib의 {@code TextExtractor}는 표를 순회하며 셀 텍스트만 이어 붙이고 행·셀 구분자를
+ * 넣지 않는다. {@code TextExtractOption}에도 구분자를 지정하는 항목이 없어, 어느 값이 어느 행에
+ * 속하는지 복원할 수 없다. 표를 직접 순회해 구분자를 넣는다.</p>
+ *
+ * <p>출력 형식은 HWPX 쪽과 같다. 문단과 표의 행은 개행으로 나누고 셀은 구분자로 잇는다.
+ * 구분자는 셀 사이에만 들어가며 행 맨 앞에는 붙지 않는다.</p>
+ */
+public final class EgovHwpStructuredExtractor {
+
+    /** 표의 셀 사이에 넣는 구분자. HWPX 추출과 같은 값을 쓴다. */
+    private static final String CELL_SEPARATOR = " | ";
+
+    private EgovHwpStructuredExtractor() {
+    }
+
+    /**
+     * 문단과 표 구조를 유지한 텍스트를 만든다.
+     *
+     * @param hwpFile 추출 대상 문서
+     * @return 문단은 개행으로, 표는 행마다 개행·셀마다 구분자로 구분한 텍스트
+     * @throws UnsupportedEncodingException 문단 텍스트를 문자열로 바꾸지 못한 경우
+     */
+    public static String extract(HWPFile hwpFile) throws UnsupportedEncodingException {
+        StringBuilder text = new StringBuilder();
+        for (Section section : hwpFile.getBodyText().getSectionList()) {
+            appendParagraphList(text, section);
+        }
+        return text.toString();
+    }
+
+    private static void appendParagraphList(StringBuilder text, ParagraphListInterface paragraphList)
+            throws UnsupportedEncodingException {
+        for (int i = 0; i < paragraphList.getParagraphCount(); i++) {
+            appendParagraph(text, paragraphList.getParagraph(i));
+        }
+    }
+
+    private static void appendParagraph(StringBuilder text, Paragraph paragraph)
+            throws UnsupportedEncodingException {
+        if (paragraph == null) {
+            return;
+        }
+
+        if (paragraph.getText() != null) {
+            String paragraphText = clean(paragraph.getText().getNormalString(0));
+            if (!paragraphText.isEmpty()) {
+                appendLine(text, paragraphText);
+            }
+        }
+
+        if (paragraph.getControlList() == null) {
+            return;
+        }
+        for (Control control : paragraph.getControlList()) {
+            if (control != null && control.getType() == ControlType.Table) {
+                appendTable(text, (ControlTable) control);
+            }
+        }
+    }
+
+    private static void appendTable(StringBuilder text, ControlTable table)
+            throws UnsupportedEncodingException {
+        for (Row row : table.getRowList()) {
+            StringBuilder line = new StringBuilder();
+            for (Cell cell : row.getCellList()) {
+                String cellText = cellText(cell);
+                if (line.length() > 0) {
+                    line.append(CELL_SEPARATOR);
+                }
+                line.append(cellText);
+            }
+            appendLine(text, line.toString());
+        }
+    }
+
+    /** 셀 안의 문단을 공백으로 이어 한 줄로 만든다. */
+    private static String cellText(Cell cell) throws UnsupportedEncodingException {
+        StringBuilder cellText = new StringBuilder();
+        ParagraphListInterface paragraphList = cell.getParagraphList();
+        for (int i = 0; i < paragraphList.getParagraphCount(); i++) {
+            Paragraph paragraph = paragraphList.getParagraph(i);
+            if (paragraph == null || paragraph.getText() == null) {
+                continue;
+            }
+            String paragraphText = clean(paragraph.getText().getNormalString(0));
+            if (paragraphText.isEmpty()) {
+                continue;
+            }
+            if (cellText.length() > 0) {
+                cellText.append(' ');
+            }
+            cellText.append(paragraphText);
+        }
+        return cellText.toString();
+    }
+
+    /**
+     * 문단 텍스트에서 제어 문자를 걷어낸다.
+     *
+     * <p>{@code getNormalString()}은 문단 끝 표시인 캐리지 리턴을 그대로 포함한다. 그대로 두면
+     * 이 클래스가 넣는 개행과 겹쳐 빈 줄이 생긴다.</p>
+     */
+    private static String clean(String rawText) {
+        if (rawText == null) {
+            return "";
+        }
+        StringBuilder cleaned = new StringBuilder(rawText.length());
+        for (int i = 0; i < rawText.length(); i++) {
+            char ch = rawText.charAt(i);
+            if (ch >= ' ' || ch == '\t') {
+                cleaned.append(ch);
+            }
+        }
+        return cleaned.toString().trim();
+    }
+
+    private static void appendLine(StringBuilder text, String line) {
+        if (text.length() > 0) {
+            text.append('\n');
+        }
+        text.append(line);
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovHwpStructureExtractionTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/etl/readers/EgovHwpStructureExtractionTest.java
@@ -1,0 +1,124 @@
+package com.example.chat.config.etl.readers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.object.bodytext.ParagraphListInterface;
+import kr.dogfoot.hwplib.object.bodytext.Section;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlTable;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlType;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Cell;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Row;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.Paragraph;
+import kr.dogfoot.hwplib.tool.blankfilemaker.BlankFileMaker;
+import kr.dogfoot.hwplib.tool.textextractor.TextExtractMethod;
+import kr.dogfoot.hwplib.tool.textextractor.TextExtractor;
+
+/**
+ * HWP 추출이 문단과 표 구조를 남기는지 검증한다.
+ *
+ * <p>문서를 메모리에서 만들어 확인한다. 샘플 파일을 저장소에 두지 않고도 결정적으로
+ * 검증할 수 있다.</p>
+ */
+class EgovHwpStructureExtractionTest {
+
+    /** 비교를 위해 제어 문자와 개행을 걷어낸다. */
+    private String stripControlChars(String text) {
+        StringBuilder stripped = new StringBuilder(text.length());
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (ch >= ' ') {
+                stripped.append(ch);
+            }
+        }
+        return stripped.toString();
+    }
+
+    private void addParagraph(ParagraphListInterface list, String text) throws Exception {
+        Paragraph paragraph = list.addNewParagraph();
+        paragraph.createText();
+        paragraph.getText().addString(text);
+    }
+
+    /** 문단 2개와 3×3 표 하나를 담은 문서. */
+    private HWPFile sampleDocument() throws Exception {
+        HWPFile file = BlankFileMaker.make();
+        Section section = file.getBodyText().getSectionList().get(0);
+        addParagraph(section, "제1조(목적) 이 규정은 수수료 기준을 정함을 목적으로 한다");
+        addParagraph(section, "제2조(수수료) 수수료는 별표와 같다");
+
+        Paragraph tableParagraph = section.addNewParagraph();
+        tableParagraph.createText();
+        // 제어 문자를 넣어야 표 컨트롤이 문단에 연결된다
+        tableParagraph.getText().addExtendCharForTable();
+        ControlTable table = (ControlTable) tableParagraph.addNewControl(ControlType.Table);
+
+        String[][] rows = {
+                {"민원종류", "수수료", "처리기간"},
+                {"주민등록등본", "400원", "즉시"},
+                {"가족관계증명서", "1000원", "3일"}};
+        for (String[] row : rows) {
+            Row tableRow = table.addNewRow();
+            for (String cell : row) {
+                Cell tableCell = tableRow.addNewCell();
+                addParagraph(tableCell.getParagraphList(), cell);
+            }
+        }
+        return file;
+    }
+
+    @Test
+    @DisplayName("문단 사이에 개행이 들어간다")
+    void paragraphsAreSeparated() throws Exception {
+        String extracted = EgovHwpStructuredExtractor.extract(sampleDocument());
+
+        assertThat(extracted).contains("정함을 목적으로 한다\n제2조(수수료)");
+    }
+
+    @Test
+    @DisplayName("표는 행마다 줄이 나뉘고 셀은 구분자로 이어진다")
+    void tableRowsAndCellsAreSeparated() throws Exception {
+        String extracted = EgovHwpStructuredExtractor.extract(sampleDocument());
+
+        assertThat(extracted)
+                .contains("민원종류 | 수수료 | 처리기간")
+                .contains("주민등록등본 | 400원 | 즉시")
+                .contains("가족관계증명서 | 1000원 | 3일");
+    }
+
+    @Test
+    @DisplayName("셀 구분자는 행 맨 앞에 붙지 않는다")
+    void cellSeparatorDoesNotStartALine() throws Exception {
+        String extracted = EgovHwpStructuredExtractor.extract(sampleDocument());
+
+        for (String line : extracted.split("\n")) {
+            assertThat(line.trim()).doesNotStartWith("|");
+        }
+    }
+
+    @Test
+    @DisplayName("기본 추출은 표의 행 관계를 남기지 않는다")
+    void defaultExtractionLosesTableStructure() throws Exception {
+        // 기본 추출은 문단 끝 캐리지 리턴을 포함하므로 비교 전에 걷어낸다
+        String extracted = stripControlChars(TextExtractor.extract(sampleDocument(),
+                TextExtractMethod.AppendControlTextAfterParagraphText));
+
+        // 셀 값이 구분자 없이 이어 붙어 어느 값이 어느 행인지 알 수 없다
+        assertThat(extracted).contains("주민등록등본400원즉시");
+        assertThat(extracted).doesNotContain("주민등록등본 | 400원");
+    }
+
+    @Test
+    @DisplayName("본문 글자는 기본 추출과 같다")
+    void textContentIsUnchanged() throws Exception {
+        String defaultText = stripControlChars(TextExtractor.extract(sampleDocument(),
+                TextExtractMethod.AppendControlTextAfterParagraphText));
+        String structured = EgovHwpStructuredExtractor.extract(sampleDocument());
+
+        assertThat(structured.replace("\n", "").replace(" | ", ""))
+                .isEqualTo(defaultText);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpReader.java
@@ -13,8 +13,6 @@ import org.springframework.stereotype.Component;
 
 import kr.dogfoot.hwplib.object.HWPFile;
 import kr.dogfoot.hwplib.reader.HWPReader;
-import kr.dogfoot.hwplib.tool.textextractor.TextExtractMethod;
-import kr.dogfoot.hwplib.tool.textextractor.TextExtractor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -82,7 +80,9 @@ public class EgovHwpReader implements DocumentReader {
         HWPFile hwpFile = HWPReader.fromFile(file);
 
         // 본문 + 표/각주 등 컨트롤 텍스트까지 포함하여 추출
-        String content = TextExtractor.extract(hwpFile, TextExtractMethod.AppendControlTextAfterParagraphText);
+        // 문단·표 구조를 남겨 추출한다. hwplib 기본 추출은 표의 행·셀 구분자를 넣지 않아
+        // 어느 값이 어느 행에 속하는지 복원할 수 없다.
+        String content = EgovHwpStructuredExtractor.extract(hwpFile);
 
         if (content == null || content.trim().isEmpty()) {
             log.warn("HWP 파일 '{}': 추출된 텍스트가 없습니다.", filename);

--- a/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpStructuredExtractor.java
+++ b/spring-ai-rag-redis-stack/src/main/java/com/example/chat/config/etl/readers/EgovHwpStructuredExtractor.java
@@ -1,0 +1,140 @@
+package com.example.chat.config.etl.readers;
+
+import java.io.UnsupportedEncodingException;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.object.bodytext.Section;
+import kr.dogfoot.hwplib.object.bodytext.control.Control;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlTable;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlType;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Cell;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Row;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.Paragraph;
+import kr.dogfoot.hwplib.object.bodytext.ParagraphListInterface;
+
+/**
+ * HWP 문서에서 문단과 표 구조를 남기며 텍스트를 추출한다.
+ *
+ * <p>hwplib의 {@code TextExtractor}는 표를 순회하며 셀 텍스트만 이어 붙이고 행·셀 구분자를
+ * 넣지 않는다. {@code TextExtractOption}에도 구분자를 지정하는 항목이 없어, 어느 값이 어느 행에
+ * 속하는지 복원할 수 없다. 표를 직접 순회해 구분자를 넣는다.</p>
+ *
+ * <p>출력 형식은 HWPX 쪽과 같다. 문단과 표의 행은 개행으로 나누고 셀은 구분자로 잇는다.
+ * 구분자는 셀 사이에만 들어가며 행 맨 앞에는 붙지 않는다.</p>
+ */
+public final class EgovHwpStructuredExtractor {
+
+    /** 표의 셀 사이에 넣는 구분자. HWPX 추출과 같은 값을 쓴다. */
+    private static final String CELL_SEPARATOR = " | ";
+
+    private EgovHwpStructuredExtractor() {
+    }
+
+    /**
+     * 문단과 표 구조를 유지한 텍스트를 만든다.
+     *
+     * @param hwpFile 추출 대상 문서
+     * @return 문단은 개행으로, 표는 행마다 개행·셀마다 구분자로 구분한 텍스트
+     * @throws UnsupportedEncodingException 문단 텍스트를 문자열로 바꾸지 못한 경우
+     */
+    public static String extract(HWPFile hwpFile) throws UnsupportedEncodingException {
+        StringBuilder text = new StringBuilder();
+        for (Section section : hwpFile.getBodyText().getSectionList()) {
+            appendParagraphList(text, section);
+        }
+        return text.toString();
+    }
+
+    private static void appendParagraphList(StringBuilder text, ParagraphListInterface paragraphList)
+            throws UnsupportedEncodingException {
+        for (int i = 0; i < paragraphList.getParagraphCount(); i++) {
+            appendParagraph(text, paragraphList.getParagraph(i));
+        }
+    }
+
+    private static void appendParagraph(StringBuilder text, Paragraph paragraph)
+            throws UnsupportedEncodingException {
+        if (paragraph == null) {
+            return;
+        }
+
+        if (paragraph.getText() != null) {
+            String paragraphText = clean(paragraph.getText().getNormalString(0));
+            if (!paragraphText.isEmpty()) {
+                appendLine(text, paragraphText);
+            }
+        }
+
+        if (paragraph.getControlList() == null) {
+            return;
+        }
+        for (Control control : paragraph.getControlList()) {
+            if (control != null && control.getType() == ControlType.Table) {
+                appendTable(text, (ControlTable) control);
+            }
+        }
+    }
+
+    private static void appendTable(StringBuilder text, ControlTable table)
+            throws UnsupportedEncodingException {
+        for (Row row : table.getRowList()) {
+            StringBuilder line = new StringBuilder();
+            for (Cell cell : row.getCellList()) {
+                String cellText = cellText(cell);
+                if (line.length() > 0) {
+                    line.append(CELL_SEPARATOR);
+                }
+                line.append(cellText);
+            }
+            appendLine(text, line.toString());
+        }
+    }
+
+    /** 셀 안의 문단을 공백으로 이어 한 줄로 만든다. */
+    private static String cellText(Cell cell) throws UnsupportedEncodingException {
+        StringBuilder cellText = new StringBuilder();
+        ParagraphListInterface paragraphList = cell.getParagraphList();
+        for (int i = 0; i < paragraphList.getParagraphCount(); i++) {
+            Paragraph paragraph = paragraphList.getParagraph(i);
+            if (paragraph == null || paragraph.getText() == null) {
+                continue;
+            }
+            String paragraphText = clean(paragraph.getText().getNormalString(0));
+            if (paragraphText.isEmpty()) {
+                continue;
+            }
+            if (cellText.length() > 0) {
+                cellText.append(' ');
+            }
+            cellText.append(paragraphText);
+        }
+        return cellText.toString();
+    }
+
+    /**
+     * 문단 텍스트에서 제어 문자를 걷어낸다.
+     *
+     * <p>{@code getNormalString()}은 문단 끝 표시인 캐리지 리턴을 그대로 포함한다. 그대로 두면
+     * 이 클래스가 넣는 개행과 겹쳐 빈 줄이 생긴다.</p>
+     */
+    private static String clean(String rawText) {
+        if (rawText == null) {
+            return "";
+        }
+        StringBuilder cleaned = new StringBuilder(rawText.length());
+        for (int i = 0; i < rawText.length(); i++) {
+            char ch = rawText.charAt(i);
+            if (ch >= ' ' || ch == '\t') {
+                cleaned.append(ch);
+            }
+        }
+        return cleaned.toString().trim();
+    }
+
+    private static void appendLine(StringBuilder text, String line) {
+        if (text.length() > 0) {
+            text.append('\n');
+        }
+        text.append(line);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovHwpStructureExtractionTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/config/etl/readers/EgovHwpStructureExtractionTest.java
@@ -1,0 +1,124 @@
+package com.example.chat.config.etl.readers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import kr.dogfoot.hwplib.object.HWPFile;
+import kr.dogfoot.hwplib.object.bodytext.ParagraphListInterface;
+import kr.dogfoot.hwplib.object.bodytext.Section;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlTable;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlType;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Cell;
+import kr.dogfoot.hwplib.object.bodytext.control.table.Row;
+import kr.dogfoot.hwplib.object.bodytext.paragraph.Paragraph;
+import kr.dogfoot.hwplib.tool.blankfilemaker.BlankFileMaker;
+import kr.dogfoot.hwplib.tool.textextractor.TextExtractMethod;
+import kr.dogfoot.hwplib.tool.textextractor.TextExtractor;
+
+/**
+ * HWP 추출이 문단과 표 구조를 남기는지 검증한다.
+ *
+ * <p>문서를 메모리에서 만들어 확인한다. 샘플 파일을 저장소에 두지 않고도 결정적으로
+ * 검증할 수 있다.</p>
+ */
+class EgovHwpStructureExtractionTest {
+
+    /** 비교를 위해 제어 문자와 개행을 걷어낸다. */
+    private String stripControlChars(String text) {
+        StringBuilder stripped = new StringBuilder(text.length());
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (ch >= ' ') {
+                stripped.append(ch);
+            }
+        }
+        return stripped.toString();
+    }
+
+    private void addParagraph(ParagraphListInterface list, String text) throws Exception {
+        Paragraph paragraph = list.addNewParagraph();
+        paragraph.createText();
+        paragraph.getText().addString(text);
+    }
+
+    /** 문단 2개와 3×3 표 하나를 담은 문서. */
+    private HWPFile sampleDocument() throws Exception {
+        HWPFile file = BlankFileMaker.make();
+        Section section = file.getBodyText().getSectionList().get(0);
+        addParagraph(section, "제1조(목적) 이 규정은 수수료 기준을 정함을 목적으로 한다");
+        addParagraph(section, "제2조(수수료) 수수료는 별표와 같다");
+
+        Paragraph tableParagraph = section.addNewParagraph();
+        tableParagraph.createText();
+        // 제어 문자를 넣어야 표 컨트롤이 문단에 연결된다
+        tableParagraph.getText().addExtendCharForTable();
+        ControlTable table = (ControlTable) tableParagraph.addNewControl(ControlType.Table);
+
+        String[][] rows = {
+                {"민원종류", "수수료", "처리기간"},
+                {"주민등록등본", "400원", "즉시"},
+                {"가족관계증명서", "1000원", "3일"}};
+        for (String[] row : rows) {
+            Row tableRow = table.addNewRow();
+            for (String cell : row) {
+                Cell tableCell = tableRow.addNewCell();
+                addParagraph(tableCell.getParagraphList(), cell);
+            }
+        }
+        return file;
+    }
+
+    @Test
+    @DisplayName("문단 사이에 개행이 들어간다")
+    void paragraphsAreSeparated() throws Exception {
+        String extracted = EgovHwpStructuredExtractor.extract(sampleDocument());
+
+        assertThat(extracted).contains("정함을 목적으로 한다\n제2조(수수료)");
+    }
+
+    @Test
+    @DisplayName("표는 행마다 줄이 나뉘고 셀은 구분자로 이어진다")
+    void tableRowsAndCellsAreSeparated() throws Exception {
+        String extracted = EgovHwpStructuredExtractor.extract(sampleDocument());
+
+        assertThat(extracted)
+                .contains("민원종류 | 수수료 | 처리기간")
+                .contains("주민등록등본 | 400원 | 즉시")
+                .contains("가족관계증명서 | 1000원 | 3일");
+    }
+
+    @Test
+    @DisplayName("셀 구분자는 행 맨 앞에 붙지 않는다")
+    void cellSeparatorDoesNotStartALine() throws Exception {
+        String extracted = EgovHwpStructuredExtractor.extract(sampleDocument());
+
+        for (String line : extracted.split("\n")) {
+            assertThat(line.trim()).doesNotStartWith("|");
+        }
+    }
+
+    @Test
+    @DisplayName("기본 추출은 표의 행 관계를 남기지 않는다")
+    void defaultExtractionLosesTableStructure() throws Exception {
+        // 기본 추출은 문단 끝 캐리지 리턴을 포함하므로 비교 전에 걷어낸다
+        String extracted = stripControlChars(TextExtractor.extract(sampleDocument(),
+                TextExtractMethod.AppendControlTextAfterParagraphText));
+
+        // 셀 값이 구분자 없이 이어 붙어 어느 값이 어느 행인지 알 수 없다
+        assertThat(extracted).contains("주민등록등본400원즉시");
+        assertThat(extracted).doesNotContain("주민등록등본 | 400원");
+    }
+
+    @Test
+    @DisplayName("본문 글자는 기본 추출과 같다")
+    void textContentIsUnchanged() throws Exception {
+        String defaultText = stripControlChars(TextExtractor.extract(sampleDocument(),
+                TextExtractMethod.AppendControlTextAfterParagraphText));
+        String structured = EgovHwpStructuredExtractor.extract(sampleDocument());
+
+        assertThat(structured.replace("\n", "").replace(" | ", ""))
+                .isEqualTo(defaultText);
+    }
+}


### PR DESCRIPTION
#77에서 예고한 HWP 후속입니다. #78로 반영된 HWPX와 같은 출력 형식을 씁니다.

## 변경 이유

hwplib의 `TextExtractor`는 표를 순회하며 셀 텍스트만 이어 붙이고 행·셀 구분자를 넣지 않습니다. `TextExtractOption`에는 `method`·`withControlChar`·`appendEndingLF`·`insertParaHead`만 있어 구분자를 지정할 수 없습니다. hwpxlib의 `TextMarks`에 해당하는 것이 없습니다.

문단 2개와 3×3 표 하나를 담은 문서를 리더와 같은 호출로 추출한 결과입니다.

```
제1조(목적) 이 규정은 수수료 기준을 정함을 목적으로 한다
제2조(수수료) 수수료는 별표와 같다
민원종류수수료처리기간주민등록등본400원즉시가족관계증명서1000원3일

길이=106 / 개행수=3
```

개행 3개는 문단 세 개의 끝입니다. 표 안에는 구분자가 없어 `주민등록등본`의 수수료가 `400원`이라는 관계가 남지 않습니다.

## 변경 내용

`EgovHwpStructuredExtractor`를 추가해 `ControlTable.getRowList()`·`Row.getCellList()`를 직접 순회하며 구분자를 넣습니다. 리더는 이 추출기를 씁니다.

같은 문서의 결과가 이렇게 바뀝니다.

```
제1조(목적) 이 규정은 수수료 기준을 정함을 목적으로 한다
제2조(수수료) 수수료는 별표와 같다
민원종류 | 수수료 | 처리기간
주민등록등본 | 400원 | 즉시
가족관계증명서 | 1000원 | 3일

길이=127 / 개행수=6
```

출력 형식은 #78과 맞췄습니다. 문단과 표의 행은 개행으로 나누고 셀은 구분자로 이으며, 구분자는 셀 사이에만 들어가 행 맨 앞에는 붙지 않습니다.

문단 텍스트에 섞인 제어 문자는 걷어냅니다. `getNormalString()`이 문단 끝 캐리지 리턴을 포함하는데, 그대로 두면 추출기가 넣는 개행과 겹쳐 빈 줄이 생깁니다.

## 테스트 방법

```
cd spring-ai-rag-redis-stack && mvn -B test
cd langchain4j-ai-rag-postgre && mvn -B test
```

spring-ai 149건, langchain4j 138건이 통과합니다(각 신규 5건 포함, 실패·오류 0건). main 기준으로는 144건과 133건입니다.

테스트는 `BlankFileMaker`로 문서를 메모리에서 만들어 확인합니다. 문단 사이 개행, 표의 행 분리와 셀 구분자, 행 맨 앞에 구분자가 붙지 않는지, 기본 추출은 행 관계를 남기지 않는지, 구조화 전후로 본문 글자가 같은지입니다.

## 영향 범위

- 추가 파일은 두 모듈의 `EgovHwpStructuredExtractor.java`와 테스트 2개이고, 각 `EgovHwpReader.java`는 추출 호출 한 줄이 바뀝니다.
- HWP 문서에서 뽑히는 텍스트가 달라지므로 이미 색인한 문서는 재색인해야 새 구조가 반영됩니다. 본문 글자 자체는 바뀌지 않습니다.
- 설정 키, 공개 API, 의존성 변경은 없습니다.

## 한계

병합 셀과 중첩 표는 셀 텍스트를 그대로 출력하고 구조를 복원하지 않습니다. HWPX 쪽과 같은 범위입니다.
