### PR TITLE
fix: 업로드 계약(파일당 5MB, 총 20MB)이 멀티파트 기본 한도에 막히던 문제 수정

### DIFF
--- a/langchain4j-ai-rag-postgre/src/main/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/main/resources/application.yml
@@ -2,6 +2,15 @@ spring:
   application:
     name: langchain4j-ai-rag-postgre
 
+  # 업로드 한도. 컨트롤러·서비스가 선언한 계약(파일당 5MB, 총 20MB)이 톰캣 멀티파트 파서에
+  # 먼저 걸리지 않도록 맞춘다. 기본값 1MB/10MB 로는 계약상 허용인 파일이 서비스 검증에
+  # 닿기도 전에 413으로 끊긴다. max-request-size 는 20MB 정각이 아니라 여유를 둔다 —
+  # 서비스의 총량 검증은 파일 바이트만 세지만 실제 요청에는 멀티파트 경계·헤더가 더 실린다.
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 21MB
+
   # PostgreSQL 데이터베이스 설정
   datasource:
     url: jdbc:postgresql://localhost:5432/ragdb

--- a/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/controller/EgovDocumentUploadMultipartLimitTest.java
+++ b/langchain4j-ai-rag-postgre/src/test/java/com/example/chat/controller/EgovDocumentUploadMultipartLimitTest.java
@@ -1,0 +1,113 @@
+package com.example.chat.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import com.example.chat.config.EgovLangChain4jConfig;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+
+/**
+ * 업로드 계약의 파일당 상한(5MB)이 톰캣 멀티파트 파서를 통과하는지 검증한다.
+ *
+ * <p>서비스 단위 테스트는 {@code MockMultipartFile} 로 서비스를 직접 호출하므로 파서를 건너뛴다.
+ * 그래서 {@code spring.servlet.multipart} 한도가 기본값(1MB/10MB)이던 동안에도 계약 테스트는
+ * 초록인 채였고 실제 HTTP 업로드만 413 으로 끊겼다. 이 테스트가 그 구간을 덮는다.
+ *
+ * <p>지원하지 않는 확장자로 보내는 이유 — 요청이 파서를 통과했는지만 보면 되고, 서비스가 확장자
+ * 검사에서 곧바로 400 을 돌려주므로 디스크에 아무것도 쓰지 않는다. 한도에 걸린 413 은 본문이
+ * 비어 있어 구분된다.
+ *
+ * <p>총 20MB(요청 상한) 경계는 여기서 다루지 않는다. 이 모듈은 webflux 를 함께 의존해
+ * {@link TestRestTemplate} 이 reactor-netty 클라이언트를 쓰는데, 그 클라이언트가 20MB 멀티파트
+ * 본문을 서버 한도와 무관하게 끝내 전송하지 못한다. 요청 상한은 spring-ai 모듈 쪽 같은 이름의
+ * 테스트가 덮는다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class EgovDocumentUploadMultipartLimitTest {
+
+    private static final int FIVE_MB = 5 * 1024 * 1024;
+
+    @MockitoBean
+    private EmbeddingModel embeddingModel;
+
+    @MockitoBean
+    private OllamaChatModel chatLanguageModel;
+
+    @MockitoBean
+    private OllamaStreamingChatModel streamingChatLanguageModel;
+
+    @MockitoBean
+    private EmbeddingStore<TextSegment> embeddingStore;
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate rest;
+
+    @Test
+    @DisplayName("계약 상한인 5MB 파일 1개가 서비스까지 도달한다")
+    void singleFileAtContractLimitReachesService() {
+        ResponseEntity<String> response = upload(FIVE_MB);
+
+        assertThat(response.getStatusCode().value())
+                .as("413 이면 멀티파트 한도가 업로드 계약보다 낮은 것이다")
+                .isEqualTo(400);
+        assertThat(response.getBody()).contains("지원하지 않는 파일 형식입니다.");
+    }
+
+    private ResponseEntity<String> upload(int... sizes) {
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        for (int i = 0; i < sizes.length; i++) {
+            final String filename = "doc" + i + ".txt";
+            body.add("files", new ByteArrayResource(new byte[sizes[i]]) {
+                @Override
+                public String getFilename() {
+                    return filename;
+                }
+            });
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        return rest.postForEntity("http://localhost:" + port + "/api/documents/upload",
+                new HttpEntity<>(body, headers), String.class);
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public static BeanFactoryPostProcessor removeRealConfig() {
+            return (ConfigurableListableBeanFactory beanFactory) -> {
+                if (beanFactory instanceof BeanDefinitionRegistry registry) {
+                    for (String name : beanFactory.getBeanNamesForType(EgovLangChain4jConfig.class, false, false)) {
+                        registry.removeBeanDefinition(name);
+                    }
+                }
+            };
+        }
+    }
+}

--- a/langchain4j-ai-rag-postgre/src/test/resources/application.yml
+++ b/langchain4j-ai-rag-postgre/src/test/resources/application.yml
@@ -2,6 +2,12 @@ spring:
   application:
     name: langchain4j-ai-rag-postgre-test
 
+  # 업로드 한도 (main 과 동일). test classpath 의 이 파일이 main 의 application.yml 을 가린다.
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 21MB
+
   # H2 데이터베이스 설정 (테스트용)
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL

--- a/spring-ai-rag-redis-stack/src/main/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/main/resources/application.yml
@@ -2,6 +2,15 @@ spring:
   application:
     name: spring-ai-rag-redis
 
+  # 업로드 한도. 컨트롤러·서비스가 선언한 계약(파일당 5MB, 총 20MB)이 톰캣 멀티파트 파서에
+  # 먼저 걸리지 않도록 맞춘다. 기본값 1MB/10MB 로는 계약상 허용인 파일이 서비스 검증에
+  # 닿기도 전에 413으로 끊긴다. max-request-size 는 20MB 정각이 아니라 여유를 둔다 —
+  # 서비스의 총량 검증은 파일 바이트만 세지만 실제 요청에는 멀티파트 경계·헤더가 더 실린다.
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 21MB
+
   # Ollama 설정
   ai:
     ollama:

--- a/spring-ai-rag-redis-stack/src/test/java/com/example/chat/controller/EgovDocumentUploadMultipartLimitTest.java
+++ b/spring-ai-rag-redis-stack/src/test/java/com/example/chat/controller/EgovDocumentUploadMultipartLimitTest.java
@@ -1,0 +1,83 @@
+package com.example.chat.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * 업로드 계약(파일당 5MB, 총 20MB)이 톰캣 멀티파트 파서를 통과하는지 검증한다.
+ *
+ * <p>서비스 단위 테스트는 {@code MockMultipartFile} 로 서비스를 직접 호출하므로 파서를 건너뛴다.
+ * 그래서 {@code spring.servlet.multipart} 한도가 기본값(1MB/10MB)이던 동안에도 계약 테스트는
+ * 초록인 채였고 실제 HTTP 업로드만 413 으로 끊겼다. 이 테스트가 그 구간을 덮는다.
+ *
+ * <p>지원하지 않는 확장자로 보내는 이유 — 요청이 파서를 통과했는지만 보면 되고, 서비스가 확장자
+ * 검사에서 곧바로 400 을 돌려주므로 디스크에 아무것도 쓰지 않는다. 한도에 걸린 413 은 본문이
+ * 비어 있어 구분된다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class EgovDocumentUploadMultipartLimitTest {
+
+    private static final int FIVE_MB = 5 * 1024 * 1024;
+
+    @MockitoBean
+    EmbeddingModel embeddingModel;
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate rest;
+
+    @Test
+    @DisplayName("계약 상한인 5MB 파일 1개가 서비스까지 도달한다")
+    void singleFileAtContractLimitReachesService() {
+        assertReachesService(upload(FIVE_MB));
+    }
+
+    @Test
+    @DisplayName("계약 상한인 총 20MB(5MB × 4) 요청이 서비스까지 도달한다")
+    void requestAtContractLimitReachesService() {
+        assertReachesService(upload(FIVE_MB, FIVE_MB, FIVE_MB, FIVE_MB));
+    }
+
+    private void assertReachesService(ResponseEntity<String> response) {
+        assertThat(response.getStatusCode().value())
+                .as("413 이면 멀티파트 한도가 업로드 계약보다 낮은 것이다")
+                .isEqualTo(400);
+        assertThat(response.getBody()).contains("지원하지 않는 파일 형식입니다.");
+    }
+
+    private ResponseEntity<String> upload(int... sizes) {
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        for (int i = 0; i < sizes.length; i++) {
+            final String filename = "doc" + i + ".txt";
+            body.add("files", new ByteArrayResource(new byte[sizes[i]]) {
+                @Override
+                public String getFilename() {
+                    return filename;
+                }
+            });
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        return rest.postForEntity("http://localhost:" + port + "/api/documents/upload",
+                new HttpEntity<>(body, headers), String.class);
+    }
+}

--- a/spring-ai-rag-redis-stack/src/test/resources/application.yml
+++ b/spring-ai-rag-redis-stack/src/test/resources/application.yml
@@ -2,6 +2,12 @@ spring:
   application:
     name: spring-ai-rag-redis-test
 
+  # 업로드 한도 (main 과 동일). test classpath 의 이 파일이 main 의 application.yml 을 가린다.
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 21MB
+
   ai:
     ollama:
       base-url: http://localhost:11434


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

두 모듈 모두 업로드 계약을 파일당 5MB, 총 20MB로 선언합니다. 컨트롤러 javadoc, 화면의 사전 검증, 서비스의 검증, 그 검증을 고정한 `EgovDocumentServiceImplUploadValidationTest`가 모두 같은 숫자를 씁니다(spring-ai 기준 `EgovDocumentController.java:36`, `chat.html:1117`·`1124`, `EgovDocumentServiceImpl.java:256`·`264`). 그런데 요청이 컨트롤러에 닿기 위해 필요한 `spring.servlet.multipart` 한도는 어느 yml에도 없어 Spring Boot 기본값 1MB/10MB가 그대로 걸립니다.

1MB를 넘는 순간 413으로 끊기므로 서비스의 5MB 분기는 실행되지 않습니다. 실효 상한이 계약의 1/5입니다. 화면은 5MB까지 통과시키니, 사전 검증을 지난 파일만 골라 서버에서 실패합니다.

기존 단위 테스트가 이를 못 본 것은 `MockMultipartFile`로 서비스를 직접 호출해 멀티파트 파서를 건너뛰기 때문입니다. 계약 테스트는 초록인 채로 HTTP 경로만 깨져 있었습니다.

두 모듈의 main·test `application.yml`에 같은 네 줄을 넣었습니다.

```yaml
  servlet:
    multipart:
      max-file-size: 5MB
      max-request-size: 21MB
```

`max-request-size`는 20MB 정각이 아니라 21MB로 뒀습니다. 서비스의 총량 검증은 파일 바이트만 세는데 실제 요청에는 멀티파트 경계와 헤더가 더 실려, 정각으로 두면 5MB × 4 = 20MB라는 계약 경계값이 여전히 잘립니다. 총량 거절은 지금처럼 서비스가 맡아 이유가 담긴 응답을 돌려주고, 멀티파트 한도는 바깥 백스톱으로 둡니다.

`MultipartFile`을 받는 엔드포인트는 두 모듈의 `/api/documents/upload` 하나씩이고 둘 다 반영했습니다. `src` 아래 `application.yml`은 모듈당 main·test 두 개씩 넷이며 역시 모두 반영했습니다. test classpath의 `application.yml`이 main 것을 가리므로 양쪽 다 필요합니다.

자바 코드, 의존성, 공개 API 변경은 없습니다. 계약을 넘는 요청은 여전히 본문 없는 413으로 끊기는데, 이는 응답 형식 쪽 문제라 이 PR에서 다루지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

실제 포트를 열고 요청을 던져 파서를 거치는 `EgovDocumentUploadMultipartLimitTest`를 두 모듈에 추가했습니다. 각 모듈의 yml에서 넣은 네 줄을 뺀 상태로 돌리면 둘 다 실패합니다.

spring-ai (파일당 상한, 요청 상한 2건)

```
[ERROR]   EgovDocumentUploadMultipartLimitTest.requestAtContractLimitReachesService:57->assertReachesService:63 [413 이면 멀티파트 한도가 업로드 계약보다 낮은 것이다]
expected: 400
 but was: 413
[ERROR]   EgovDocumentUploadMultipartLimitTest.singleFileAtContractLimitReachesService:51->assertReachesService:63 [413 이면 멀티파트 한도가 업로드 계약보다 낮은 것이다]
expected: 400
 but was: 413
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

langchain4j (파일당 상한 1건)

```
[ERROR]   EgovDocumentUploadMultipartLimitTest.singleFileAtContractLimitReachesService:79 [413 이면 멀티파트 한도가 업로드 계약보다 낮은 것이다]
expected: 400
 but was: 413
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```

네 줄을 넣은 뒤 두 모듈을 모두 돌렸습니다.

```
cd spring-ai-rag-redis-stack && mvn -B test
[INFO] Tests run: 151, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS

cd langchain4j-ai-rag-postgre && mvn -B test
[INFO] Tests run: 139, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

langchain4j 쪽 테스트는 파일당 상한만 확인합니다. 이 모듈은 webflux를 함께 의존해 `TestRestTemplate`이 reactor-netty 클라이언트를 쓰는데, 서버 한도와 무관하게 20MB 멀티파트 본문 전송이 끝나지 않습니다. 요청 상한 경계는 spring-ai 쪽 같은 이름 테스트가 덮습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

설정 변경이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
