### PR TITLE
fix(langchain4j): 읽히지 않는 테이블명 설정 키 제거

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -159,13 +159,6 @@ chat:
   memory:
     # 최대 메시지 수
     max-messages: 20
-    # PostgreSQL 테이블명
-    table-name: chat_memory
-
-# 세션 관리 설정
-session:
-  # PostgreSQL 테이블명
-  table-name: chat_sessions
 
 # 로깅 설정
 logging:

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovYamlBindingTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/config/EgovYamlBindingTest.java
@@ -34,7 +34,7 @@ import org.yaml.snakeyaml.Yaml;
 class EgovYamlBindingTest {
 
     /** 검사 대상 — yml 경로와, 그 아래 키가 모두 읽혀야 하는 블록. */
-    private static final List<String> WATCHED = List.of("pgvector", "document.pdf");
+    private static final List<String> WATCHED = List.of("pgvector", "document.pdf", "chat.memory", "session");
 
     private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([A-Za-z0-9._-]+)");
 

--- a/langchain4j-ai-rag-postgre/src/test/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/test/resources/application.yml
@@ -86,11 +86,6 @@ rag:
 chat:
   memory:
     max-messages: 20
-    table-name: chat_memory
-
-# 세션 관리 설정
-session:
-  table-name: chat_sessions
 
 # 로깅 설정
 logging:


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`application.yml`의 `chat.memory.table-name`과 `session.table-name`을 읽는 곳이 없습니다. 두 테이블 이름은 엔티티에 고정돼 있습니다.

```java
// ChatMemoryEntity.java:11
@Table(name = "chat_memory", indexes = { ... })

// ChatSessionEntity.java:11
@Table(name = "chat_sessions")
```

같은 파일의 `pgvector.table-name`은 `@Value`로 읽히지만(`EgovLangChain4jConfig.java:66`), 이 두 키는 `@Value`에도 `@ConfigurationProperties`에도 걸려 있지 않습니다. 값을 바꿔도 아무 일이 일어나지 않는데, 설정이 동작을 바꾸는 것처럼 보입니다.

두 키를 지웠습니다. 값을 쓰지 않는 `session` 블록도 함께 비워 없앴습니다.

`EgovYamlBindingTest`가 이런 키를 막으라고 있는데 감시 블록이 `pgvector`와 `document.pdf` 둘뿐이라 걸리지 않았습니다. 감시 범위를 넓혔습니다.

```diff
-    private static final List<String> WATCHED = List.of("pgvector", "document.pdf");
+    private static final List<String> WATCHED = List.of("pgvector", "document.pdf", "chat.memory", "session");
```

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

감시 범위를 넓힌 상태에서 키를 두면 기존 테스트가 실패합니다.

키를 둔 채로

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0 -- in EgovYamlBindingTest
```

키를 지운 뒤

```
[INFO] Tests run: 133, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

설정 정리라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
